### PR TITLE
Add cost tracking and theme extraction metrics

### DIFF
--- a/newsletter/chains.py
+++ b/newsletter/chains.py
@@ -783,11 +783,47 @@ def create_rendering_chain():
                 combined_data["newsletter_topic"] = keywords[0]
             elif isinstance(keywords, list) and len(keywords) > 1:
                 # 3. 여러 키워드의 공통 주제 추출
-                common_theme = tools.extract_common_theme_from_keywords(keywords)
+                cb = []
+                if os.environ.get("ENABLE_COST_TRACKING") or os.environ.get(
+                    "LANGCHAIN_TRACING_V2"
+                ):
+                    try:
+                        from .cost_tracking import (
+                            get_tracking_callbacks,
+                            register_recent_callbacks,
+                        )
+
+                        cb = get_tracking_callbacks()
+                        register_recent_callbacks(cb)
+                    except Exception as e:
+                        print(
+                            f"[yellow]Cost tracking setup error: {e}. Continuing without tracking.[/yellow]"
+                        )
+                common_theme = tools.extract_common_theme_from_keywords(
+                    keywords, callbacks=cb
+                )
                 combined_data["newsletter_topic"] = common_theme
             elif isinstance(keywords, str) and "," in keywords:
                 # 4. 콤마로 구분된 여러 키워드
-                common_theme = tools.extract_common_theme_from_keywords(keywords)
+                cb = []
+                if os.environ.get("ENABLE_COST_TRACKING") or os.environ.get(
+                    "LANGCHAIN_TRACING_V2"
+                ):
+                    try:
+                        from .cost_tracking import (
+                            get_tracking_callbacks,
+                            register_recent_callbacks,
+                        )
+
+                        cb = get_tracking_callbacks()
+                        register_recent_callbacks(cb)
+                    except Exception as e:
+                        print(
+                            f"[yellow]Cost tracking setup error: {e}. Continuing without tracking.[/yellow]"
+                        )
+                common_theme = tools.extract_common_theme_from_keywords(
+                    keywords, callbacks=cb
+                )
                 combined_data["newsletter_topic"] = common_theme
             else:
                 # 5. 기본값 - 단일 문자열 키워드

--- a/newsletter/cli.py
+++ b/newsletter/cli.py
@@ -314,6 +314,16 @@ def run(
         f"[green]Newsletter generated successfully using {template_style} template via LangGraph.[/green]"
     )
 
+    info = graph.get_last_generation_info()
+    step_times = info.get("step_times", {})
+    total_time = info.get("total_time")
+    cost_summary = info.get("cost_summary")
+    console.print(f"[blue]Step times (seconds): {step_times}[/blue]")
+    if total_time is not None:
+        console.print(f"[blue]Total generation time: {total_time:.2f} seconds[/blue]")
+    if cost_summary:
+        console.print(f"[blue]Cost summary: {cost_summary}[/blue]")
+
     # 뉴스레터 주제 및 파일명 설정
     newsletter_topic = ""
     if domain:


### PR DESCRIPTION
## Summary
- register cost tracking callbacks for theme extraction and summarization
- collect newsletter generation cost summary via new helpers in `cost_tracking`
- track time spent extracting the newsletter theme
- expose total cost and per-step timings through the CLI

## Testing
- `python check_quality.py` *(fails: ModuleNotFoundError: rich, requests, jinja2, yaml, langchain_core)*