### PR TITLE
ci: guard pages deploy steps when GitHub Pages is unavailable

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -209,15 +209,34 @@ jobs:
           echo "Normalized artifact: output/newsletter.html"
           echo "File size: $(wc -c < output/newsletter.html) bytes"
 
+      - name: Check GitHub Pages availability
+        id: pages_check
+        run: |
+          status_code="$(curl -sS -o /tmp/pages.json -w '%{http_code}' \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'Authorization: Bearer ${{ github.token }}' \
+            "https://api.github.com/repos/${{ github.repository }}/pages")"
+
+          if [ "$status_code" = "200" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "✅ GitHub Pages is enabled for this repository."
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "⚠️ GitHub Pages is not enabled (status=${status_code}). Skipping pages deploy steps."
+          fi
+
       - name: Setup GitHub Pages
+        if: steps.pages_check.outputs.enabled == 'true'
         uses: actions/configure-pages@v4
 
       - name: Upload to GitHub Pages
+        if: steps.pages_check.outputs.enabled == 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: './output/'
 
       - name: Deploy to GitHub Pages
+        if: steps.pages_check.outputs.enabled == 'true'
         id: deployment
         uses: actions/deploy-pages@v4
 


### PR DESCRIPTION
## Summary
- Fix `Deployment Pipeline` failure when GitHub Pages is not enabled in repository settings.
- Root cause from run `22212703398`: `Get Pages site failed` / `HttpError: Not Found` at `actions/configure-pages@v4`.
- Add a guard step that checks Pages availability and skips Pages setup/upload/deploy steps when unavailable.

## Base
- Base branch/tag: `main`
- Base commit SHA: `82710450965c6c827889d6a03f7e87252d139220`

## Scope (in/out)
### In scope
- `.github/workflows/deployment.yml`

### Out of scope
- Runtime feature code
- `release/runtime-binary` payload

## Risk
- Low runtime risk (workflow-only control flow)
- Affected high-risk files (if any):
  - [ ] `web/app.py`
  - [ ] `web/schedule_runner.py`
  - [ ] `web/graceful_shutdown.py`
  - [ ] `newsletter/utils/shutdown_manager.py`

## Test Evidence
- [x] preflight passed
- [x] format/lint passed
- [x] core unit tests passed
- [ ] schedule/shutdown integration tests passed (N/A: runtime code unchanged)
- [x] security scan completed (new high issues = 0)

### Commands run
```bash
make PYTHON=.venv/bin/python preflight-release
make PYTHON=.venv/bin/python test-quick
make PYTHON=.venv/bin/python test-full
make PYTHON=.venv/bin/python validate-ci-manifest
```

## PR Metadata Applied
- [ ] Labels applied in GitHub UI/API (`release`, `risk:*`, `area:*`)
- [ ] Reviewers assigned in GitHub UI/API (code owner + ops owner)
- [x] Solo/virtual mode used (ops role = `virtual:ops-owner` in `.release/reviewer_roles.json`)

## Rollback Plan
- Tag to rollback to: `82710450965c6c827889d6a03f7e87252d139220`
- Rollback command / process: `git revert d5f1211`
- Data migration impact (if any): none

## Docs Updated
- [ ] CHANGELOG updated
- [x] Related docs updated
- [ ] No docs change needed (reason):
