### PR TITLE
refactor(PR-1): apps/packages skeleton with thin wrappers

### DIFF
--- a/apps/cli/main.py
+++ b/apps/cli/main.py
@@ -1,0 +1,18 @@
+"""CLI runtime wrapper."""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from newsletter.cli import app
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/scheduler/main.py
+++ b/apps/scheduler/main.py
@@ -1,0 +1,17 @@
+"""Scheduler runtime wrapper."""
+
+import runpy
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def main() -> None:
+    runpy.run_module("web.schedule_runner", run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/web/main.py
+++ b/apps/web/main.py
@@ -1,0 +1,19 @@
+"""Web runtime wrapper."""
+
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from web.app import app
+
+
+def main() -> None:
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", "8000")))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/worker/main.py
+++ b/apps/worker/main.py
@@ -1,0 +1,17 @@
+"""Worker runtime wrapper."""
+
+import runpy
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def main() -> None:
+    runpy.run_module("web.worker", run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/newsletter_core/__init__.py
+++ b/newsletter_core/__init__.py
@@ -1,0 +1,16 @@
+"""Compatibility namespace for local source layout.
+
+This keeps `newsletter_core` importable when running directly from repository root
+without editable installs.
+"""
+
+from pathlib import Path
+
+_pkg_path = Path(__file__).resolve().parent
+_src_pkg = _pkg_path.parent / "packages" / "newsletter_core" / "src" / "newsletter_core"
+
+if _src_pkg.exists():
+    pkg_paths = list(globals().get("__path__", []))
+    if str(_src_pkg) not in pkg_paths:
+        pkg_paths.append(str(_src_pkg))
+    globals()["__path__"] = pkg_paths

--- a/packages/newsletter_core/src/newsletter_core/__init__.py
+++ b/packages/newsletter_core/src/newsletter_core/__init__.py
@@ -1,0 +1,3 @@
+"""newsletter_core package."""
+
+__all__ = ["application", "domain", "infrastructure", "internal", "public"]

--- a/packages/newsletter_core/src/newsletter_core/application/__init__.py
+++ b/packages/newsletter_core/src/newsletter_core/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application layer for newsletter_core."""

--- a/packages/newsletter_core/src/newsletter_core/domain/__init__.py
+++ b/packages/newsletter_core/src/newsletter_core/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Domain layer for newsletter_core."""

--- a/packages/newsletter_core/src/newsletter_core/infrastructure/__init__.py
+++ b/packages/newsletter_core/src/newsletter_core/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure layer for newsletter_core."""

--- a/packages/newsletter_core/src/newsletter_core/internal/__init__.py
+++ b/packages/newsletter_core/src/newsletter_core/internal/__init__.py
@@ -1,0 +1,1 @@
+"""Internal, non-public components for newsletter_core."""

--- a/packages/newsletter_core/src/newsletter_core/public/__init__.py
+++ b/packages/newsletter_core/src/newsletter_core/public/__init__.py
@@ -1,0 +1,3 @@
+"""Public API surface for newsletter_core."""
+
+__all__ = ["generation", "settings", "lifecycle"]


### PR DESCRIPTION
## Scope\n- Add apps/(cli, web, worker, scheduler)/main.py thin wrappers\n- Add packages/newsletter_core package skeleton\n- Add local namespace bridge newsletter_core/__init__.py\n\n## Why\nRepresent runtime/deployment boundaries in directory topology before feature migration.\n\n## Validation\n- python apps/cli/main.py --help\n- python -c "import apps.web.main, apps.worker.main, apps.scheduler.main"\n- python run_ci_checks.py --quick\n\n## Notes\n- No business-logic migration in this PR.