### PR TITLE
test(release): add scheduler fallback coverage and release gate wiring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Newsletter Generator - Makefile
 # 개발 워크플로우 자동화를 위한 Makefile
 
-.PHONY: help format lint test test-quick test-full test-nightly preflight-release validate-ci-manifest validate-scheduler-manifest validate-runtime-bootstrap-manifest apply-pr-metadata ci-check ci-fix clean install pre-commit
+.PHONY: help format lint test test-quick test-full test-nightly preflight-release validate-ci-manifest validate-scheduler-manifest validate-runtime-bootstrap-manifest apply-pr-metadata ci-check ci-fix clean install pre-commit skill-ci-gate skill-docs-and-config-consistency skill-newsletter-smoke skill-web-smoke skill-scheduler-debug skill-release-integration skills-check
 
 # Python 실행 파일 설정
 PYTHON ?= python3
@@ -106,6 +106,36 @@ ci-fix: ## CI 검사 + 자동 수정
 ci-full: ## 전체 CI 검사 (테스트 포함)
 	@echo "🚀 전체 CI 검사 실행 중..."
 	$(PYTHON) run_ci_checks.py --full
+
+skill-ci-gate: ## Skill: ci-gate
+	@echo "🧠 Skill ci-gate 실행 중..."
+	$(PYTHON) run_ci_checks.py --fix --full
+
+skill-docs-and-config-consistency: ## Skill: docs-and-config-consistency
+	@echo "🧠 Skill docs-and-config-consistency 검증 중..."
+	@! rg -nP 'SENDGRID_API_KEY|(?<!POSTMARK_)FROM_EMAIL=|POSTMARK_TOKEN|POSTMARK_API_TOKEN' README.md docs/setup web/.env.example web/requirements.txt
+
+skill-newsletter-smoke: ## Skill: newsletter-smoke
+	@echo "🧠 Skill newsletter-smoke 실행 중..."
+	MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com $(PYTHON) -c "from unittest.mock import patch; from newsletter.api import GenerateNewsletterRequest, generate_newsletter; sample='<html><head><title>Smoke</title></head><body>ok</body></html>'; info={'step_times': {'collect': 0.1}, 'total_time': 0.2}; p1=patch('newsletter.api.graph.generate_newsletter', return_value=(sample, 'success')); p2=patch('newsletter.api.graph.get_last_generation_info', return_value=info); p1.start(); p2.start(); r=generate_newsletter(GenerateNewsletterRequest(keywords='AI', period=7)); p2.stop(); p1.stop(); assert r['status']=='success'; assert r['title']=='Smoke'; assert '<html' in r['html_content'].lower(); print('newsletter-smoke: ok')"
+
+skill-web-smoke: ## Skill: web-smoke
+	@echo "🧠 Skill web-smoke 실행 중..."
+	MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com $(PYTHON) -m pytest tests/test_web_api.py -q
+
+skill-scheduler-debug: ## Skill: scheduler-debug
+	@echo "🧠 Skill scheduler-debug 실행 중..."
+	MOCK_MODE=true TESTING=1 $(PYTHON) -m pytest tests/integration/test_schedule_execution.py tests/unit_tests/test_schedule_time_sync.py -q
+
+skill-release-integration: ## Skill: release-integration
+	@echo "🧠 Skill release-integration 실행 중..."
+	$(PYTHON) scripts/release_preflight.py
+	$(PYTHON) scripts/validate_release_manifest.py --manifest .release/manifests/release-ci-platform.txt --source staged
+	$(PYTHON) scripts/validate_release_manifest.py --manifest .release/manifests/release-scheduler-reliability.txt --source staged
+	$(PYTHON) scripts/validate_release_manifest.py --manifest .release/manifests/release-runtime-binary-bootstrap.txt --source staged
+
+skills-check: skill-docs-and-config-consistency skill-newsletter-smoke skill-web-smoke skill-scheduler-debug ## Run core skills verification
+	@echo "✅ skills-check 완료"
 
 pre-commit: ## Pre-commit hooks 설치
 	@echo "🔗 Pre-commit hooks 설치 중..."

--- a/docs/dev/CI_CD_GUIDE.md
+++ b/docs/dev/CI_CD_GUIDE.md
@@ -153,4 +153,34 @@ docs/dev/
 
 - **Test execution time**: ~50% reduction with dependency optimization
 - **CI stability**: External dependency removal improves reliability
-- **Development efficiency**: Automated code quality checks 
+- **Development efficiency**: Automated code quality checks
+
+## Skill-Aligned Gate Mapping
+
+The repository uses six baseline skills and mapped Makefile targets:
+
+- `ci-gate` -> `make skill-ci-gate`
+- `docs-and-config-consistency` -> `make skill-docs-and-config-consistency`
+- `newsletter-smoke` -> `make skill-newsletter-smoke`
+- `web-smoke` -> `make skill-web-smoke`
+- `scheduler-debug` -> `make skill-scheduler-debug`
+- `release-integration` -> `make skill-release-integration`
+
+Recommended execution order:
+
+1. `make skill-docs-and-config-consistency`
+2. `make skill-newsletter-smoke`
+3. `make skill-web-smoke`
+4. `make skill-scheduler-debug`
+5. `make skill-release-integration`
+6. `make skill-ci-gate`
+
+## Release Checklist
+
+Before merge/release:
+
+1. `python scripts/release_preflight.py`
+2. `python scripts/validate_release_manifest.py --manifest .release/manifests/release-ci-platform.txt --source staged`
+3. `python scripts/validate_release_manifest.py --manifest .release/manifests/release-scheduler-reliability.txt --source staged`
+4. `python scripts/validate_release_manifest.py --manifest .release/manifests/release-runtime-binary-bootstrap.txt --source staged`
+5. `python run_ci_checks.py --fix --full`

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -11,12 +11,26 @@ import sys
 from pathlib import Path
 
 REQUIRED_FILES = [
+    "AGENTS.md",
+    "web/AGENTS.md",
     ".github/PULL_REQUEST_TEMPLATE/release_integration.md",
     "docs/dev/MAIN_INTEGRATION_EXECUTION_PLAN.md",
     "docs/dev/BRANCH_MAIN_GAP_ANALYSIS.md",
     "Makefile",
     ".release/baseline.json",
     ".release/manifests/release-ci-platform.txt",
+    ".agents/skills/ci-gate/SKILL.md",
+    ".agents/skills/ci-gate/agents/openai.yaml",
+    ".agents/skills/docs-and-config-consistency/SKILL.md",
+    ".agents/skills/docs-and-config-consistency/agents/openai.yaml",
+    ".agents/skills/newsletter-smoke/SKILL.md",
+    ".agents/skills/newsletter-smoke/agents/openai.yaml",
+    ".agents/skills/web-smoke/SKILL.md",
+    ".agents/skills/web-smoke/agents/openai.yaml",
+    ".agents/skills/scheduler-debug/SKILL.md",
+    ".agents/skills/scheduler-debug/agents/openai.yaml",
+    ".agents/skills/release-integration/SKILL.md",
+    ".agents/skills/release-integration/agents/openai.yaml",
 ]
 REQUIRED_CMD_GROUPS = [
     ("python", "python3"),

--- a/scripts/validate_release_manifest.py
+++ b/scripts/validate_release_manifest.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 from pathlib import Path
 
@@ -31,8 +32,8 @@ def main() -> int:
     parser.add_argument(
         "--source",
         default="staged",
-        choices=["staged", "head"],
-        help="Check staged files or working tree against HEAD.",
+        choices=["staged", "head", "baseline"],
+        help="Check staged files, working tree against HEAD, or baseline...HEAD.",
     )
     args = parser.parse_args()
 
@@ -41,7 +42,14 @@ def main() -> int:
         raise SystemExit(f"missing manifest file: {manifest}")
 
     allowed = read_manifest(manifest)
-    diff_args = ["--cached"] if args.source == "staged" else ["HEAD"]
+    if args.source == "staged":
+        diff_args = ["--cached"]
+    elif args.source == "head":
+        diff_args = ["HEAD"]
+    else:
+        baseline_ref = os.getenv("CI_BASELINE_REF", "baseline/main-equivalent")
+        diff_args = [f"{baseline_ref}...HEAD"]
+
     changed = run(["git", "diff", "--name-only", *diff_args])
     changed_files = {x for x in changed.splitlines() if x.strip()}
 
@@ -49,6 +57,7 @@ def main() -> int:
 
     print("=== RELEASE MANIFEST VALIDATION ===")
     print(f"manifest: {manifest}")
+    print(f"source: {args.source}")
     print(f"changed files: {len(changed_files)}")
 
     if extra:

--- a/tests/integration/test_schedule_execution.py
+++ b/tests/integration/test_schedule_execution.py
@@ -442,6 +442,38 @@ class TestScheduleIntegration:
                 mock_newsletter_generation.call_count == 1
             ), "Newsletter generation should be called only once"
 
+    def test_redis_enqueue_failure_falls_back_to_sync(
+        self, schedule_runner_with_db, mock_newsletter_generation
+    ):
+        """Redis enqueue failure should fallback to synchronous execution."""
+        from unittest.mock import MagicMock
+
+        fixed_now = datetime(2025, 8, 13, 15, 50, 0, tzinfo=timezone.utc)
+
+        schedule_runner_with_db.queue = MagicMock()
+        schedule_runner_with_db.queue.enqueue.side_effect = RuntimeError(
+            "redis unavailable"
+        )
+
+        schedule = {
+            "id": "redis_fallback_schedule",
+            "params": {"keywords": ["AI"], "send_email": False},
+            "rrule": "FREQ=DAILY;BYHOUR=15;BYMINUTE=50",
+            "next_run": fixed_now - timedelta(minutes=1),
+            "created_at": fixed_now - timedelta(days=1),
+            "is_test": False,
+        }
+
+        with patch("web.schedule_runner.datetime") as mock_datetime:
+            mock_datetime.now.return_value = fixed_now
+            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+
+            success = schedule_runner_with_db.execute_schedule(schedule)
+
+        assert success, "Execution should succeed through fallback path"
+        schedule_runner_with_db.queue.enqueue.assert_called_once()
+        mock_newsletter_generation.assert_called_once()
+
 
 @pytest.mark.integration
 @pytest.mark.real_api

--- a/tests/unit_tests/test_schedule_time_sync.py
+++ b/tests/unit_tests/test_schedule_time_sync.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Unit tests for schedule time-window and sync behavior."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from web.schedule_runner import ScheduleRunner
+
+
+@pytest.fixture
+def temp_db_path():
+    db_fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(db_fd)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE schedules (
+            id TEXT PRIMARY KEY,
+            params JSON NOT NULL,
+            rrule TEXT NOT NULL,
+            next_run TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            enabled INTEGER DEFAULT 1,
+            is_test INTEGER DEFAULT 0,
+            expires_at TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    yield db_path
+
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+
+@pytest.fixture
+def runner(temp_db_path):
+    schedule_runner = ScheduleRunner(db_path=temp_db_path, redis_url=None)
+    schedule_runner.redis_conn = None
+    schedule_runner.queue = None
+    return schedule_runner
+
+
+def _insert_schedule(
+    db_path: str,
+    schedule_id: str,
+    next_run: datetime,
+    *,
+    is_test: int,
+    enabled: int = 1,
+) -> None:
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        INSERT INTO schedules (id, params, rrule, next_run, created_at, enabled, is_test, expires_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            schedule_id,
+            json.dumps({"keywords": ["ai"], "send_email": False}),
+            "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+            next_run.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            enabled,
+            is_test,
+            (datetime.now(timezone.utc) + timedelta(hours=1)).strftime(
+                "%Y-%m-%dT%H:%M:%S.%fZ"
+            ),
+        ),
+    )
+
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.unit
+def test_parse_iso_datetime_handles_z_suffix(runner):
+    parsed = runner._parse_iso_datetime("2026-02-20T09:00:00.000000Z")
+    assert parsed.tzinfo == timezone.utc
+    assert parsed.hour == 9
+
+
+@pytest.mark.unit
+def test_test_schedule_window_boundary_is_inclusive(temp_db_path, runner):
+    now = datetime.now(timezone.utc)
+    _insert_schedule(
+        temp_db_path,
+        "test-window-boundary",
+        now - timedelta(minutes=9, seconds=50),
+        is_test=1,
+    )
+
+    pending = runner.get_pending_schedules()
+
+    pending_ids = [item["id"] for item in pending]
+    assert "test-window-boundary" in pending_ids
+
+
+@pytest.mark.unit
+def test_regular_schedule_window_boundary_is_inclusive(temp_db_path, runner):
+    now = datetime.now(timezone.utc)
+    _insert_schedule(
+        temp_db_path,
+        "regular-window-boundary",
+        now - timedelta(minutes=29, seconds=50),
+        is_test=0,
+    )
+
+    pending = runner.get_pending_schedules()
+
+    pending_ids = [item["id"] for item in pending]
+    assert "regular-window-boundary" in pending_ids
+
+
+@pytest.mark.unit
+def test_expired_schedule_updates_next_run(temp_db_path, runner):
+    now = datetime.now(timezone.utc)
+    old_next_run = now - timedelta(hours=2)
+
+    _insert_schedule(
+        temp_db_path,
+        "expired-regular",
+        old_next_run,
+        is_test=0,
+    )
+
+    pending = runner.get_pending_schedules()
+
+    # Expired schedule should not be in immediate queue.
+    assert all(item["id"] != "expired-regular" for item in pending)
+
+    conn = sqlite3.connect(temp_db_path)
+    cursor = conn.cursor()
+    cursor.execute("SELECT next_run FROM schedules WHERE id = ?", ("expired-regular",))
+    updated_next_run = cursor.fetchone()[0]
+    conn.close()
+
+    updated_dt = datetime.fromisoformat(updated_next_run.replace("Z", "+00:00"))
+    assert updated_dt > now


### PR DESCRIPTION
## 목적
배포/스케줄/릴리즈 게이트를 고정하고, 스케줄러 회귀 위험을 테스트로 방지합니다.

## 이 PR의 역할
- 스케줄 안정성 테스트 강화
  - 실행창 경계, 만료 스케줄 동기화, Redis enqueue 실패 시 sync fallback 검증
- 릴리즈 가드레일 강화
  - preflight에 AGENTS/skills 필수파일 점검 추가
  - manifest validator에 `--source baseline` 지원 추가
- 운영 명령 체계 고정
  - Makefile에 skill 매핑 타겟 추가
  - CI/CD 문서에 실행 순서 및 체크리스트 명시

## 이 PR의 비범위
- 환경변수/문서 정합화 자체
- web-core API 호출 구조 리팩터링 자체

## 주요 변경 파일
- `tests/integration/test_schedule_execution.py`
- `tests/unit_tests/test_schedule_time_sync.py`
- `scripts/release_preflight.py`
- `scripts/validate_release_manifest.py`
- `Makefile`
- `docs/dev/CI_CD_GUIDE.md`

## 검증
- `make PYTHON=/Users/hojungjung/development/newsletter-generator/.venv/bin/python skill-scheduler-debug`
- `make PYTHON=/Users/hojungjung/development/newsletter-generator/.venv/bin/python skill-release-integration`
- `make PYTHON=/Users/hojungjung/development/newsletter-generator/.venv/bin/python skill-ci-gate`
