### PR TITLE
test(contract): lock newsletter-html API behavior before web refactor

### DIFF
--- a/tests/contract/test_web_email_routes_contract.py
+++ b/tests/contract/test_web_email_routes_contract.py
@@ -1,0 +1,83 @@
+"""Contract tests that pin email/html web route behavior before refactor."""
+
+import json
+import sqlite3
+import uuid
+
+import pytest
+
+from web.app import DATABASE_PATH, app
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as test_client:
+        yield test_client
+
+
+def _insert_history_row(job_id: str, status: str, result: dict, params: dict) -> None:
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT OR REPLACE INTO history (id, params, result, status) VALUES (?, ?, ?, ?)",
+        (
+            job_id,
+            json.dumps(params),
+            json.dumps(result),
+            status,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _delete_history_row(job_id: str) -> None:
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM history WHERE id = ?", (job_id,))
+    conn.commit()
+    conn.close()
+
+
+def test_newsletter_html_returns_not_found_for_missing_job(client):
+    response = client.get("/api/newsletter-html/non-existent-contract-job")
+
+    assert response.status_code == 404
+    assert "뉴스레터를 찾을 수 없습니다" in response.get_data(as_text=True)
+
+
+def test_newsletter_html_returns_pending_message_for_unfinished_job(client):
+    job_id = f"contract-pending-{uuid.uuid4()}"
+    _insert_history_row(
+        job_id=job_id,
+        status="pending",
+        result={},
+        params={"keywords": "AI"},
+    )
+
+    try:
+        response = client.get(f"/api/newsletter-html/{job_id}")
+        assert response.status_code == 400
+        assert "완료되지 않았습니다" in response.get_data(as_text=True)
+    finally:
+        _delete_history_row(job_id)
+
+
+def test_newsletter_html_returns_rendered_content_for_completed_job(client):
+    job_id = f"contract-completed-{uuid.uuid4()}"
+    expected_html = "<html><body><h1>contract-html</h1></body></html>"
+    _insert_history_row(
+        job_id=job_id,
+        status="completed",
+        result={"html_content": expected_html},
+        params={"keywords": "AI"},
+    )
+
+    try:
+        response = client.get(f"/api/newsletter-html/{job_id}")
+        assert response.status_code == 200
+        assert response.headers["Content-Type"].startswith("text/html")
+        assert "contract-html" in response.get_data(as_text=True)
+    finally:
+        _delete_history_row(job_id)


### PR DESCRIPTION
## Summary
Phase 5 (`web/app.py` 분해) 착수용 **contract-first slice** 입니다.

이번 PR은 리팩터링 전에 `/api/newsletter-html/<job_id>`의 현재 동작을 계약 테스트로 고정합니다.

## Changes
- Added contract tests:
  - `tests/contract/test_web_email_routes_contract.py`
- Covered behaviors:
  - 존재하지 않는 job 조회 시 `404` + 오류 HTML 메시지
  - 완료되지 않은 job 조회 시 `400` + 상태 메시지
  - 완료된 job 조회 시 `200` + `text/html` 응답

## Why this slice
- Phase 5 규칙(“contract test 먼저 고정 후 리팩터”)을 먼저 충족합니다.
- 다음 PR에서 `web/app.py` 라우트 이동/분해 시 회귀 검출 기준으로 사용합니다.

## Verification
- `python run_ci_checks.py --full --source head` ✅
- `pytest tests/contract/test_web_email_routes_contract.py -q` ✅
- `pytest tests/test_web_api.py -q` ✅

## Notes
- `make check-full`의 `docs-check`는 현재 main에도 존재하는 레거시 markdown style debt로 실패할 수 있습니다(이번 PR에서 markdown 파일 변경 없음).
