### PR TITLE
ci: default main-ci PYTHON_VERSION to 3.12

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -16,7 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.10'
+  # Default interpreter for non-matrix jobs (quality/mock/integration/report)
+  PYTHON_VERSION: '3.12'
   CACHE_VERSION: v1
 
 jobs:


### PR DESCRIPTION
## Summary
- set `.github/workflows/main-ci.yml` global `env.PYTHON_VERSION` to `3.12`
- align non-matrix jobs (Mock API/Integration/Test Report) with supported interpreter

## Why
- PR #28 is blocked by Mock API Tests running on Python 3.10 and failing during cryptography/PyO3 import

## Validation
- pre-commit checks passed locally on commit
- CI validation via this PR checks

## Linked
- Unblocks #28
