### PR TITLE
ci: fix deployment fallback syntax and preflight python command detection

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -162,37 +162,36 @@ jobs:
           html_files=(output/*.html)
           if [ ${#html_files[@]} -eq 0 ]; then
             echo "⚠️ No HTML generated from real pipeline path. Creating fallback demo artifact."
-            cat > output/newsletter.html << 'EOF'
-            <!DOCTYPE html>
-            <html lang="ko">
-            <head>
-                <meta charset="UTF-8">
-                <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                <title>Newsletter Generator - Fallback</title>
-                <style>
-                    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background-color: #f5f5f5; }
-                    .container { max-width: 800px; margin: 0 auto; background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
-                    .header { background: linear-gradient(135deg, #0ea5e9 0%, #0369a1 100%); color: white; padding: 36px 20px; text-align: center; }
-                    .content { padding: 28px; color: #334155; line-height: 1.6; }
-                    code { background: #f1f5f9; padding: 2px 6px; border-radius: 4px; }
-                </style>
-            </head>
-            <body>
-                <div class="container">
-                    <div class="header">
-                        <h1>Newsletter Generator</h1>
-                        <p>Fallback Artifact</p>
-                    </div>
-                    <div class="content">
-                        <p>Real newsletter generation path did not produce an HTML artifact.</p>
-                        <p>This fallback file keeps deployment and pages publishing deterministic.</p>
-                        <p>Run: <code>${{ github.run_id }}</code></p>
-                        <p>Commit: <code>${{ github.sha }}</code></p>
-                    </div>
-                </div>
-            </body>
-            </html>
-            EOF
+            printf '%s\n' \
+              '<!DOCTYPE html>' \
+              '<html lang="ko">' \
+              '<head>' \
+              '  <meta charset="UTF-8">' \
+              '  <meta name="viewport" content="width=device-width, initial-scale=1.0">' \
+              '  <title>Newsletter Generator - Fallback</title>' \
+              '  <style>' \
+              '    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 0; padding: 20px; background-color: #f5f5f5; }' \
+              '    .container { max-width: 800px; margin: 0 auto; background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }' \
+              '    .header { background: linear-gradient(135deg, #0ea5e9 0%, #0369a1 100%); color: white; padding: 36px 20px; text-align: center; }' \
+              '    .content { padding: 28px; color: #334155; line-height: 1.6; }' \
+              '    code { background: #f1f5f9; padding: 2px 6px; border-radius: 4px; }' \
+              '  </style>' \
+              '</head>' \
+              '<body>' \
+              '  <div class="container">' \
+              '    <div class="header">' \
+              '      <h1>Newsletter Generator</h1>' \
+              '      <p>Fallback Artifact</p>' \
+              '    </div>' \
+              '    <div class="content">' \
+              '      <p>Real newsletter generation path did not produce an HTML artifact.</p>' \
+              '      <p>This fallback file keeps deployment and pages publishing deterministic.</p>' \
+              '      <p>Run: <code>${{ github.run_id }}</code></p>' \
+              '      <p>Commit: <code>${{ github.sha }}</code></p>' \
+              '    </div>' \
+              '  </div>' \
+              '</body>' \
+              '</html>' > output/newsletter.html
             html_files=(output/*.html)
           fi
           latest_html="$(ls -t output/*.html | head -n1)"

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -18,7 +18,10 @@ REQUIRED_FILES = [
     ".release/baseline.json",
     ".release/manifests/release-ci-platform.txt",
 ]
-REQUIRED_CMDS = ["python", "git"]
+REQUIRED_CMD_GROUPS = [
+    ("python", "python3"),
+    ("git",),
+]
 REQUIRED_PY_PACKAGES = ["flake8", "bandit"]
 
 
@@ -59,9 +62,9 @@ def main() -> int:
 
     failures: list[str] = []
 
-    for cmd in REQUIRED_CMDS:
-        if shutil.which(cmd) is None:
-            failures.append(f"missing command: {cmd}")
+    for cmd_group in REQUIRED_CMD_GROUPS:
+        if not any(shutil.which(cmd) for cmd in cmd_group):
+            failures.append(f"missing command: {' or '.join(cmd_group)}")
 
     for rel in REQUIRED_FILES:
         if not Path(rel).exists():


### PR DESCRIPTION
## Summary
- Fix `Deployment Pipeline` fallback artifact generation to avoid bash heredoc parse failure.
- Make release preflight command detection deterministic on macOS (`python` or `python3`) so local gate execution does not fail on interpreter alias differences.
- This is a stability hotfix before starting `release/runtime-binary` split PR work.

## Base
- Base branch/tag: `main`
- Base commit SHA: `8dbadf53bbaec3d09b1e59c8b2345a0b2e2f37e5`

## Scope (in/out)
### In scope
- `.github/workflows/deployment.yml`
- `scripts/release_preflight.py`

### Out of scope
- Runtime feature changes (`newsletter/*`, `web/*`)
- `release/runtime-binary` integration content

## Risk
- Primary runtime/operational risks.
  - Low runtime risk (CI/workflow + gate tooling only).
  - Operational gain: deployment workflow no longer fails on shell syntax when fallback is needed.
- Affected high-risk files (if any):
  - [ ] `web/app.py`
  - [ ] `web/schedule_runner.py`
  - [ ] `web/graceful_shutdown.py`
  - [ ] `newsletter/utils/shutdown_manager.py`

## Test Evidence
- [x] preflight passed
- [x] format/lint passed
- [x] core unit tests passed
- [ ] schedule/shutdown integration tests passed (N/A: runtime code unchanged)
- [x] security scan completed (new high issues = 0)

### Commands run
```bash
make PYTHON=.venv/bin/python preflight-release
make PYTHON=.venv/bin/python test-quick
make PYTHON=.venv/bin/python test-full
make PYTHON=.venv/bin/python validate-ci-manifest
```

## PR Metadata Applied
- [ ] Labels applied in GitHub UI/API (`release`, `risk:*`, `area:*`)
- [ ] Reviewers assigned in GitHub UI/API (code owner + ops owner)
- [x] Solo/virtual mode used (ops role = `virtual:ops-owner` in `.release/reviewer_roles.json`)

## Rollback Plan
- Tag to rollback to: `8dbadf53bbaec3d09b1e59c8b2345a0b2e2f37e5`
- Rollback command / process: `git revert 8c1b9d6`
- Data migration impact (if any): none

## Docs Updated
- [ ] CHANGELOG updated
- [x] Related docs updated
- [ ] No docs change needed (reason):
