### PR TITLE
refactor: extract web sentry bootstrap

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -11,6 +11,7 @@ import sqlite3
 import sys
 import uuid
 from datetime import datetime
+from typing import Any
 
 import redis
 from flask import Flask, jsonify, render_template, request, send_file
@@ -41,115 +42,12 @@ except ImportError:
 # Import web types module - will be loaded later to avoid conflicts
 
 
-# Sentry 통합 - 더미 함수 먼저 정의
-def set_sentry_user_context(*args, **kwargs):
-    """Sentry 사용자 컨텍스트 설정 (더미)"""
-    pass
-
-
-def set_sentry_tags(**kwargs):
-    """Sentry 태그 설정 (더미)"""
-    pass
-
-
-# Centralized Settings 사용한 Sentry 설정
 try:
-    from newsletter_core.public.settings import get_settings
+    from sentry_integration import setup_sentry
+except ImportError:
+    from web.sentry_integration import setup_sentry  # pragma: no cover
 
-    settings = get_settings()
-
-    if settings.sentry_dsn:
-        try:
-            import sentry_sdk
-            from sentry_sdk.integrations.flask import FlaskIntegration
-            from sentry_sdk.integrations.logging import LoggingIntegration
-
-            logging_integration = LoggingIntegration(
-                level=logging.INFO,
-                event_level=logging.ERROR,
-            )
-
-            sentry_sdk.init(
-                dsn=settings.sentry_dsn,
-                integrations=[
-                    FlaskIntegration(transaction_style="endpoint"),
-                    logging_integration,
-                ],
-                traces_sample_rate=settings.sentry_traces_sample_rate,
-                environment=settings.environment,
-                release=settings.app_version,
-                profiles_sample_rate=settings.sentry_profiles_sample_rate,
-                before_send=lambda event, hint: (
-                    event if event.get("level") != "info" else None
-                ),
-            )
-            print("✅ Sentry initialized successfully")
-
-            # 실제 Sentry 함수들로 재정의
-            def set_sentry_user_context(user_id=None, email=None, **kwargs):
-                """Sentry에 사용자 컨텍스트 설정"""
-                sentry_sdk.set_user({"id": user_id, "email": email, **kwargs})
-
-            def set_sentry_tags(**tags):
-                """Sentry에 태그 설정"""
-                for key, value in tags.items():
-                    sentry_sdk.set_tag(key, value)
-
-        except ImportError:
-            print("⚠️  Sentry SDK not installed, skipping Sentry integration")
-        except Exception as e:
-            print(f"⚠️  Sentry initialization failed: {e}")
-    else:
-        print("ℹ️  Sentry DSN not configured, skipping Sentry integration")
-
-except Exception as e:
-    # Centralized settings 실패 시 legacy fallback
-    print(f"⚠️  Centralized settings unavailable, checking legacy SENTRY_DSN: {e}")
-    if os.getenv("SENTRY_DSN"):
-        try:
-            import sentry_sdk
-            from sentry_sdk.integrations.flask import FlaskIntegration
-            from sentry_sdk.integrations.logging import LoggingIntegration
-
-            logging_integration = LoggingIntegration(
-                level=logging.INFO,
-                event_level=logging.ERROR,
-            )
-
-            sentry_sdk.init(
-                dsn=os.getenv("SENTRY_DSN"),
-                integrations=[
-                    FlaskIntegration(transaction_style="endpoint"),
-                    logging_integration,
-                ],
-                traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.1")),
-                environment=os.getenv("ENVIRONMENT", "production"),
-                release=os.getenv("APP_VERSION", "1.0.0"),
-                profiles_sample_rate=float(
-                    os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.1")
-                ),
-                before_send=lambda event, hint: (
-                    event if event.get("level") != "info" else None
-                ),
-            )
-            print("✅ Sentry initialized successfully (legacy mode)")
-
-            # 실제 Sentry 함수들로 재정의
-            def set_sentry_user_context(user_id=None, email=None, **kwargs):
-                """Sentry에 사용자 컨텍스트 설정"""
-                sentry_sdk.set_user({"id": user_id, "email": email, **kwargs})
-
-            def set_sentry_tags(**tags):
-                """Sentry에 태그 설정"""
-                for key, value in tags.items():
-                    sentry_sdk.set_tag(key, value)
-
-        except ImportError:
-            print("⚠️  Sentry SDK not installed, skipping Sentry integration")
-        except Exception as e:
-            print(f"⚠️  Sentry initialization failed: {e}")
-    else:
-        print("ℹ️  Legacy SENTRY_DSN not configured, skipping Sentry integration")
+set_sentry_user_context, set_sentry_tags = setup_sentry()
 
 
 # Import task function for RQ
@@ -222,13 +120,13 @@ except Exception as e:
     task_queue = None
 
 # In-memory task storage for when Redis is unavailable
-in_memory_tasks = {}
+in_memory_tasks: dict[str, dict[str, Any]] = {}
 
 # Database initialization
 DATABASE_PATH = resolve_database_path()
 
 
-def init_db():
+def init_db() -> None:
     """Initialize SQLite database with required tables"""
     conn = sqlite3.connect(DATABASE_PATH)
     cursor = conn.cursor()
@@ -269,7 +167,7 @@ init_db()
 
 
 @app.route("/")
-def index():
+def index() -> str | tuple[str, int]:
     """Main dashboard page"""
     try:
         print(f"Template folder: {app.template_folder}")

--- a/web/sentry_integration.py
+++ b/web/sentry_integration.py
@@ -1,0 +1,126 @@
+"""
+Sentry initialization helpers for the Flask web runtime.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from typing import Any
+
+SentryUserContextSetter = Callable[..., None]
+SentryTagSetter = Callable[..., None]
+SentryCallbacks = tuple[SentryUserContextSetter, SentryTagSetter]
+
+
+def _noop_set_sentry_user_context(*args: Any, **kwargs: Any) -> None:
+    del args, kwargs
+
+
+def _noop_set_sentry_tags(**kwargs: Any) -> None:
+    del kwargs
+
+
+def _build_callbacks(sentry_sdk_module: Any) -> SentryCallbacks:
+    def set_sentry_user_context(
+        user_id: Any = None, email: Any = None, **kwargs: Any
+    ) -> None:
+        sentry_sdk_module.set_user({"id": user_id, "email": email, **kwargs})
+
+    def set_sentry_tags(**tags: Any) -> None:
+        for key, value in tags.items():
+            sentry_sdk_module.set_tag(key, value)
+
+    return set_sentry_user_context, set_sentry_tags
+
+
+def _init_sentry(
+    *,
+    dsn: str,
+    traces_sample_rate: float,
+    environment: str,
+    release: str,
+    profiles_sample_rate: float,
+    success_label: str,
+) -> SentryCallbacks:
+    callbacks: SentryCallbacks = (
+        _noop_set_sentry_user_context,
+        _noop_set_sentry_tags,
+    )
+
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.flask import FlaskIntegration
+        from sentry_sdk.integrations.logging import LoggingIntegration
+    except ImportError:
+        print("⚠️  Sentry SDK not installed, skipping Sentry integration")
+        return callbacks
+
+    try:
+        logging_integration = LoggingIntegration(
+            level=logging.INFO,
+            event_level=logging.ERROR,
+        )
+
+        sentry_sdk.init(
+            dsn=dsn,
+            integrations=[
+                FlaskIntegration(transaction_style="endpoint"),
+                logging_integration,
+            ],
+            traces_sample_rate=traces_sample_rate,
+            environment=environment,
+            release=release,
+            profiles_sample_rate=profiles_sample_rate,
+            before_send=lambda event, hint: (
+                event if event.get("level") != "info" else None
+            ),
+        )
+        print(success_label)
+        return _build_callbacks(sentry_sdk)
+    except Exception as exc:
+        print(f"⚠️  Sentry initialization failed: {exc}")
+        return callbacks
+
+
+def setup_sentry() -> SentryCallbacks:
+    callbacks: SentryCallbacks = (
+        _noop_set_sentry_user_context,
+        _noop_set_sentry_tags,
+    )
+
+    try:
+        from newsletter_core.public.settings import get_settings
+
+        settings = get_settings()
+        if settings.sentry_dsn:
+            return _init_sentry(
+                dsn=settings.sentry_dsn,
+                traces_sample_rate=settings.sentry_traces_sample_rate,
+                environment=settings.environment,
+                release=settings.app_version,
+                profiles_sample_rate=settings.sentry_profiles_sample_rate,
+                success_label="✅ Sentry initialized successfully",
+            )
+
+        print("ℹ️  Sentry DSN not configured, skipping Sentry integration")
+        return callbacks
+    except Exception as exc:
+        print(
+            f"⚠️  Centralized settings unavailable, checking legacy SENTRY_DSN: {exc}"
+        )
+
+    legacy_dsn = os.getenv("SENTRY_DSN")
+    if not legacy_dsn:
+        print("ℹ️  Legacy SENTRY_DSN not configured, skipping Sentry integration")
+        return callbacks
+
+    return _init_sentry(
+        dsn=legacy_dsn,
+        traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.1")),
+        environment=os.getenv("ENVIRONMENT", "production"),
+        release=os.getenv("APP_VERSION", "1.0.0"),
+        profiles_sample_rate=float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.1")),
+        success_label="✅ Sentry initialized successfully (legacy mode)",
+    )


### PR DESCRIPTION
## Summary
- extract Sentry initialization and callback wiring from `web/app.py` into `web/sentry_integration.py`
- keep runtime behavior and fallback modes (centralized settings + legacy env)
- add type annotations for `in_memory_tasks`, `init_db`, and `index` in `web/app.py`

## Verification
- `.venv/bin/python run_ci_checks.py --full --source head`

## Outcome
- `web/app.py` reduced to 253 lines
