### PR TITLE
test: add PR-D contract stabilization coverage

### DIFF
--- a/tests/contract/test_chains_contract.py
+++ b/tests/contract/test_chains_contract.py
@@ -1,0 +1,201 @@
+"""Contract tests for newsletter.chains orchestration behavior."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from newsletter import chains, chains_llm_utils, chains_prompts
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+class _StubRunnable:
+    def __init__(self, result: Any) -> None:
+        self.result = result
+        self.calls: list[Any] = []
+
+    def invoke(self, payload: Any) -> Any:
+        self.calls.append(payload)
+        return self.result
+
+
+def test_public_re_exports_remain_stable() -> None:
+    assert chains.COMPOSITION_PROMPT == chains_prompts.COMPOSITION_PROMPT
+    assert chains.HTML_TEMPLATE == chains_prompts.HTML_TEMPLATE
+    assert chains.SYSTEM_PROMPT == chains_prompts.SYSTEM_PROMPT
+    assert chains.load_html_template is chains_prompts.load_html_template
+    assert chains.get_llm is chains_llm_utils.get_llm
+
+
+def test_get_newsletter_chain_compact_skips_detailed_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    categories_data = {"categories": [{"name": "industry"}]}
+    sections_data = {"sections": [{"category": "industry"}]}
+    compact_result = {"mode": "compact", "html": "<html>compact</html>"}
+
+    categorization_chain = _StubRunnable(categories_data)
+    summarization_chain = _StubRunnable(sections_data)
+
+    monkeypatch.setattr(
+        chains,
+        "create_categorization_chain",
+        lambda is_compact=False: categorization_chain,
+    )
+    monkeypatch.setattr(
+        chains,
+        "create_summarization_chain",
+        lambda is_compact=False: summarization_chain,
+    )
+    monkeypatch.setattr(
+        chains,
+        "create_composition_chain",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("compact flow must not build composition chain")
+        ),
+    )
+    monkeypatch.setattr(
+        chains,
+        "create_rendering_chain",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("compact flow must not build rendering chain")
+        ),
+    )
+    monkeypatch.setattr(
+        chains,
+        "build_compact_newsletter_result",
+        lambda data, sections: compact_result,
+    )
+
+    payload = {"articles": [{"title": "A"}], "keywords": "AI"}
+    result = chains.get_newsletter_chain(is_compact=True).invoke(payload)
+
+    assert result == compact_result
+    assert categorization_chain.calls == [payload]
+    assert summarization_chain.calls == [
+        {"categories_data": categories_data, "articles_data": payload}
+    ]
+
+
+def test_get_newsletter_chain_detailed_runs_composition_and_rendering(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    categories_data = {"categories": [{"name": "mobility"}]}
+    sections_data = {"sections": [{"category": "mobility"}]}
+    composition_data = {"title": "Detailed Contract"}
+    rendering_output = (
+        "<html><body><h1>Detailed Contract</h1></body></html>",
+        {"title": "Detailed Contract"},
+    )
+
+    categorization_chain = _StubRunnable(categories_data)
+    summarization_chain = _StubRunnable(sections_data)
+    composition_chain = _StubRunnable(composition_data)
+    rendering_chain = _StubRunnable(rendering_output)
+
+    monkeypatch.setattr(
+        chains,
+        "create_categorization_chain",
+        lambda is_compact=False: categorization_chain,
+    )
+    monkeypatch.setattr(
+        chains,
+        "create_summarization_chain",
+        lambda is_compact=False: summarization_chain,
+    )
+    monkeypatch.setattr(chains, "create_composition_chain", lambda: composition_chain)
+    monkeypatch.setattr(chains, "create_rendering_chain", lambda: rendering_chain)
+
+    payload = {
+        "articles": [{"title": "A"}],
+        "keywords": "AI",
+        "domain": "example.com",
+        "ranked_articles": [{"title": "A"}],
+        "processed_articles": [{"title": "A"}],
+        "email_compatible": True,
+        "template_style": "detailed",
+    }
+    result = chains.get_newsletter_chain(is_compact=False).invoke(payload)
+
+    assert result["mode"] == "detailed"
+    assert result["html"] == rendering_output[0]
+    assert result["structured_data"] == rendering_output[1]
+    assert result["sections"] == sections_data["sections"]
+    assert composition_chain.calls == [
+        {"sections_data": sections_data, "articles_data": payload}
+    ]
+    assert rendering_chain.calls == [
+        {
+            "composition": composition_data,
+            "sections_data": sections_data,
+            "keywords": "AI",
+            "domain": "example.com",
+            "ranked_articles": payload["ranked_articles"],
+            "processed_articles": payload["processed_articles"],
+            "email_compatible": True,
+            "template_style": "detailed",
+        }
+    ]
+
+
+def test_get_newsletter_chain_no_articles_uses_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    categorization_chain = _StubRunnable({"categories": []})
+    summarization_chain = _StubRunnable({"sections": []})
+    composition_chain = _StubRunnable({"title": "unused"})
+    rendering_chain = _StubRunnable(("<html>unused</html>", {"title": "unused"}))
+
+    monkeypatch.setattr(
+        chains,
+        "create_categorization_chain",
+        lambda is_compact=False: categorization_chain,
+    )
+    monkeypatch.setattr(
+        chains,
+        "create_summarization_chain",
+        lambda is_compact=False: summarization_chain,
+    )
+    monkeypatch.setattr(chains, "create_composition_chain", lambda: composition_chain)
+    monkeypatch.setattr(chains, "create_rendering_chain", lambda: rendering_chain)
+    monkeypatch.setattr(
+        chains,
+        "handle_no_articles_scenario",
+        lambda data, is_compact: {"mode": "detailed", "reason": "no-articles"},
+    )
+
+    result = chains.get_newsletter_chain(is_compact=False).invoke(
+        {"articles": [], "keywords": "AI"}
+    )
+
+    assert result == {"mode": "detailed", "reason": "no-articles"}
+    assert categorization_chain.calls == []
+    assert summarization_chain.calls == []
+    assert composition_chain.calls == []
+    assert rendering_chain.calls == []
+
+
+def test_get_newsletter_chain_requires_articles_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        chains,
+        "create_categorization_chain",
+        lambda is_compact=False: _StubRunnable({"categories": []}),
+    )
+    monkeypatch.setattr(
+        chains,
+        "create_summarization_chain",
+        lambda is_compact=False: _StubRunnable({"sections": []}),
+    )
+    monkeypatch.setattr(chains, "create_composition_chain", lambda: _StubRunnable({}))
+    monkeypatch.setattr(
+        chains,
+        "create_rendering_chain",
+        lambda: _StubRunnable(("<html></html>", {})),
+    )
+
+    with pytest.raises(ValueError, match="articles"):
+        chains.get_newsletter_chain(is_compact=False).invoke({"keywords": "AI"})

--- a/tests/contract/test_web_email_routes_contract.py
+++ b/tests/contract/test_web_email_routes_contract.py
@@ -9,6 +9,8 @@ import pytest
 
 from web.app import DATABASE_PATH, app
 
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
 
 @pytest.fixture
 def client():

--- a/tests/contract/test_web_runtime_contract.py
+++ b/tests/contract/test_web_runtime_contract.py
@@ -1,0 +1,49 @@
+"""Contract tests for Flask runtime bootstrap behavior."""
+
+from __future__ import annotations
+
+import pytest
+
+from web import sentry_integration
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def test_web_app_registers_core_routes() -> None:
+    from web.app import app
+
+    registered_routes = {rule.rule for rule in app.url_map.iter_rules()}
+    expected_routes = {
+        "/",
+        "/health",
+        "/api/generate",
+        "/api/send-email",
+        "/api/newsletter-html/<job_id>",
+    }
+
+    assert expected_routes.issubset(registered_routes)
+
+
+def test_setup_sentry_returns_noop_callbacks_without_dsn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from newsletter_core.public import settings as settings_module
+
+    class _Settings:
+        sentry_dsn = None
+        sentry_traces_sample_rate = 0.0
+        environment = "test"
+        app_version = "test"
+        sentry_profiles_sample_rate = 0.0
+
+    monkeypatch.setattr(settings_module, "get_settings", lambda: _Settings())
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+
+    set_user_context, set_tags = sentry_integration.setup_sentry()
+
+    assert callable(set_user_context)
+    assert callable(set_tags)
+    assert (
+        set_user_context(user_id="user-1", email="u@example.com", role="admin") is None
+    )
+    assert set_tags(component="web", layer="runtime") is None


### PR DESCRIPTION
## Summary
- add unit-marked contract tests for `newsletter.chains` orchestration behavior (compact/detailed/no-articles/missing input + public re-exports)
- add unit-marked runtime contract tests for `web.app` core route registration and `web.sentry_integration.setup_sentry()` no-op callback behavior when DSN is unset
- include existing `tests/contract/test_web_email_routes_contract.py` in the unit gate via module-level markers

## Risk
- low: test-only changes, no runtime code path changed

## Verification
- `MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/contract/test_chains_contract.py tests/contract/test_web_runtime_contract.py tests/contract/test_web_email_routes_contract.py -m unit -q`
- `./.venv/bin/python run_ci_checks.py --full --source head`
- `make check-full` *(fails at existing repository-wide `docs-check` baseline issues unrelated to this PR; `run_ci_checks.py --full` passes)*
