### PR TITLE
chore: remove strict-gate runtime exclusions

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           set -euo pipefail
           RUNTIME_FILES="$(echo "${{ steps.changed-python.outputs.files }}" | grep -E '^(newsletter|web|apps|packages/newsletter_core|newsletter_core)/.*\.py$' || true)"
-          STRICT_RUNTIME_FILES="$(echo "$RUNTIME_FILES" | grep -Ev '^(web/app.py|newsletter/cli.py|newsletter/chains.py)$' || true)"
+          STRICT_RUNTIME_FILES="$RUNTIME_FILES"
           if [ -z "$STRICT_RUNTIME_FILES" ]; then
             echo "Skip mypy: no runtime Python file changes."
             exit 0
@@ -157,7 +157,7 @@ jobs:
         run: |
           set -euo pipefail
           RUNTIME_FILES="$(echo "${{ steps.changed-python.outputs.files }}" | grep -E '^(newsletter|web|apps|packages/newsletter_core|newsletter_core)/.*\.py$' || true)"
-          STRICT_RUNTIME_FILES="$(echo "$RUNTIME_FILES" | grep -Ev '^(web/app.py|newsletter/cli.py|newsletter/chains.py)$' || true)"
+          STRICT_RUNTIME_FILES="$RUNTIME_FILES"
           if [ -z "$STRICT_RUNTIME_FILES" ]; then
             echo "Skip bandit: no runtime Python file changes."
             exit 0

--- a/run_ci_checks.py
+++ b/run_ci_checks.py
@@ -30,12 +30,8 @@ if sys.platform.startswith("win"):
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
     sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
 
-# Temporary strict-gate exclusion list for legacy large modules under refactor.
-LEGACY_RUNTIME_GATE_EXCLUDES = {
-    "web/app.py",
-    "newsletter/cli.py",
-    "newsletter/chains.py",
-}
+# Legacy strict-gate exclusions removed: all runtime modules are now enforced.
+LEGACY_RUNTIME_GATE_EXCLUDES: set[str] = set()
 
 
 class Colors:


### PR DESCRIPTION
## Summary
- remove legacy runtime strict-gate exclusions from `run_ci_checks.py`
- update `main-ci.yml` to run mypy/bandit against all changed runtime Python files without excluding `web/app.py`, `newsletter/cli.py`, `newsletter/chains.py`

## Verification
- `.venv/bin/python run_ci_checks.py --full --source head`
- `.venv/bin/python -m mypy --ignore-missing-imports --follow-imports=skip newsletter/cli.py newsletter/chains.py`
- `.venv/bin/python -m mypy --ignore-missing-imports --follow-imports=skip -m web.app`
- `.venv/bin/python -m bandit -f txt --skip B104,B110 newsletter/cli.py newsletter/chains.py web/app.py`
