### PR TITLE
feat: Implement LLM based article scoring

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -34,3 +34,11 @@ distribution:
 
   # GitHub Artifact settings
   upload_artifact: true # Set to true to upload the newsletter as a workflow artifact
+
+# Article scoring weights
+scoring:
+  relevance: 0.40
+  impact: 0.25
+  novelty: 0.15
+  source_tier: 0.10
+  recency: 0.10

--- a/newsletter/graph.py
+++ b/newsletter/graph.py
@@ -25,6 +25,7 @@ class NewsletterState(TypedDict):
     # 중간 결과물
     collected_articles: Optional[List[Dict]]  # Made Optional
     processed_articles: Optional[List[Dict]]  # New field
+    ranked_articles: Optional[List[Dict]]  # Articles scored and ranked
     article_summaries: Optional[Dict]  # Made Optional
     category_summaries: Optional[Dict]  # 카테고리별 요약 결과
     newsletter_topic: Optional[str]  # 뉴스레터 주제 필드
@@ -314,7 +315,53 @@ def process_articles_node(state: NewsletterState) -> NewsletterState:
     return {
         **state,
         "processed_articles": processed_articles_sorted,
-        "status": "summarizing",  # Next status is summarizing
+        "status": "scoring",  # Next step is scoring
+    }
+
+
+def score_articles_node(state: NewsletterState) -> NewsletterState:
+    """Score articles using LLM to rank priority."""
+    from .scoring import score_articles
+
+    print("\n[cyan]Step: Scoring articles...[/cyan]")
+
+    processed = state.get("processed_articles") or []
+    if not processed:
+        print("[yellow]No articles to score.[/yellow]")
+        return {
+            **state,
+            "error": "기사 점수를 매길 데이터가 없습니다.",
+            "status": "error",
+        }
+
+    domain = state.get("domain", "")
+    ranked = score_articles(processed, domain, top_n=None)
+
+    output_dir = os.path.join(os.getcwd(), "output", "intermediate_processing")
+    os.makedirs(output_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    scored_path = os.path.join(output_dir, f"{timestamp}_scored_articles.json")
+    try:
+        with open(scored_path, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "keywords": state.get("keywords", []),
+                    "domain": domain,
+                    "news_period_days": state.get("news_period_days"),
+                    "articles": ranked,
+                },
+                f,
+                ensure_ascii=False,
+                indent=4,
+            )
+        print(f"Saved scored articles to {scored_path}")
+    except Exception as e:
+        print(f"[red]Error saving scored articles: {e}[/red]")
+
+    return {
+        **state,
+        "ranked_articles": ranked[:10],
+        "status": "summarizing",
     }
 
 
@@ -329,12 +376,14 @@ def summarize_articles_node(
 
     print("\n[cyan]Step: Summarizing articles...[/cyan]")
 
-    processed_articles = state.get("processed_articles")
-    if not processed_articles:  # Check processed_articles
-        print("[yellow]No processed articles to summarize.[/yellow]")
+    articles_for_summary = state.get("ranked_articles") or state.get(
+        "processed_articles"
+    )
+    if not articles_for_summary:
+        print("[yellow]No articles to summarize.[/yellow]")
         return {
             **state,
-            "error": "처리된 기사가 없어 요약을 진행할 수 없습니다.",  # More specific error
+            "error": "요약할 기사가 없습니다.",
             "status": "error",
         }
 
@@ -359,7 +408,7 @@ def summarize_articles_node(
 
         # 데이터 형식 맞추기: processed_articles를 'articles' 키를 가진 딕셔너리로 감싸기
         input_data = {
-            "articles": processed_articles,
+            "articles": articles_for_summary,
             "keywords": state.get("keywords", ""),
         }
 
@@ -491,6 +540,7 @@ def create_newsletter_graph() -> StateGraph:
     # 노드 추가
     workflow.add_node("collect_articles", collect_articles_node)  # Use new name
     workflow.add_node("process_articles", process_articles_node)  # Add new node
+    workflow.add_node("score_articles", score_articles_node)
     workflow.add_node("summarize_articles", summarize_articles_node)  # Use new name
     workflow.add_node(
         "compose_newsletter", compose_newsletter_node
@@ -510,10 +560,14 @@ def create_newsletter_graph() -> StateGraph:
             "handle_error"
             if state.get("status") == "error"
             else (
-                "summarize_articles"
-                if state.get("processed_articles")
-                else "handle_error"
+                "score_articles" if state.get("processed_articles") else "handle_error"
             )
+        ),
+    )
+    workflow.add_conditional_edges(
+        "score_articles",
+        lambda state: (
+            "handle_error" if state.get("status") == "error" else "summarize_articles"
         ),
     )
     workflow.add_conditional_edges(
@@ -569,6 +623,7 @@ def generate_newsletter(
         "newsletter_topic": newsletter_topic,  # 뉴스레터 주제 추가
         "collected_articles": None,  # Initialize as None
         "processed_articles": None,  # Initialize as None
+        "ranked_articles": None,  # Initialize as None
         "article_summaries": None,  # Initialize as None
         "category_summaries": None,  # Initialize as None
         "newsletter_html": None,  # Initialize as None

--- a/newsletter/scoring.py
+++ b/newsletter/scoring.py
@@ -1,0 +1,155 @@
+"""Scoring utilities for ranking news articles."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from langchain_core.messages import HumanMessage, AIMessage
+
+from .article_filter import MAJOR_NEWS_SOURCES
+from .date_utils import parse_date_string
+from .chains import get_llm
+
+# Default weights for priority score calculation
+DEFAULT_WEIGHTS = {
+    "relevance": 0.40,
+    "impact": 0.25,
+    "novelty": 0.15,
+    "source_tier": 0.10,
+    "recency": 0.10,
+}
+
+SCORE_PROMPT = """
+You are a professional news editor. Evaluate the article below for the newsletter topic <DOMAIN>.
+Return scores only as JSON in the format {{"relevance":1-5,"impact":1-5,"novelty":1-5}}.
+
+Title: {title}
+Summary: {summary}
+"""
+
+
+def _get_source_tier(source: str) -> float:
+    if any(s.lower() in source.lower() for s in MAJOR_NEWS_SOURCES["tier1"]):
+        return 1.0
+    if any(s.lower() in source.lower() for s in MAJOR_NEWS_SOURCES["tier2"]):
+        return 0.8
+    return 0.6
+
+
+def _get_recency(date_str: Any) -> float:
+    dt = parse_date_string(date_str)
+    if not dt:
+        return 0.0
+    now = datetime.now(timezone.utc)
+    if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    days = (now - dt).total_seconds() / 86400
+    return math.exp(-days / 14)
+
+
+def _parse_llm_json(text: str) -> Dict[str, float]:
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if match:
+        try:
+            return json.loads(match.group(0))
+        except Exception:
+            pass
+    return {"relevance": 1, "impact": 1, "novelty": 1}
+
+
+def request_llm_scores(
+    article: Dict[str, Any], domain: str, llm=None
+) -> Dict[str, float]:
+    if llm is None:
+        llm = get_llm(temperature=0)
+    prompt = SCORE_PROMPT.replace("<DOMAIN>", domain).format(
+        title=article.get("title", ""),
+        summary=article.get("content") or article.get("snippet", ""),
+    )
+    message = HumanMessage(content=prompt)
+    result = llm.invoke([message])
+    if isinstance(result, AIMessage):
+        text = result.content
+    else:
+        text = str(result)
+    return _parse_llm_json(text)
+
+
+def calculate_priority_score(
+    article: Dict[str, Any],
+    domain: str,
+    weights: Optional[Dict[str, float]] = None,
+    llm=None,
+    scores: Optional[Dict[str, float]] = None,
+) -> float:
+    if weights is None:
+        weights = DEFAULT_WEIGHTS
+    if scores is None:
+        scores = request_llm_scores(article, domain, llm=llm)
+    relevance = scores.get("relevance", 1) / 5
+    impact = scores.get("impact", 1) / 5
+    novelty = scores.get("novelty", 1) / 5
+    source_tier = _get_source_tier(article.get("source", ""))
+    recency = _get_recency(article.get("date"))
+    priority = (
+        weights["relevance"] * relevance
+        + weights["impact"] * impact
+        + weights["novelty"] * novelty
+        + weights["source_tier"] * source_tier
+        + weights["recency"] * recency
+    ) * 100
+    return round(priority, 4)
+
+
+def score_articles(
+    articles: List[Dict[str, Any]],
+    domain: str,
+    top_n: Optional[int] = 10,
+    weights: Optional[Dict[str, float]] = None,
+    llm=None,
+) -> List[Dict[str, Any]]:
+    """Score and rank articles using an LLM.
+
+    If ``top_n`` is ``None`` all scored articles are returned in ranked order.
+    """
+
+    if weights is None:
+        weights = DEFAULT_WEIGHTS
+
+    scored_list = []
+    for article in articles:
+        scores = request_llm_scores(article, domain, llm=llm)
+        source_tier = _get_source_tier(article.get("source", ""))
+        recency = _get_recency(article.get("date"))
+
+        relevance = scores.get("relevance", 1) / 5
+        impact = scores.get("impact", 1) / 5
+        novelty = scores.get("novelty", 1) / 5
+        priority_score = (
+            weights["relevance"] * relevance
+            + weights["impact"] * impact
+            + weights["novelty"] * novelty
+            + weights["source_tier"] * source_tier
+            + weights["recency"] * recency
+        ) * 100
+        priority_score = round(priority_score, 4)
+        article["scoring"] = {
+            "relevance": scores.get("relevance", 1),
+            "impact": scores.get("impact", 1),
+            "novelty": scores.get("novelty", 1),
+            "source_tier": source_tier,
+            "recency": recency,
+        }
+        article["priority_score"] = priority_score
+        scored_list.append(article)
+
+    scored_list.sort(key=lambda a: a["priority_score"], reverse=True)
+
+    if top_n is not None:
+        return scored_list[:top_n]
+    return scored_list

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest.mock import MagicMock
+from langchain_core.messages import AIMessage
+
+from newsletter.scoring import score_articles, DEFAULT_WEIGHTS
+
+
+class TestScoring(unittest.TestCase):
+    def test_score_articles_ranking(self):
+        articles = [
+            {
+                "title": "A",
+                "content": "text",
+                "source": "조선일보",
+                "date": "2025-01-01",
+            },
+            {"title": "B", "content": "text", "source": "블로그", "date": "2025-01-01"},
+        ]
+
+        llm = MagicMock()
+        llm.invoke.side_effect = [
+            AIMessage(content='{"relevance":5,"impact":5,"novelty":4}'),
+            AIMessage(content='{"relevance":1,"impact":1,"novelty":1}'),
+        ]
+
+        ranked = score_articles(
+            articles, "AI", top_n=2, weights=DEFAULT_WEIGHTS, llm=llm
+        )
+        self.assertEqual(len(ranked), 2)
+        self.assertGreaterEqual(
+            ranked[0]["priority_score"], ranked[1]["priority_score"]
+        )
+
+    def test_score_articles_all_return(self):
+        articles = [
+            {
+                "title": "A",
+                "content": "text",
+                "source": "조선일보",
+                "date": "2025-01-01",
+            },
+            {"title": "B", "content": "text", "source": "블로그", "date": "2025-01-01"},
+        ]
+
+        llm = MagicMock()
+        llm.invoke.side_effect = [
+            AIMessage(content='{"relevance":5,"impact":5,"novelty":4}'),
+            AIMessage(content='{"relevance":1,"impact":1,"novelty":1}'),
+        ]
+
+        ranked = score_articles(
+            articles, "AI", top_n=None, weights=DEFAULT_WEIGHTS, llm=llm
+        )
+        self.assertEqual(len(ranked), 2)
+        self.assertIn("scoring", ranked[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add scoring module for relevance, impact, novelty and recency weighting
- integrate new `score_articles_node` in newsletter graph
- save scored article list as intermediate JSON
- expose scoring weights in example config
- add unit test for scoring logic
- store raw scoring details for each article and keep all scores for later reuse

## Testing
- `python run_tests.py --format` *(failed to run tests: No module named pytest)*
- `python run_tests.py` *(failed to run tests: No module named pytest)*