### PR TITLE
refactor(web): extract send-email route registration

### DIFF
--- a/tests/contract/test_web_email_routes_contract.py
+++ b/tests/contract/test_web_email_routes_contract.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+import sys
 import uuid
 
 import pytest
@@ -79,5 +80,69 @@ def test_newsletter_html_returns_rendered_content_for_completed_job(client):
         assert response.status_code == 200
         assert response.headers["Content-Type"].startswith("text/html")
         assert "contract-html" in response.get_data(as_text=True)
+    finally:
+        _delete_history_row(job_id)
+
+
+def test_send_email_requires_job_id_and_email(client):
+    response = client.post(
+        "/api/send-email",
+        json={"job_id": "missing-email"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "job_id와 email이 필요합니다"}
+
+
+def test_send_email_returns_not_found_for_missing_job(client):
+    response = client.post(
+        "/api/send-email",
+        json={"job_id": "missing-job", "email": "contract@example.com"},
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "작업을 찾을 수 없습니다"}
+
+
+def test_send_email_sends_completed_newsletter(client, monkeypatch):
+    try:
+        import mail as mail_module
+    except ImportError:
+        from web import mail as mail_module
+
+    sent: dict[str, str] = {}
+
+    def _fake_send_email(*, to: str, subject: str, html: str) -> None:
+        sent["to"] = to
+        sent["subject"] = subject
+        sent["html"] = html
+
+    monkeypatch.setitem(sys.modules, "mail", mail_module)
+    monkeypatch.setattr(mail_module, "send_email", _fake_send_email)
+
+    job_id = f"contract-send-{uuid.uuid4()}"
+    expected_html = "<html><body><h1>contract-send</h1></body></html>"
+    _insert_history_row(
+        job_id=job_id,
+        status="completed",
+        result={"html_content": expected_html},
+        params={"keywords": ["AI", "ML"]},
+    )
+
+    try:
+        response = client.post(
+            "/api/send-email",
+            json={"job_id": job_id, "email": "contract@example.com"},
+        )
+        payload = response.get_json()
+
+        assert response.status_code == 200
+        assert payload == {
+            "success": True,
+            "message": "이메일이 성공적으로 발송되었습니다",
+        }
+        assert sent["to"] == "contract@example.com"
+        assert sent["subject"] == "Newsletter: AI, ML"
+        assert sent["html"] == expected_html
     finally:
         _delete_history_row(job_id)

--- a/web/app.py
+++ b/web/app.py
@@ -1629,73 +1629,12 @@ def manual_test():
     return render_template("manual_test.html")
 
 
-@app.route("/api/send-email", methods=["POST"])
-def send_email_api():
-    """생성된 뉴스레터를 이메일로 발송"""
-    try:
-        data = request.get_json()
-        job_id = data.get("job_id")
-        email = data.get("email")
+try:
+    from routes_send_email import register_send_email_route
+except ImportError:
+    from web.routes_send_email import register_send_email_route  # pragma: no cover
 
-        if not job_id or not email:
-            return jsonify({"error": "job_id와 email이 필요합니다"}), 400
-
-        # 작업 상태 확인
-        conn = sqlite3.connect(DATABASE_PATH)
-        cursor = conn.cursor()
-        cursor.execute(
-            "SELECT status, result, params FROM history WHERE id = ?", (job_id,)
-        )
-        row = cursor.fetchone()
-        conn.close()
-
-        if not row:
-            return jsonify({"error": "작업을 찾을 수 없습니다"}), 404
-
-        status, result_json, params_json = row
-        if status != "completed":
-            return jsonify({"error": "완료되지 않은 작업입니다"}), 400
-
-        result = json.loads(result_json) if result_json else {}
-        params = json.loads(params_json) if params_json else {}
-
-        html_content = result.get("html_content")
-        if not html_content:
-            return jsonify({"error": "발송할 콘텐츠가 없습니다"}), 400
-
-        # 이메일 발송 - try-except로 import 처리
-        try:
-            import mail
-
-            send_email_func = mail.send_email
-        except ImportError:
-            try:
-                from . import mail
-
-                send_email_func = mail.send_email
-            except ImportError:
-                return (
-                    jsonify({"error": "이메일 모듈을 찾을 수 없습니다. mail.py 파일을 확인해주세요."}),
-                    500,
-                )
-
-        # 제목 생성
-        keywords = params.get("keywords", [])
-        if isinstance(keywords, str):
-            keywords = [keywords]
-
-        subject = (
-            f"Newsletter: {', '.join(keywords) if keywords else 'Your Newsletter'}"
-        )
-
-        # 이메일 발송
-        send_email_func(to=email, subject=subject, html=html_content)
-
-        return jsonify({"success": True, "message": "이메일이 성공적으로 발송되었습니다"})
-
-    except Exception as e:
-        logging.error(f"Email sending failed: {e}")
-        return jsonify({"error": f"이메일 발송 실패: {str(e)}"}), 500
+register_send_email_route(app, DATABASE_PATH)
 
 
 try:

--- a/web/routes_send_email.py
+++ b/web/routes_send_email.py
@@ -1,0 +1,77 @@
+"""Route registration for newsletter send-email endpoint."""
+
+import json
+import logging
+import sqlite3
+from types import ModuleType
+from typing import cast
+
+from flask import Flask, jsonify, request
+from flask.typing import ResponseReturnValue
+
+
+def _resolve_mail_module() -> ModuleType:
+    """Resolve mail module in both script and package execution modes."""
+    try:
+        import mail
+
+        return cast(ModuleType, mail)
+    except ImportError:
+        from . import mail  # pragma: no cover
+
+        return cast(ModuleType, mail)
+
+
+def register_send_email_route(app: Flask, database_path: str) -> None:
+    """Register send-email route on the given Flask app."""
+
+    @app.route("/api/send-email", methods=["POST"])  # type: ignore[untyped-decorator]
+    def send_email_api() -> ResponseReturnValue:
+        """생성된 뉴스레터를 이메일로 발송"""
+        try:
+            data = request.get_json()
+            job_id = data.get("job_id")
+            email = data.get("email")
+
+            if not job_id or not email:
+                return jsonify({"error": "job_id와 email이 필요합니다"}), 400
+
+            conn = sqlite3.connect(database_path)
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT status, result, params FROM history WHERE id = ?", (job_id,)
+            )
+            row = cursor.fetchone()
+            conn.close()
+
+            if not row:
+                return jsonify({"error": "작업을 찾을 수 없습니다"}), 404
+
+            status, result_json, params_json = row
+            if status != "completed":
+                return jsonify({"error": "완료되지 않은 작업입니다"}), 400
+
+            result = json.loads(result_json) if result_json else {}
+            params = json.loads(params_json) if params_json else {}
+
+            html_content = result.get("html_content")
+            if not html_content:
+                return jsonify({"error": "발송할 콘텐츠가 없습니다"}), 400
+
+            mail_module = _resolve_mail_module()
+
+            keywords = params.get("keywords", [])
+            if isinstance(keywords, str):
+                keywords = [keywords]
+
+            subject = (
+                f"Newsletter: {', '.join(keywords) if keywords else 'Your Newsletter'}"
+            )
+
+            mail_module.send_email(to=email, subject=subject, html=html_content)
+
+            return jsonify({"success": True, "message": "이메일이 성공적으로 발송되었습니다"})
+
+        except Exception as e:
+            logging.error(f"Email sending failed: {e}")
+            return jsonify({"error": f"이메일 발송 실패: {str(e)}"}), 500


### PR DESCRIPTION
## Summary
- extract `/api/send-email` route implementation from `/Users/hojungjung/development/newsletter-generator/web/app.py`
- add `/Users/hojungjung/development/newsletter-generator/web/routes_send_email.py` with `register_send_email_route(app, database_path)`
- add contract coverage for `/api/send-email` behavior in `/Users/hojungjung/development/newsletter-generator/tests/contract/test_web_email_routes_contract.py`

## Why
- continue Phase 5 incremental decomposition of `/Users/hojungjung/development/newsletter-generator/web/app.py`
- pin behavior before further route refactors to reduce regression risk

## Verification
- `.venv/bin/pytest tests/contract/test_web_email_routes_contract.py -q`
- `.venv/bin/python run_ci_checks.py --full --source head`
