### PR TITLE
fix: make web/cli/chains strict-gate ready

### DIFF
--- a/newsletter/chains.py
+++ b/newsletter/chains.py
@@ -3,6 +3,8 @@ Newsletter Generator - LangChain Chains
 이 모듈은 뉴스레터 생성을 위한 LangChain 체인을 정의합니다.
 """
 
+from typing import Any, cast
+
 from langchain_core.runnables import RunnableLambda
 
 from . import chains_prompts
@@ -27,7 +29,7 @@ load_html_template = chains_prompts.load_html_template
 get_llm = _get_llm
 
 
-def create_categorization_chain(is_compact=False):
+def create_categorization_chain(is_compact: bool = False) -> Any:
     return build_categorization_chain(
         categorization_prompt=CATEGORIZATION_PROMPT,
         is_compact=is_compact,
@@ -38,7 +40,7 @@ def create_categorization_chain(is_compact=False):
 
 
 # 2. 카테고리별 요약 체인 생성 함수 (compact 옵션 추가)
-def create_summarization_chain(is_compact=False):
+def create_summarization_chain(is_compact: bool = False) -> Any:
     return build_summarization_chain(
         summarization_prompt=SUMMARIZATION_PROMPT,
         is_compact=is_compact,
@@ -46,7 +48,7 @@ def create_summarization_chain(is_compact=False):
 
 
 # 전체 파이프라인 구성 (compact 옵션 추가)
-def get_newsletter_chain(is_compact=False):
+def get_newsletter_chain(is_compact: bool = False) -> RunnableLambda:
     # 1. 분류 체인
     categorization_chain = create_categorization_chain(is_compact=is_compact)
 
@@ -60,7 +62,7 @@ def get_newsletter_chain(is_compact=False):
     rendering_chain = create_rendering_chain() if not is_compact else None
 
     # 데이터 흐름 관리 함수
-    def manage_data_flow(data):
+    def manage_data_flow(data: dict[str, Any]) -> dict[str, Any]:
         logger.debug(f"manage_data_flow 호출됨. is_compact={is_compact}")
         try:
             # 데이터 유효성 검증
@@ -72,7 +74,10 @@ def get_newsletter_chain(is_compact=False):
             # 빈 기사 배열 처리 - 유용한 뉴스레터를 생성하도록 개선
             if not articles or len(articles) == 0:
                 logger.info("뉴스 기사가 수집되지 않았지만, 키워드 기반 유용한 뉴스레터를 생성합니다.")
-                return handle_no_articles_scenario(data, is_compact)
+                return cast(
+                    dict[str, Any],
+                    handle_no_articles_scenario(data, is_compact),
+                )
 
             # 1. 분류 단계 실행
             if is_compact:
@@ -91,43 +96,42 @@ def get_newsletter_chain(is_compact=False):
             )
 
             if is_compact:
-                return build_compact_newsletter_result(data, sections_data)
-
-            else:
-                # Detailed 모드 처리
-                # 3. 종합 구성 단계 실행
-                logger.step("종합 구성", "composition")
-                composition_data = composition_chain.invoke(
-                    {"sections_data": sections_data, "articles_data": data}
+                return cast(
+                    dict[str, Any],
+                    build_compact_newsletter_result(data, sections_data),
                 )
 
-                # 4. 렌더링 단계 실행
-                logger.step("HTML 템플릿 렌더링", "rendering")
+            # Detailed 모드 처리
+            if composition_chain is None or rendering_chain is None:
+                raise RuntimeError(
+                    "Detailed mode requires composition/rendering chains to be initialized."
+                )
 
-                # 템플릿 렌더링을 위한 데이터 준비
-                rendering_data = {
-                    "composition": composition_data,
-                    "sections_data": sections_data,
-                    "keywords": data.get("keywords", ""),
-                    "domain": data.get("domain", ""),
-                    "ranked_articles": data.get("ranked_articles", []),
-                    "processed_articles": data.get("processed_articles", []),
-                    "email_compatible": data.get("email_compatible", False),
-                    "template_style": data.get("template_style", "detailed"),
-                }
+            logger.step("종합 구성", "composition")
+            composition_data = composition_chain.invoke(
+                {"sections_data": sections_data, "articles_data": data}
+            )
 
-                # 렌더링 체인 호출
-                html_content, structured_data = rendering_chain.invoke(rendering_data)
+            logger.step("HTML 템플릿 렌더링", "rendering")
+            rendering_data = {
+                "composition": composition_data,
+                "sections_data": sections_data,
+                "keywords": data.get("keywords", ""),
+                "domain": data.get("domain", ""),
+                "ranked_articles": data.get("ranked_articles", []),
+                "processed_articles": data.get("processed_articles", []),
+                "email_compatible": data.get("email_compatible", False),
+                "template_style": data.get("template_style", "detailed"),
+            }
 
-                logger.success("Detailed 뉴스레터 생성 완료!")
-
-                # Detailed 모드에서 HTML과 구조화된 데이터를 함께 반환
-                return {
-                    "html": html_content,
-                    "structured_data": structured_data,
-                    "sections": sections_data.get("sections", []),
-                    "mode": "detailed",
-                }
+            html_content, structured_data = rendering_chain.invoke(rendering_data)
+            logger.success("Detailed 뉴스레터 생성 완료!")
+            return {
+                "html": html_content,
+                "structured_data": structured_data,
+                "sections": sections_data.get("sections", []),
+                "mode": "detailed",
+            }
 
         except Exception as e:
             logger.error(f"데이터 흐름 처리 중 오류 발생: {e}")
@@ -141,8 +145,9 @@ def get_newsletter_chain(is_compact=False):
 
 
 # 기존 summarization_chain 유지 (하위 호환성)
-def get_summarization_chain(callbacks=None):
+def get_summarization_chain(callbacks: Any = None) -> RunnableLambda:
     """callbacks 매개변수를 지원하는 요약 체인 반환 함수"""
+    del callbacks
 
     # get_newsletter_chain()은 RunnableLambda(manage_data_flow)를 반환하고,
     # manage_data_flow는 이제 final_html만 반환합니다.

--- a/newsletter/cli.py
+++ b/newsletter/cli.py
@@ -7,7 +7,7 @@ import os
 import sys
 import traceback
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, cast
 
 # F-14: Windows 한글 인코딩 문제 해결 (강화된 버전)
 if sys.platform.startswith("win"):
@@ -87,7 +87,7 @@ console = Console()
 
 
 # The 'collect' command can remain if it's used for other purposes or direct testing.
-@app.command()
+@app.command()  # type: ignore[untyped-decorator]
 def collect(
     keywords: str,
     max_per_source: int = typer.Option(
@@ -107,7 +107,7 @@ def collect(
         "--log-level",
         help="Logging level: DEBUG, INFO, WARNING, ERROR",
     ),
-):
+) -> None:
     """
     Collect articles based on keywords with improved filtering and grouping.
     """
@@ -163,7 +163,7 @@ def collect(
     logger.success(f"Results saved to {output_path}")
 
 
-@app.command()
+@app.command()  # type: ignore[untyped-decorator]
 def suggest(
     domain: str = typer.Option(..., "--domain", help="Domain to suggest keywords for."),
     count: int = typer.Option(
@@ -174,7 +174,7 @@ def suggest(
         "--log-level",
         help="Logging level: DEBUG, INFO, WARNING, ERROR",
     ),
-):
+) -> None:
     """
     Suggests trend keywords for a given domain using Google Gemini.
     """
@@ -238,7 +238,7 @@ def suggest_keywords(domain: str, count: int = 10) -> list[str]:
     from . import tools
 
     # 기존 검증된 키워드 생성 함수 사용
-    return tools.generate_keywords_with_gemini(domain, count=count)
+    return cast(list[str], tools.generate_keywords_with_gemini(domain, count=count))
 
 
 if __name__ == "__main__":

--- a/web/app.py
+++ b/web/app.py
@@ -11,7 +11,7 @@ import sqlite3
 import sys
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 import redis
 from flask import Flask, jsonify, render_template, request, send_file
@@ -166,7 +166,7 @@ def init_db() -> None:
 init_db()
 
 
-@app.route("/")
+@app.route("/")  # type: ignore[untyped-decorator]
 def index() -> str | tuple[str, int]:
     """Main dashboard page"""
     try:
@@ -175,7 +175,7 @@ def index() -> str | tuple[str, int]:
         template_path = os.path.join(app.template_folder, "index.html")
         print(f"Template path: {template_path}")
         print(f"Template exists: {os.path.exists(template_path)}")
-        return render_template("index.html")
+        return cast(str, render_template("index.html"))
     except Exception as e:
         print(f"Template rendering error: {e}")
         return f"Template error: {str(e)}", 500
@@ -254,4 +254,4 @@ if __name__ == "__main__":
     port = int(os.environ.get("PORT", 5000))
     debug = os.environ.get("FLASK_ENV") == "development"
     print(f"Starting Flask app on port {port}, debug={debug}")
-    app.run(host="0.0.0.0", port=port, debug=True)
+    app.run(host="0.0.0.0", port=port, debug=debug)


### PR DESCRIPTION
## Summary
- make `web/app.py` pass strict checks (`mypy` decorator/return typing and `bandit` debug flag issue)
- add typing/return handling in `newsletter/chains.py` to remove strict mypy blockers
- add typing updates in `newsletter/cli.py` for typer decorator + return typing

## Verification
- `.venv/bin/python run_ci_checks.py --full --source head`
- `.venv/bin/python -m mypy --ignore-missing-imports --follow-imports=skip newsletter/cli.py newsletter/chains.py`
- `.venv/bin/python -m mypy --ignore-missing-imports --follow-imports=skip -m web.app`
- `.venv/bin/python -m bandit -f txt --skip B104,B110 newsletter/cli.py newsletter/chains.py web/app.py`
