### PR TITLE
refactor(web): replace subprocess generation path with newsletter.api

### DIFF
--- a/newsletter/api.py
+++ b/newsletter/api.py
@@ -1,0 +1,126 @@
+"""Stable programmatic API for newsletter generation."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, TypedDict, Union
+
+from . import graph, tools
+
+
+class NewsletterGenerationError(Exception):
+    """Raised when newsletter generation cannot produce a successful result."""
+
+
+class GenerationStats(TypedDict, total=False):
+    step_times: Dict[str, float]
+    total_time: float
+    cost_summary: Dict[str, Any]
+
+
+class NewsletterResult(TypedDict):
+    status: str
+    html_content: str
+    title: str
+    generation_stats: GenerationStats
+    input_params: Dict[str, Any]
+    error: Optional[str]
+
+
+@dataclass
+class GenerateNewsletterRequest:
+    keywords: Optional[Union[str, List[str]]] = None
+    domain: Optional[str] = None
+    template_style: str = "compact"
+    email_compatible: bool = False
+    period: int = 14
+    suggest_count: int = 10
+
+
+def _normalize_keywords(raw: Optional[Union[str, List[str]]]) -> List[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [item.strip() for item in raw.split(",") if item.strip()]
+    return [str(item).strip() for item in raw if str(item).strip()]
+
+
+def _extract_title(html_content: str, fallback: str) -> str:
+    match = re.search(r"<title>(.*?)</title>", html_content, flags=re.IGNORECASE)
+    if match and match.group(1).strip():
+        return match.group(1).strip()
+    return fallback
+
+
+def _resolve_keywords(request: GenerateNewsletterRequest) -> List[str]:
+    keywords = _normalize_keywords(request.keywords)
+    if keywords:
+        return keywords
+
+    if request.domain:
+        generated = tools.generate_keywords_with_gemini(
+            request.domain,
+            count=max(1, int(request.suggest_count)),
+        )
+        normalized = _normalize_keywords(generated)
+        if normalized:
+            return normalized
+        raise NewsletterGenerationError(
+            f"Failed to generate keywords from domain: {request.domain}"
+        )
+
+    raise NewsletterGenerationError("Either keywords or domain must be provided")
+
+
+def generate_newsletter(request: GenerateNewsletterRequest) -> NewsletterResult:
+    """Generate newsletter HTML and return a stable response schema."""
+    keywords = _resolve_keywords(request)
+
+    try:
+        html_or_error, status = graph.generate_newsletter(
+            keywords,
+            news_period_days=request.period,
+            domain=request.domain,
+            template_style=request.template_style,
+            email_compatible=request.email_compatible,
+        )
+    except Exception as exc:  # pragma: no cover - defensive wrapper
+        raise NewsletterGenerationError(str(exc)) from exc
+
+    info = graph.get_last_generation_info() or {}
+    stats: GenerationStats = {
+        "step_times": info.get("step_times", {}),
+        "total_time": info.get("total_time", 0.0),
+    }
+    if info.get("cost_summary"):
+        stats["cost_summary"] = info["cost_summary"]
+
+    input_params: Dict[str, Any] = {
+        "keywords": keywords,
+        "domain": request.domain,
+        "template_style": request.template_style,
+        "email_compatible": request.email_compatible,
+        "period": request.period,
+        "suggest_count": request.suggest_count,
+    }
+
+    if status != "success":
+        message = str(html_or_error)
+        raise NewsletterGenerationError(message)
+
+    title_fallback = (
+        f"Newsletter: {request.domain}"
+        if request.domain
+        else f"Newsletter: {', '.join(keywords[:3])}"
+    )
+    title = _extract_title(str(html_or_error), title_fallback)
+
+    return {
+        "status": "success",
+        "html_content": str(html_or_error),
+        "title": title,
+        "generation_stats": stats,
+        "input_params": input_params,
+        "error": None,
+    }

--- a/web/app.py
+++ b/web/app.py
@@ -159,8 +159,8 @@ from tasks import generate_newsletter_task
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 # Real newsletter CLI integration
-import subprocess
-import tempfile
+from newsletter.api import GenerateNewsletterRequest, NewsletterGenerationError
+from newsletter.api import generate_newsletter as generate_newsletter_core
 
 # 현재 디렉토리를 파이썬 패스에 추가
 current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -225,7 +225,7 @@ class RealNewsletterCLI:
         required_keys = {
             "GEMINI_API_KEY": "Gemini (primary LLM)",
             "OPENAI_API_KEY": "OpenAI (fallback LLM)",
-            "POSTMARK_TOKEN": "Email service",
+            "POSTMARK_SERVER_TOKEN": "Email service",
         }
 
         configured = []
@@ -251,158 +251,32 @@ class RealNewsletterCLI:
         email_compatible=False,
         period=14,
     ):
-        """실제 CLI를 사용하여 뉴스레터 생성"""
+        """공유 코어 API를 사용하여 뉴스레터 생성"""
         try:
-            # CLI 명령어 구성 - --output 옵션 제거
-            cmd = [
-                sys.executable,
-                "-m",
-                "newsletter.cli",
-                "run",
-                "--output-format",
-                "html",
-                "--template-style",
-                template_style,
-                "--period",
-                str(period),
-                "--log-level",
-                "INFO",  # 웹서비스에서는 INFO 레벨로 설정
-            ]
-
-            # 키워드 또는 도메인 추가
-            if keywords:
-                # 키워드가 문자열인 경우 그대로, 리스트인 경우 조인
-                keyword_str = (
-                    keywords if isinstance(keywords, str) else ",".join(keywords)
-                )
-                cmd.extend(["--keywords", keyword_str])
-                input_description = f"keywords: {keyword_str}"
-            elif domain:
-                cmd.extend(["--domain", domain])
-                input_description = f"domain: {domain}"
-            else:
-                raise ValueError("Either keywords or domain must be provided")
-
-            # 이메일 호환성 옵션 추가
-            if email_compatible:
-                cmd.append("--email-compatible")
-
-            # CLI 실행 환경 설정 - 한국어 인코딩 문제 해결
-            env = dict(os.environ)
-            env["PYTHONPATH"] = self.module_root
-            # UTF-8 인코딩 강제 설정
-            env["PYTHONIOENCODING"] = "utf-8"
-            env["PYTHONUTF8"] = "1"
-            # Windows CMD 인코딩 설정
-            env["CHCP"] = "65001"
-
-            # CLI 실행
-            logging.info(f"Executing CLI command: {' '.join(cmd)}")
-            logging.info(f"Working directory: {self.runtime_work_dir}")
-            logging.info(f"Input: {input_description}")
-
-            # 바이트 모드로 실행하여 인코딩 문제 방지
-            result = subprocess.run(
-                cmd,
-                cwd=self.runtime_work_dir,
-                capture_output=True,
-                text=False,  # 바이트 모드 사용
-                timeout=self.timeout,
-                env=env,
+            request_payload = GenerateNewsletterRequest(
+                keywords=keywords,
+                domain=domain,
+                template_style=template_style,
+                email_compatible=email_compatible,
+                period=period,
             )
+            result = generate_newsletter_core(request_payload)
 
-            # 안전한 디코딩
-            stdout_text = ""
-            stderr_text = ""
+            return {
+                "content": result["html_content"],
+                "title": result["title"],
+                "status": result["status"],
+                "generation_stats": result.get("generation_stats", {}),
+                "input_params": result.get("input_params", {}),
+                "error": result.get("error"),
+            }
 
-            if result.stdout:
-                try:
-                    stdout_text = result.stdout.decode("utf-8")
-                except UnicodeDecodeError:
-                    try:
-                        stdout_text = result.stdout.decode("cp949")
-                    except UnicodeDecodeError:
-                        stdout_text = result.stdout.decode("latin1")
-
-            if result.stderr:
-                try:
-                    stderr_text = result.stderr.decode("utf-8")
-                except UnicodeDecodeError:
-                    try:
-                        stderr_text = result.stderr.decode("cp949")
-                    except UnicodeDecodeError:
-                        stderr_text = result.stderr.decode("latin1")
-
-            # 결과 객체에 디코딩된 텍스트 할당
-            result.stdout = stdout_text
-            result.stderr = stderr_text
-
-            logging.info(
-                f"CLI execution completed with return code: {result.returncode}"
-            )
-
-            # 결과 처리
-            if result.returncode != 0:
-                error_msg = (
-                    f"CLI execution failed (code {result.returncode}): {result.stderr}"
-                )
-                logging.error(error_msg)
-                logging.error(f"CLI stdout: {result.stdout}")
-                return self._fallback_response(keywords or domain, error_msg)
-
-            # CLI가 자동으로 생성한 HTML 파일 찾기
-            default_output_dir = os.path.join(self.runtime_work_dir, "output")
-            html_content = self._find_latest_html_file(default_output_dir, keywords)
-            if not html_content:
-                fallback_output_dir = os.path.join(self.project_root, "output")
-                html_content = self._find_latest_html_file(
-                    fallback_output_dir,
-                    keywords,
-                )
-
-            if html_content:
-                # 제목 추출
-                title = (
-                    self._extract_title_from_html(html_content)
-                    or f"Newsletter: {keywords or domain}"
-                )
-
-                # 성공 통계 정보 추출
-                stats = self._extract_generation_stats(result.stdout)
-
-                logging.info(f"Newsletter generated successfully: {title}")
-                logging.info(f"Generated HTML size: {len(html_content)} characters")
-
-                response = {
-                    "content": html_content,
-                    "title": title,
-                    "status": "success",
-                    "cli_output": result.stdout,
-                    "generation_stats": stats,
-                    "input_params": {
-                        "keywords": keywords,
-                        "domain": domain,
-                        "template_style": template_style,
-                        "email_compatible": email_compatible,
-                        "period": period,
-                    },
-                }
-
-                return response
-            else:
-                error_msg = f"No HTML output file found in {default_output_dir}"
-                logging.error(error_msg)
-                return self._fallback_response(keywords or domain, error_msg)
-
-        except subprocess.TimeoutExpired:
-            error_msg = f"뉴스레터 생성이 {self.timeout}초 후 타임아웃되었습니다. API 키 설정을 확인해주세요."
-            logging.error(f"CLI execution timed out after {self.timeout} seconds")
-            logging.error("타임아웃 원인: API 키 누락으로 인한 Mock 데이터 사용 또는 외부 API 응답 지연")
-            return self._fallback_response(keywords or domain, error_msg)
-
+        except NewsletterGenerationError as exc:
+            logging.error("Core generation failed: %s", exc)
+            return self._fallback_response(keywords or domain, str(exc))
         except Exception as e:
             error_msg = f"Unexpected error: {str(e)}"
-            logging.error(error_msg, exc_info=True)  # 스택 트레이스 포함
+            logging.error(error_msg, exc_info=True)
             return self._fallback_response(keywords or domain, error_msg)
 
     def _find_latest_html_file(self, output_dir, keywords=None):
@@ -934,8 +808,11 @@ def generate_newsletter():
                                 fallback_result = {
                                     "status": "completed",
                                     "title": "Newsletter Generated",
-                                    "content": task_result["result"].get(
-                                        "content", "Newsletter content available"
+                                    "html_content": task_result["result"].get(
+                                        "html_content",
+                                        task_result["result"].get(
+                                            "content", "Newsletter content available"
+                                        ),
                                     ),
                                     "error": f"JSON serialization failed: {str(json_error)}",
                                 }
@@ -1180,18 +1057,16 @@ def process_newsletter_sync(data):
                 # 이메일 발송 실패해도 뉴스레터 생성은 성공으로 처리
 
         response = {
-            "html_content": result["content"],
-            "subject": result["title"],
-            "articles_count": result.get("generation_stats", {}).get(
-                "articles_count", 0
-            ),
-            "status": result["status"],
-            "cli_output": result.get("cli_output", ""),
-            "error": result.get("error"),
+            "status": result.get("status", "error"),
+            "html_content": result.get("content", ""),
+            "title": result.get("title", "Newsletter"),
             "generation_stats": result.get("generation_stats", {}),
             "input_params": result.get("input_params", {}),
-            "html_size": len(result["content"]) if result.get("content") else 0,
-            "email_sent": email_sent,  # 이메일 발송 상태 추가
+            "error": result.get("error"),
+            "sent": email_sent,
+            "email_sent": email_sent,
+            "subject": result.get("title", "Newsletter"),  # compatibility alias
+            "html_size": len(result.get("content", "")),
             "processing_info": {
                 "using_real_cli": isinstance(newsletter_cli, RealNewsletterCLI),
                 "template_style": template_style,
@@ -1476,8 +1351,13 @@ def run_schedule_now(schedule_id):
 
         # 즉시 뉴스레터 생성 작업 큐에 추가
         if redis_conn and task_queue:
+            immediate_job_id = f"schedule_{schedule_id}_{uuid.uuid4().hex[:8]}"
             job = task_queue.enqueue(
-                generate_newsletter_task, params, job_timeout="10m"
+                generate_newsletter_task,
+                params,
+                immediate_job_id,
+                params.get("send_email", False),
+                job_timeout="10m",
             )
 
             return jsonify(
@@ -1489,7 +1369,12 @@ def run_schedule_now(schedule_id):
             )
         else:
             # Redis가 없는 경우 직접 실행
-            result = generate_newsletter_task(params)
+            immediate_job_id = f"schedule_{schedule_id}_{uuid.uuid4().hex[:8]}"
+            result = generate_newsletter_task(
+                params,
+                immediate_job_id,
+                params.get("send_email", False),
+            )
             return jsonify({"status": "completed", "result": result})
 
     except Exception as e:

--- a/web/tasks.py
+++ b/web/tasks.py
@@ -1,27 +1,52 @@
-"""
-Background tasks for newsletter generation
-Uses Redis Queue (RQ) for asynchronous processing
-"""
+"""Background tasks for newsletter generation."""
 
-import os
+from __future__ import annotations
+
 import json
+import os
 import sqlite3
-from datetime import datetime, timedelta
-import subprocess
 import traceback
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
 
-# Add the parent directory to the path to import newsletter modules
-# sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from newsletter.api import (
+    GenerateNewsletterRequest,
+    NewsletterGenerationError,
+    generate_newsletter,
+)
 
 DATABASE_PATH = os.path.join(os.path.dirname(__file__), "storage.db")
 
 
-def update_job_status(job_id, status, result=None):
-    """Update job status in database"""
+def _ensure_history_row(job_id: str, params: Optional[Dict[str, Any]] = None) -> None:
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+    cursor.execute("SELECT id FROM history WHERE id = ?", (job_id,))
+    exists = cursor.fetchone() is not None
+
+    if not exists:
+        cursor.execute(
+            "INSERT INTO history (id, params, status) VALUES (?, ?, ?)",
+            (job_id, json.dumps(params or {}), "pending"),
+        )
+
+    conn.commit()
+    conn.close()
+
+
+def update_job_status(
+    job_id: str,
+    status: str,
+    result: Optional[Dict[str, Any]] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Update job status in database, creating the row if needed."""
+    _ensure_history_row(job_id, params)
+
     conn = sqlite3.connect(DATABASE_PATH)
     cursor = conn.cursor()
 
-    if result:
+    if result is not None:
         cursor.execute(
             "UPDATE history SET status = ?, result = ? WHERE id = ?",
             (status, json.dumps(result), job_id),
@@ -33,310 +58,126 @@ def update_job_status(job_id, status, result=None):
     conn.close()
 
 
-def generate_newsletter_task(data, job_id, send_email=False):
-    """Redis Worker에서 실행되는 뉴스레터 생성 작업"""
+def _build_request(data: Dict[str, Any]) -> GenerateNewsletterRequest:
+    return GenerateNewsletterRequest(
+        keywords=data.get("keywords"),
+        domain=data.get("domain"),
+        template_style=data.get("template_style", "compact"),
+        email_compatible=bool(data.get("email_compatible", False)),
+        period=int(data.get("period", 14)),
+        suggest_count=int(data.get("suggest_count", 10)),
+    )
 
-    print(f"🔄 Redis Worker: Starting newsletter generation for job {job_id}")
-    print(f"📊 Input data: {data}")
-    print(f"📧 Send email: {send_email}")
+
+def generate_newsletter_task(
+    data: Dict[str, Any],
+    job_id: str,
+    send_email: bool = False,
+) -> Dict[str, Any]:
+    """Generate newsletter in worker context with stable response schema."""
+    print(f"🔄 Worker: starting newsletter generation for job {job_id}")
+    update_job_status(job_id, "processing", params=data)
+
+    email = data.get("email", "")
 
     try:
-        update_job_status(job_id, "processing")
+        request = _build_request(data)
+        result = generate_newsletter(request)
 
-        # CLI 명령어 구성
-        keywords = data.get("keywords", "")
-        domain = data.get("domain", "")
-        template_style = data.get("template_style", "compact")
-        email_compatible = data.get("email_compatible", False)
-        period = data.get("period", 14)
-        email = data.get("email", "")
-
-        # CLI 명령어 구성
-        cmd = [
-            os.path.join(
-                os.path.dirname(__file__), "..", ".venv", "Scripts", "python.exe"
-            ),
-            "-m",
-            "newsletter.cli",
-            "run",
-            "--output-format",
-            "html",
-            "--template-style",
-            template_style,
-            "--period",
-            str(period),
-            "--log-level",
-            "INFO",
-        ]
-
-        # 키워드 또는 도메인 추가
-        if keywords:
-            keyword_str = keywords if isinstance(keywords, str) else ",".join(keywords)
-            # 한국어 키워드를 UTF-8로 안전하게 처리
-            try:
-                keyword_str.encode("utf-8")  # UTF-8 인코딩 가능한지 확인
-            except UnicodeEncodeError:
-                print(f"⚠️ Keyword encoding issue, trying to normalize: {keyword_str}")
-                keyword_str = keyword_str.encode("utf-8", errors="ignore").decode(
-                    "utf-8"
-                )
-            cmd.extend(["--keywords", keyword_str])
-        elif domain:
-            cmd.extend(["--domain", domain])
-        else:
-            raise ValueError("키워드 또는 도메인이 필요합니다")
-
-        print(f"🚀 Executing CLI command: {' '.join(cmd)}")
-
-        # CLI 실행 환경 설정
-        env = os.environ.copy()
-        env["PYTHONIOENCODING"] = "utf-8"
-        env["PYTHONPATH"] = os.path.dirname(os.path.dirname(__file__))
-        # 한국어 인코딩 관련 환경 변수 설정
-        env["LC_ALL"] = "en_US.UTF-8"
-        env["LANG"] = "en_US.UTF-8"
-        env["PYTHONUTF8"] = "1"
-
-        # CLI 실행 - 바이트 모드로 처리 후 안전하게 디코딩
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=False,  # 바이트 모드 사용
-                cwd=os.path.dirname(os.path.dirname(__file__)),
-                env=env,
-                timeout=300,
-            )
-
-            # 안전한 UTF-8 디코딩
-            stdout_text = ""
-            stderr_text = ""
-
-            if result.stdout:
-                try:
-                    stdout_text = result.stdout.decode("utf-8")
-                except UnicodeDecodeError:
-                    # CP949/EUC-KR로 시도
-                    try:
-                        stdout_text = result.stdout.decode("cp949")
-                    except UnicodeDecodeError:
-                        # 마지막으로 latin1으로 안전하게 디코딩
-                        stdout_text = result.stdout.decode("latin1")
-
-            if result.stderr:
-                try:
-                    stderr_text = result.stderr.decode("utf-8")
-                except UnicodeDecodeError:
-                    try:
-                        stderr_text = result.stderr.decode("cp949")
-                    except UnicodeDecodeError:
-                        stderr_text = result.stderr.decode("latin1")
-
-            # 결과 객체에 디코딩된 텍스트 할당
-            result.stdout = stdout_text
-            result.stderr = stderr_text
-
-        except subprocess.TimeoutExpired:
-            raise RuntimeError("CLI 실행이 시간 초과되었습니다 (300초)")
-        except Exception as e:
-            raise RuntimeError(f"CLI 실행 중 오류 발생: {str(e)}")
-
-        print(f"✅ CLI execution completed")
-        print(f"📝 CLI stdout: {result.stdout[:500]}...")
-        if result.stderr:
-            print(f"⚠️ CLI stderr: {result.stderr[:500]}...")
-
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"CLI failed with return code {result.returncode}: {result.stderr}"
-            )
-
-        # 생성된 HTML 파일 찾기
-        output_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "output")
-
-        # 키워드 기반으로 최신 파일 찾기
-        search_terms = []
-        if keywords:
-            if isinstance(keywords, str):
-                search_terms = [kw.strip().lower() for kw in keywords.split(",")]
-            else:
-                search_terms = [str(kw).strip().lower() for kw in keywords]
-        elif domain:
-            search_terms = [domain.lower()]
-
-        html_files = [f for f in os.listdir(output_dir) if f.endswith(".html")]
-
-        # 검색어가 포함된 파일 필터링
-        matching_files = []
-        for file in html_files:
-            file_lower = file.lower()
-            for term in search_terms:
-                if term in file_lower:
-                    matching_files.append(file)
-                    break
-
-        if matching_files:
-            html_files = matching_files
-            print(
-                f"📁 Found {len(matching_files)} files matching search terms: {search_terms}"
-            )
-        else:
-            print(f"⚠️ No files found matching search terms, using all HTML files")
-
-        if not html_files:
-            raise FileNotFoundError("생성된 HTML 파일을 찾을 수 없습니다")
-
-        # 최신 파일 선택
-        latest_file = max(
-            html_files, key=lambda x: os.path.getctime(os.path.join(output_dir, x))
-        )
-        file_path = os.path.join(output_dir, latest_file)
-
-        print(f"📄 Reading HTML file: {latest_file}")
-        print(f"📂 File path: {file_path}")
-        print(f"📏 File size: {os.path.getsize(file_path)} bytes")
-
-        # 다양한 인코딩으로 파일 읽기 시도
-        encodings = ["utf-8", "utf-8-sig", "cp949", "euc-kr", "latin1"]
-        html_content = None
-
-        for encoding in encodings:
-            try:
-                with open(file_path, "r", encoding=encoding) as f:
-                    html_content = f.read()
-                    print(f"✅ Successfully read file with {encoding} encoding")
-                    print(f"📊 Content length: {len(html_content)} characters")
-                    break
-            except UnicodeDecodeError:
-                print(f"❌ Failed to read with {encoding} encoding")
-                continue
-
-        if not html_content:
-            raise RuntimeError("모든 인코딩으로 파일 읽기에 실패했습니다")
-
-        # 결과 구성
-        result_data = {
-            "status": "success",
-            "html_content": html_content,
-            "file_path": latest_file,
-            "file_size": len(html_content),
-            "encoding_used": encoding,
-            "cli_mode": "Real CLI",
-            "template_style": template_style,
-            "email_compatible": email_compatible,
-            "period": f"{period} days",
-            "keywords": keywords,
-            "domain": domain,
+        response: Dict[str, Any] = {
+            "status": result["status"],
+            "html_content": result["html_content"],
+            "title": result["title"],
+            "generation_stats": result.get("generation_stats", {}),
+            "input_params": result.get("input_params", {}),
+            "error": None,
+            "sent": False,
+            "email_sent": False,
         }
 
-        # 이메일 발송 (옵션)
-        email_sent = False
         if send_email and email:
-            print(f"📧 Sending email to: {email}")
             try:
-                # 이메일 모듈 import
                 from mail import send_email as mail_send_email
 
-                # 제목 생성
-                if keywords:
-                    subject_keywords = (
-                        keywords if isinstance(keywords, str) else ", ".join(keywords)
-                    )
-                    subject = f"Newsletter: {subject_keywords}"
-                else:
-                    subject = f"Newsletter: {domain}"
+                mail_send_email(
+                    to=email,
+                    subject=result["title"],
+                    html=result["html_content"],
+                )
+                response["sent"] = True
+                response["email_sent"] = True
+                response["email_to"] = email
+            except Exception as exc:
+                response["email_sent"] = False
+                response["email_error"] = str(exc)
 
-                mail_send_email(to=email, subject=subject, html=html_content)
-                result_data["email_sent"] = True
-                result_data["email_to"] = email
-                email_sent = True
-                print(f"✅ Email sent successfully to {email}")
+        update_job_status(job_id, "completed", response)
+        return response
 
-            except Exception as e:
-                print(f"❌ Email sending failed: {e}")
-                result_data["email_sent"] = False
-                result_data["email_error"] = str(e)
-
-        result_data["sent"] = email_sent
-
-        # 성공 상태로 업데이트
-        update_job_status(job_id, "completed", result_data)
-        print(f"🎉 Newsletter generation completed successfully for job {job_id}")
-
-        return result_data
-
-    except Exception as e:
-        # 전체 스택트레이스 캡처
-        full_traceback = traceback.format_exc()
-        error_msg = f"Newsletter generation failed: {str(e)}"
-
-        print(f"❌ Error in generate_newsletter_task: {error_msg}")
-        print(f"🔍 Full traceback:\n{full_traceback}")
-
-        # sys 변수 상태 확인
-        try:
-            python_executable = os.path.join(
-                os.path.dirname(__file__), "..", ".venv", "Scripts", "python.exe"
-            )
-            print(f"🐍 Python executable: {python_executable}")
-            print(f"🐍 Current working directory: {os.getcwd()}")
-        except Exception as sys_check_error:
-            print(f"❌ Python executable check failed: {sys_check_error}")
-
-        # 실패 상태로 업데이트 (더 자세한 에러 정보 포함)
-        detailed_error_info = {
-            "error": error_msg,
-            "traceback": full_traceback,
-            "error_type": type(e).__name__,
+    except NewsletterGenerationError as exc:
+        error_response = {
+            "status": "error",
+            "html_content": "",
+            "title": "Newsletter Generation Failed",
+            "generation_stats": {},
+            "input_params": data,
+            "error": str(exc),
+            "sent": False,
+            "email_sent": False,
         }
-        update_job_status(job_id, "failed", detailed_error_info)
-
-        # 예외를 다시 발생시켜 RQ가 처리하도록 함
+        update_job_status(job_id, "failed", error_response)
+        raise
+    except Exception as exc:
+        error_response = {
+            "status": "error",
+            "html_content": "",
+            "title": "Newsletter Generation Failed",
+            "generation_stats": {},
+            "input_params": data,
+            "error": str(exc),
+            "traceback": traceback.format_exc(),
+            "sent": False,
+            "email_sent": False,
+        }
+        update_job_status(job_id, "failed", error_response)
         raise
 
 
-def generate_subject(params):
-    """Generate newsletter subject based on parameters"""
-    if "keywords" in params:
-        keywords = params["keywords"]
+def generate_subject(params: Dict[str, Any]) -> str:
+    """Generate newsletter subject based on parameters."""
+    keywords = params.get("keywords")
+    domain = params.get("domain")
+
+    if keywords:
         if isinstance(keywords, list):
-            keywords_str = ", ".join(keywords[:3])  # First 3 keywords
-        else:
-            keywords_str = keywords
-        return f"Newsletter: {keywords_str}"
-    elif "domain" in params:
-        return f"Newsletter: {params['domain']} Insights"
-    else:
-        return f"Newsletter - {datetime.now().strftime('%Y-%m-%d')}"
+            return f"Newsletter: {', '.join(str(k) for k in keywords[:3])}"
+        return f"Newsletter: {keywords}"
+    if domain:
+        return f"Newsletter: {domain} Insights"
+    return f"Newsletter - {datetime.now().strftime('%Y-%m-%d')}"
 
 
-def create_schedule_entry(params, job_id):
-    """Create a scheduled newsletter entry"""
+def create_schedule_entry(params: Dict[str, Any], job_id: str) -> str:
+    """Create a scheduled newsletter entry."""
     conn = sqlite3.connect(DATABASE_PATH)
     cursor = conn.cursor()
 
     schedule_id = f"schedule_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-
-    # Calculate next run time (simplified - would use proper RRULE parsing in production)
-    next_run = datetime.now() + timedelta(days=7)  # Default to weekly
+    next_run = datetime.now() + timedelta(days=7)
 
     cursor.execute(
         """
         INSERT INTO schedules (id, params, rrule, next_run)
         VALUES (?, ?, ?, ?)
-    """,
+        """,
         (schedule_id, json.dumps(params), params.get("rrule", "FREQ=WEEKLY"), next_run),
     )
 
     conn.commit()
     conn.close()
-
     return schedule_id
 
 
-# Worker entry point for RQ
 if __name__ == "__main__":
-    # This can be used to test tasks locally
     test_params = {"keywords": "AI, machine learning", "email": "test@example.com"}
-    result = generate_newsletter_task(test_params, "test-job-id")
-    print("Task result:", result)
+    print(generate_newsletter_task(test_params, "test-job-id"))


### PR DESCRIPTION
## 목적
web-core 호출 구조를 `newsletter.api.generate_newsletter` 단일 진입점으로 통일하고, subprocess 및 OS 종속 경로를 제거합니다.

## 이 PR의 역할
- 실행 인터페이스 표준화
  - `newsletter/api.py` 신설
  - `GenerateNewsletterRequest`, `NewsletterGenerationError`, `generate_newsletter()` 제공
- 웹/워커 호출 경로 전환
  - `web/app.py` subprocess 경로 제거, 코어 API 직접 호출
  - `web/tasks.py`의 `.venv/Scripts/python.exe` 하드코딩 제거
- 응답 스키마 정렬
  - 공통 키셋: `status`, `html_content`, `title`, `generation_stats`, `input_params`, `error`

## 이 PR의 비범위
- 릴리즈 preflight/manifest 게이트 강화
- 스케줄러 윈도우/Redis fallback 테스트 보강

## 주요 변경 파일
- `newsletter/api.py`
- `web/app.py`
- `web/tasks.py`

## 검증
- `rg -n "subprocess.run\\(|\\.venv/Scripts/python\\.exe" web/app.py web/tasks.py` -> 0건
- `make PYTHON=/Users/hojungjung/development/newsletter-generator/.venv/bin/python skill-newsletter-smoke`
- `make PYTHON=/Users/hojungjung/development/newsletter-generator/.venv/bin/python skill-web-smoke`
