### PR TITLE
refactor(chains): extract categorization chain builder

### DIFF
--- a/newsletter/chains.py
+++ b/newsletter/chains.py
@@ -13,7 +13,8 @@ from langchain_core.runnables import RunnableLambda
 
 from newsletter.article_filter import select_top_articles
 
-from .chains_llm_utils import format_articles, get_llm
+from .chains_categorization import build_categorization_chain
+from .chains_llm_utils import get_llm
 from .compose import NewsletterConfig, compose_newsletter, create_grouped_sections
 from .template_manager import TemplateManager
 from .utils.logger import get_logger
@@ -214,107 +215,10 @@ COMPOSITION_PROMPT를 사용하세요.
 
 
 def create_categorization_chain(is_compact=False):
-    llm = get_llm(temperature=0.2)
-
-    # compact 버전용 간소화된 프롬프트
-    compact_prompt = """당신은 뉴스들을 간결하게 분류하는 전문 편집자입니다.
-
-다음 뉴스 기사들을 분석하여 2-3개의 주요 카테고리로 분류해주세요:
-{formatted_articles}
-
-출력 형식은 다음과 같은 JSON 형식으로 작성해주세요:
-{{
-  "categories": [
-    {{
-      "title": "카테고리 제목",
-      "article_indices": [1, 2, 5]
-    }},
-    {{
-      "title": "카테고리 제목 2",
-      "article_indices": [3, 4, 6]
-    }}
-  ]
-}}
-
-각 카테고리 제목은 독자가 어떤 내용인지 한눈에 알 수 있도록 명확하고 구체적으로 작성해주세요."""
-
-    # 메시지 생성 함수
-    def create_messages(data):
-        try:
-            # 문자열 직접 포맷팅 대신 미리 처리된 값으로 포맷팅
-            keywords = data.get("keywords", "")
-            formatted_articles = format_articles(data)
-
-            # 중첩된 중괄호 이스케이프 처리
-            formatted_articles = formatted_articles.replace("{", "{{").replace(
-                "}", "}}"
-            )
-
-            # compact 버전인지에 따라 프롬프트 선택
-            if is_compact:
-                prompt = compact_prompt.format(formatted_articles=formatted_articles)
-            else:
-                # 포맷팅 진행
-                prompt = CATEGORIZATION_PROMPT.format(
-                    keywords=keywords,
-                    formatted_articles=formatted_articles,
-                )
-
-            # 메시지를 HumanMessage로 변환
-            # (Gemini는 시스템 메시지 지원이 불안정함)
-            return [HumanMessage(content=prompt)]
-        except Exception as e:
-            logger.error(f"카테고리 메시지 생성 중 오류: {e}")
-            import traceback
-
-            traceback.print_exc()
-            raise
-
-    # 체인 구성
-    chain = RunnableLambda(create_messages) | llm | StrOutputParser()
-
-    # JSON 파싱 함수
-    def parse_json_response(text):
-        try:
-            # JSON 부분만 추출
-            import re
-
-            json_match = re.search(r"```(?:json)?\s*(.*?)```", text, re.DOTALL)
-            if json_match:
-                json_str = json_match.group(1).strip()
-            else:
-                # compact 버전에서는 중괄호로 감싸진 JSON도 찾기
-                if is_compact:
-                    json_match = re.search(r"\{.*\}", text, re.DOTALL)
-                    if json_match:
-                        json_str = json_match.group()
-                    else:
-                        json_str = text.strip()
-                else:
-                    json_str = text.strip()
-
-            # JSON 파싱
-            result = json.loads(json_str)
-            logger.info(
-                f"카테고리 분류 결과: " f"{json.dumps(result, ensure_ascii=False, indent=2)}"
-            )
-            return result
-        except Exception as e:
-            logger.error(f"JSON 파싱 오류: {e}")
-            logger.error(f"원본 텍스트: {text}")
-            # 기본 구조 반환
-            if is_compact:
-                return {
-                    "categories": [
-                        {"title": "주요 동향", "article_indices": list(range(1, 11))}
-                    ]
-                }
-            else:
-                return {
-                    "categories": [{"title": "기타", "article_indices": [1, 2, 3, 4, 5]}]
-                }
-
-    return chain | RunnableLambda(parse_json_response)
+    return build_categorization_chain(
+        categorization_prompt=CATEGORIZATION_PROMPT,
+        is_compact=is_compact,
+    )
 
 
 # 2. 카테고리별 요약 체인 생성 함수 (compact 옵션 추가)

--- a/newsletter/chains_categorization.py
+++ b/newsletter/chains_categorization.py
@@ -1,0 +1,118 @@
+"""Categorization chain builder for newsletter generation."""
+
+# mypy: disable-error-code=no-untyped-def
+
+import json
+
+from langchain_core.messages import HumanMessage
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.runnables import RunnableLambda
+
+from .chains_llm_utils import format_articles, get_llm
+from .utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def build_categorization_chain(categorization_prompt: str, is_compact: bool = False):
+    llm = get_llm(temperature=0.2)
+
+    # compact 버전용 간소화된 프롬프트
+    compact_prompt = """당신은 뉴스들을 간결하게 분류하는 전문 편집자입니다.
+
+다음 뉴스 기사들을 분석하여 2-3개의 주요 카테고리로 분류해주세요:
+{formatted_articles}
+
+출력 형식은 다음과 같은 JSON 형식으로 작성해주세요:
+{{
+  "categories": [
+    {{
+      "title": "카테고리 제목",
+      "article_indices": [1, 2, 5]
+    }},
+    {{
+      "title": "카테고리 제목 2",
+      "article_indices": [3, 4, 6]
+    }}
+  ]
+}}
+
+각 카테고리 제목은 독자가 어떤 내용인지 한눈에 알 수 있도록 명확하고 구체적으로 작성해주세요."""
+
+    # 메시지 생성 함수
+    def create_messages(data):
+        try:
+            # 문자열 직접 포맷팅 대신 미리 처리된 값으로 포맷팅
+            keywords = data.get("keywords", "")
+            formatted_articles = format_articles(data)
+
+            # 중첩된 중괄호 이스케이프 처리
+            formatted_articles = formatted_articles.replace("{", "{{").replace(
+                "}", "}}"
+            )
+
+            # compact 버전인지에 따라 프롬프트 선택
+            if is_compact:
+                prompt = compact_prompt.format(formatted_articles=formatted_articles)
+            else:
+                # 포맷팅 진행
+                prompt = categorization_prompt.format(
+                    keywords=keywords,
+                    formatted_articles=formatted_articles,
+                )
+
+            # 메시지를 HumanMessage로 변환
+            # (Gemini는 시스템 메시지 지원이 불안정함)
+            return [HumanMessage(content=prompt)]
+        except Exception as e:
+            logger.error(f"카테고리 메시지 생성 중 오류: {e}")
+            import traceback
+
+            traceback.print_exc()
+            raise
+
+    # 체인 구성
+    chain = RunnableLambda(create_messages) | llm | StrOutputParser()
+
+    # JSON 파싱 함수
+    def parse_json_response(text):
+        try:
+            # JSON 부분만 추출
+            import re
+
+            json_match = re.search(r"```(?:json)?\s*(.*?)```", text, re.DOTALL)
+            if json_match:
+                json_str = json_match.group(1).strip()
+            else:
+                # compact 버전에서는 중괄호로 감싸진 JSON도 찾기
+                if is_compact:
+                    json_match = re.search(r"\{.*\}", text, re.DOTALL)
+                    if json_match:
+                        json_str = json_match.group()
+                    else:
+                        json_str = text.strip()
+                else:
+                    json_str = text.strip()
+
+            # JSON 파싱
+            result = json.loads(json_str)
+            logger.info(
+                f"카테고리 분류 결과: " f"{json.dumps(result, ensure_ascii=False, indent=2)}"
+            )
+            return result
+        except Exception as e:
+            logger.error(f"JSON 파싱 오류: {e}")
+            logger.error(f"원본 텍스트: {text}")
+            # 기본 구조 반환
+            if is_compact:
+                return {
+                    "categories": [
+                        {"title": "주요 동향", "article_indices": list(range(1, 11))}
+                    ]
+                }
+            else:
+                return {
+                    "categories": [{"title": "기타", "article_indices": [1, 2, 3, 4, 5]}]
+                }
+
+    return chain | RunnableLambda(parse_json_response)


### PR DESCRIPTION
## Summary
- extract categorization-chain builder from `/Users/hojungjung/development/newsletter-generator/newsletter/chains.py` into `/Users/hojungjung/development/newsletter-generator/newsletter/chains_categorization.py`
- keep existing public API by retaining `create_categorization_chain(...)` in `chains.py` as a thin wrapper
- continue Phase 5 modularization to reduce `chains.py` responsibilities

## Verification
- `.venv/bin/python run_ci_checks.py --full --source head`
