### PR TITLE
ci: fix deployment output normalization when fallback artifact exists

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -194,8 +194,16 @@ jobs:
               '</html>' > output/newsletter.html
             html_files=(output/*.html)
           fi
-          latest_html="$(ls -t output/*.html | head -n1)"
-          cp "$latest_html" output/newsletter.html
+          latest_html="$(ls -t output/*.html | head -n1 || true)"
+          if [ -z "$latest_html" ]; then
+            echo "❌ No HTML artifact available after fallback handling."
+            exit 1
+          fi
+          if [ "$latest_html" != "output/newsletter.html" ]; then
+            cp "$latest_html" output/newsletter.html
+          else
+            echo "ℹ️ output/newsletter.html already normalized."
+          fi
           echo "✅ Newsletter generated successfully"
           echo "Latest file: $latest_html"
           echo "Normalized artifact: output/newsletter.html"


### PR DESCRIPTION
## Summary
- Fix `Deployment Pipeline` verify step to avoid failing when fallback already created `output/newsletter.html`.
- Root cause from run `22212603241`: `cp: 'output/newsletter.html' and 'output/newsletter.html' are the same file`.
- This hotfix is required before starting `release/runtime-binary` split PR.

## Base
- Base branch/tag: `main`
- Base commit SHA: `72fe71898e9c0cea1ff240913cc16bd941049480`

## Scope (in/out)
### In scope
- `.github/workflows/deployment.yml`

### Out of scope
- Runtime feature changes
- `release/runtime-binary` payload

## Risk
- Low runtime risk (workflow-only shell logic)
- Affected high-risk files (if any):
  - [ ] `web/app.py`
  - [ ] `web/schedule_runner.py`
  - [ ] `web/graceful_shutdown.py`
  - [ ] `newsletter/utils/shutdown_manager.py`

## Test Evidence
- [x] preflight passed
- [x] format/lint passed
- [x] core unit tests passed
- [ ] schedule/shutdown integration tests passed (N/A: runtime code unchanged)
- [x] security scan completed (new high issues = 0)

### Commands run
```bash
make PYTHON=.venv/bin/python preflight-release
make PYTHON=.venv/bin/python test-quick
make PYTHON=.venv/bin/python test-full
make PYTHON=.venv/bin/python validate-ci-manifest
```

## PR Metadata Applied
- [ ] Labels applied in GitHub UI/API (`release`, `risk:*`, `area:*`)
- [ ] Reviewers assigned in GitHub UI/API (code owner + ops owner)
- [x] Solo/virtual mode used (ops role = `virtual:ops-owner` in `.release/reviewer_roles.json`)

## Rollback Plan
- Tag to rollback to: `72fe71898e9c0cea1ff240913cc16bd941049480`
- Rollback command / process: `git revert 17d5724`
- Data migration impact (if any): none

## Docs Updated
- [ ] CHANGELOG updated
- [x] Related docs updated
- [ ] No docs change needed (reason):
