### PR TITLE
PR-1: 운영 안전성 잠금 (설정 단일화 + 스키마 자동 수렴)

### DIFF
--- a/newsletter/centralized_settings.py
+++ b/newsletter/centralized_settings.py
@@ -9,10 +9,10 @@ F-14 중앙집중식 설정 관리 모듈
 import logging
 import os
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional, Tuple, Type, Union
+from typing import Any, Dict, Literal, Tuple, Type
 
 from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import (
@@ -20,11 +20,12 @@ from pydantic_settings import (
     PydanticBaseSettingsSource,
     SettingsConfigDict,
 )
+
 from .utils.error_handling import handle_exception
 
 # 테스트 모드 플래그
 _test_mode = "pytest" in sys.modules or os.getenv("TESTING") == "1"
-_test_env_vars = {}
+_test_env_vars: Dict[str, str] = {}
 
 
 def is_running_in_pytest() -> bool:
@@ -32,19 +33,7 @@ def is_running_in_pytest() -> bool:
     return "pytest" in sys.modules or os.getenv("PYTEST_RUNNING") == "1" or _test_mode
 
 
-def clear_settings_cache():
-    """F-14: 설정 캐시를 클리어하여 테스트 격리 지원"""
-    global _cached_settings
-    _cached_settings = None
-
-
-def disable_test_mode():
-    """F-14: 테스트 모드를 비활성화하여 실제 검증 수행"""
-    global _test_mode
-    _test_mode = False
-
-
-def enable_test_mode(test_env_vars: dict = None):
+def enable_test_mode(test_env_vars: Dict[str, str] | None = None) -> None:
     """테스트 모드 활성화 - 환경변수 오버라이드 허용"""
     global _test_mode, _test_env_vars
     _test_mode = True
@@ -52,7 +41,7 @@ def enable_test_mode(test_env_vars: dict = None):
     clear_settings_cache()
 
 
-def disable_test_mode():
+def disable_test_mode() -> None:
     """테스트 모드 비활성화"""
     global _test_mode, _test_env_vars
     _test_mode = False
@@ -60,7 +49,7 @@ def disable_test_mode():
     clear_settings_cache()
 
 
-def _get_env(key: str, default=None):
+def _get_env(key: str, default: str | None = None) -> str | None:
     """테스트 모드에서는 테스트 환경변수 우선, 아니면 OS 환경변수"""
     if _test_mode and key in _test_env_vars:
         return _test_env_vars[key]
@@ -74,7 +63,7 @@ def _should_load_dotenv() -> bool:
     return app_env == "development"
 
 
-def _load_dotenv_if_needed():
+def _load_dotenv_if_needed() -> None:
     """필요한 경우에만 .env 파일 로드"""
     if _should_load_dotenv() and not _test_mode:
         try:
@@ -85,14 +74,12 @@ def _load_dotenv_if_needed():
             pass
 
 
-# 초기 로드
-_load_dotenv_if_needed()
-
-
 class TestModeEnvSource(PydanticBaseSettingsSource):
     """테스트 모드에서 환경변수 오버라이드를 위한 소스"""
 
-    def get_field_value(self, field_info, field_name: str) -> Tuple[Any, str, bool]:
+    def get_field_value(
+        self, field_info: Any, field_name: str
+    ) -> Tuple[Any, str, bool]:
         # 테스트 모드에서 환경변수 오버라이드
         if _test_mode and field_name in _test_env_vars:
             return _test_env_vars[field_name], field_name, False
@@ -117,19 +104,12 @@ class TestModeEnvSource(PydanticBaseSettingsSource):
     def __call__(self) -> Dict[str, Any]:
         d: Dict[str, Any] = {}
 
-        if self.settings_cls.model_config.get("case_sensitive"):
-            prepare_field_value = self.prepare_field_value
-        else:
-            prepare_field_value = lambda field_name, field, value, value_is_complex: self.prepare_field_value(
-                field_name, field, value, value_is_complex
-            )
-
         for field_name, field in self.settings_cls.model_fields.items():
             field_value, field_key, value_is_complex = self.get_field_value(
                 field, field_name
             )
             if field_value is not None:
-                d[field_name] = prepare_field_value(
+                d[field_name] = self.prepare_field_value(
                     field_name, field, field_value, value_is_complex
                 )
 
@@ -141,9 +121,7 @@ class CentralizedSettings(BaseSettings):
 
     # 필수 설정 (F-14: SERPER_API_KEY를 Optional로 변경)
     serper_api_key: SecretStr | None = None
-    postmark_server_token: SecretStr | None = Field(
-        None, description="Postmark 서버 토큰"
-    )
+    postmark_server_token: SecretStr | None = Field(None, description="Postmark 서버 토큰")
     email_sender: str | None = Field(None, description="발송자 이메일")
 
     # LLM API 키 (하나 이상 필수)
@@ -163,10 +141,10 @@ class CentralizedSettings(BaseSettings):
     concurrent_requests: int = Field(5, description="동시 요청 수")
 
     # F-14: 테스트 모드 설정
-    test_mode: bool = Field(True, description="테스트 모드 활성화")
-    mock_api_responses: bool = Field(True, description="API 응답 모킹 활성화")
-    skip_real_api_calls: bool = Field(True, description="실제 API 호출 건너뛰기")
-    test_api_key_override: bool = Field(True, description="테스트용 API 키 오버라이드")
+    test_mode: bool = Field(False, description="테스트 모드 활성화")
+    mock_api_responses: bool = Field(False, description="API 응답 모킹 활성화")
+    skip_real_api_calls: bool = Field(False, description="실제 API 호출 건너뛰기")
+    test_api_key_override: bool = Field(False, description="테스트용 API 키 오버라이드")
 
     # 공통 설정
     secret_key: str = Field("dev-secret-key-change-in-production", min_length=16)
@@ -246,14 +224,12 @@ class CentralizedSettings(BaseSettings):
         return (
             init_settings,  # 명시적으로 전달된 값이 최우선
             test_env_source,  # 테스트 모드 또는 일반 환경변수
-            (
-                dotenv_settings if not _test_mode else init_settings
-            ),  # 테스트 모드에서는 .env 무시
+            (dotenv_settings if not _test_mode else init_settings),  # 테스트 모드에서는 .env 무시
             file_secret_settings,
         )
 
     # 검증
-    @field_validator("postmark_server_token")
+    @field_validator("postmark_server_token")  # type: ignore[untyped-decorator]
     @classmethod
     def validate_api_keys(cls, v: SecretStr | None) -> SecretStr | None:
         # None인 경우는 허용
@@ -266,7 +242,7 @@ class CentralizedSettings(BaseSettings):
             raise ValueError("API key must be >= 16 characters")
         return v
 
-    @field_validator("serper_api_key")
+    @field_validator("serper_api_key")  # type: ignore[untyped-decorator]
     @classmethod
     def validate_optional_serper_key(cls, v: SecretStr | None) -> SecretStr | None:
         # None인 경우는 허용
@@ -279,7 +255,7 @@ class CentralizedSettings(BaseSettings):
             raise ValueError("API key must be >= 16 characters")
         return v
 
-    def model_post_init(self, __context) -> None:
+    def model_post_init(self, __context: Any) -> None:
         """LLM 키 검증 및 디렉토리 생성"""
         # F-14: 테스트 모드 자동 감지 및 설정
         import os
@@ -330,7 +306,7 @@ class CentralizedSettings(BaseSettings):
 
 
 # 테스트를 위한 캐시 클리어 함수
-def clear_settings_cache():
+def clear_settings_cache() -> None:
     """테스트용으로 설정 캐시를 클리어합니다."""
     get_settings.cache_clear()
 
@@ -339,6 +315,7 @@ def clear_settings_cache():
 def get_settings() -> CentralizedSettings:
     """설정 싱글톤 반환"""
     try:
+        _load_dotenv_if_needed()
         return CentralizedSettings()
     except Exception as e:
         logging.critical(f"Settings validation failed: {e}")
@@ -378,7 +355,7 @@ class _SecretFilter(logging.Filter):
         return True
 
 
-def setup_secret_logging():
+def setup_secret_logging() -> None:
     """시크릿 마스킹 로거 설정"""
     root_logger = logging.getLogger()
     secret_filter = _SecretFilter()
@@ -399,7 +376,7 @@ class F14PerformanceSettings:
     concurrent_requests: int = 5  # 동시 요청 수 제한
 
     # F-14: 테스트 모드 설정 추가
-    test_mode: bool = True  # 테스트 모드 (기본값: True)
-    mock_api_responses: bool = True  # API 응답 모킹 활성화
-    skip_real_api_calls: bool = True  # 실제 API 호출 건너뛰기
-    test_api_key_override: bool = True  # 테스트용 API 키 오버라이드 활성화
+    test_mode: bool = False  # 테스트 모드 (기본값: False)
+    mock_api_responses: bool = False  # API 응답 모킹 활성화
+    skip_real_api_calls: bool = False  # 실제 API 호출 건너뛰기
+    test_api_key_override: bool = False  # 테스트용 API 키 오버라이드 활성화

--- a/newsletter/config_manager.py
+++ b/newsletter/config_manager.py
@@ -1,32 +1,39 @@
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 from dotenv import load_dotenv
 
-# 환경 변수 로드
-load_dotenv()
+
+def _load_dotenv_if_needed() -> None:
+    """Load .env lazily to avoid import-time side effects."""
+    app_env = os.getenv("APP_ENV", "production")
+    testing = os.getenv("TESTING") == "1" or "pytest" in os.getenv(
+        "PYTEST_CURRENT_TEST", ""
+    )
+    if app_env == "development" and not testing:
+        load_dotenv(override=False)
 
 
 class ConfigManager:
     """중앙 집중식 설정 관리자"""
 
-    _instance = None
-    _config_cache = {}
+    _instance: "ConfigManager | None" = None
+    _config_cache: Dict[str, Dict[str, Any]] = {}
 
-    def __new__(cls):
+    def __new__(cls) -> "ConfigManager":
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
 
-    def __init__(self):
+    def __init__(self) -> None:
         if not hasattr(self, "_initialized"):
             self._initialized = True
             self._load_environment_variables()
 
     @classmethod
-    def reset_for_testing(cls, test_env_vars: dict = None):
+    def reset_for_testing(cls, test_env_vars: Dict[str, str] | None = None) -> None:
         """테스트용으로 싱글톤 인스턴스와 캐시를 리셋합니다."""
         cls._instance = None
         cls._config_cache = {}
@@ -40,9 +47,10 @@ class ConfigManager:
         except ImportError:
             pass
 
-    def _load_environment_variables(self):
+    def _load_environment_variables(self) -> None:
         """환경 변수 로딩 - Centralized Settings 사용"""
         try:
+            _load_dotenv_if_needed()
             from newsletter.centralized_settings import get_settings
 
             settings = get_settings()
@@ -108,9 +116,7 @@ class ConfigManager:
                 raise e
 
             # Centralized settings 실패 시 fallback to legacy
-            self._log_warning(
-                f"Centralized settings 로드 실패, legacy os.getenv 사용: {e}"
-            )
+            self._log_warning(f"Centralized settings 로드 실패, legacy os.getenv 사용: {e}")
 
             # 레거시 fallback (호환성을 위해 유지)
             from newsletter.compat_env import getenv_compat
@@ -158,7 +164,7 @@ class ConfigManager:
         config_data = self.load_config_file()
         llm_settings = config_data.get("llm_settings", {})
 
-        if not llm_settings:
+        if not isinstance(llm_settings, dict) or not llm_settings:
             return self._get_default_llm_config()
 
         return llm_settings
@@ -208,9 +214,7 @@ class ConfigManager:
 
         if not required_keys.issubset(config_keys):
             missing_keys = required_keys - config_keys
-            self._log_warning(
-                f"스코어링 가중치 키가 누락되었습니다: {missing_keys}. 기본값을 사용합니다."
-            )
+            self._log_warning(f"스코어링 가중치 키가 누락되었습니다: {missing_keys}. 기본값을 사용합니다.")
             return default_weights
 
         try:
@@ -220,15 +224,11 @@ class ConfigManager:
             if abs(total - 1.0) < 0.01:  # 허용 오차
                 return weights
             else:
-                self._log_warning(
-                    f"스코어링 가중치의 합이 {total:.3f}이며 1.0이 아닙니다. 기본값을 사용합니다."
-                )
+                self._log_warning(f"스코어링 가중치의 합이 {total:.3f}이며 1.0이 아닙니다. 기본값을 사용합니다.")
                 return default_weights
 
         except (ValueError, TypeError) as e:
-            self._log_warning(
-                f"스코어링 가중치 값이 올바르지 않습니다: {e}. 기본값을 사용합니다."
-            )
+            self._log_warning(f"스코어링 가중치 값이 올바르지 않습니다: {e}. 기본값을 사용합니다.")
             return default_weights
 
     def _get_default_llm_config(self) -> Dict[str, Any]:
@@ -384,7 +384,7 @@ class ConfigManager:
             "ready": token_valid and email_valid,
         }
 
-    def _log_warning(self, message: str):
+    def _log_warning(self, message: str) -> None:
         """경고 메시지 출력"""
         try:
             from .utils.logger import get_logger
@@ -396,7 +396,7 @@ class ConfigManager:
 
 
 # 싱글톤 인스턴스 (지연 초기화)
-_config_manager_instance = None
+_config_manager_instance: ConfigManager | None = None
 
 
 def get_config_manager() -> ConfigManager:
@@ -408,4 +408,14 @@ def get_config_manager() -> ConfigManager:
 
 
 # 하위 호환성을 위한 별칭
-config_manager = get_config_manager()
+class _LazyConfigManager:
+    """Lazy proxy to prevent eager settings initialization at import time."""
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(get_config_manager(), item)
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return "<LazyConfigManager proxy>"
+
+
+config_manager = _LazyConfigManager()

--- a/tests/unit_tests/test_config_import_side_effects.py
+++ b/tests/unit_tests/test_config_import_side_effects.py
@@ -1,0 +1,51 @@
+"""Import-only tests to guard against dotenv side effects."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import dotenv
+import pytest
+
+
+def _clear_module_cache() -> None:
+    prefixes = (
+        "newsletter.config_manager",
+        "newsletter.centralized_settings",
+    )
+    for name in list(sys.modules):
+        if name.startswith(prefixes):
+            del sys.modules[name]
+
+
+@pytest.mark.unit
+def test_config_manager_import_does_not_call_load_dotenv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"count": 0}
+
+    def _fake_load_dotenv(*_args, **_kwargs):
+        calls["count"] += 1
+        return False
+
+    monkeypatch.setattr(dotenv, "load_dotenv", _fake_load_dotenv)
+    _clear_module_cache()
+    importlib.import_module("newsletter.config_manager")
+    assert calls["count"] == 0
+
+
+@pytest.mark.unit
+def test_centralized_settings_import_does_not_call_load_dotenv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"count": 0}
+
+    def _fake_load_dotenv(*_args, **_kwargs):
+        calls["count"] += 1
+        return False
+
+    monkeypatch.setattr(dotenv, "load_dotenv", _fake_load_dotenv)
+    _clear_module_cache()
+    importlib.import_module("newsletter.centralized_settings")
+    assert calls["count"] == 0

--- a/web/app.py
+++ b/web/app.py
@@ -39,6 +39,11 @@ except ImportError:
         resolve_template_dir,
     )
 
+try:
+    from db_state import ensure_database_schema
+except ImportError:
+    from web.db_state import ensure_database_schema  # pragma: no cover
+
 # Import web types module - will be loaded later to avoid conflicts
 
 
@@ -128,38 +133,7 @@ DATABASE_PATH = resolve_database_path()
 
 def init_db() -> None:
     """Initialize SQLite database with required tables"""
-    conn = sqlite3.connect(DATABASE_PATH)
-    cursor = conn.cursor()
-
-    # History table
-    cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS history (
-            id TEXT PRIMARY KEY,
-            params JSON NOT NULL,
-            result JSON,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            status TEXT DEFAULT 'pending'
-        )
-    """
-    )
-
-    # Schedules table for recurring newsletters
-    cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS schedules (
-            id TEXT PRIMARY KEY,
-            params JSON NOT NULL,
-            rrule TEXT NOT NULL,
-            next_run TIMESTAMP NOT NULL,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            enabled INTEGER DEFAULT 1
-        )
-    """
-    )
-
-    conn.commit()
-    conn.close()
+    ensure_database_schema(DATABASE_PATH)
 
 
 # Initialize database on startup

--- a/web/db_state.py
+++ b/web/db_state.py
@@ -1,0 +1,373 @@
+"""Shared DB schema, idempotency, and state-transition helpers for web runtime."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple
+
+
+def is_feature_enabled(env_var: str, default: bool = True) -> bool:
+    """Read a boolean feature flag from environment variables."""
+    raw = os.getenv(env_var)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def canonical_json(payload: Dict[str, Any] | None) -> str:
+    """Serialize payload into a deterministic JSON string."""
+    return json.dumps(
+        payload or {}, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+
+
+def build_idempotency_key(
+    payload: Dict[str, Any] | None,
+    provided_key: str | None = None,
+    namespace: str = "generate",
+) -> str:
+    """Build an idempotency key using client key first, otherwise canonical hash."""
+    if provided_key and str(provided_key).strip():
+        return str(provided_key).strip()
+
+    digest = hashlib.sha256(
+        f"{namespace}:{canonical_json(payload)}".encode("utf-8")
+    ).hexdigest()
+    return f"{namespace}:{digest}"
+
+
+def build_schedule_idempotency_key(schedule_id: str, intended_run_at: datetime) -> str:
+    """Derive deterministic schedule idempotency key from schedule and intended run."""
+    intended_utc = intended_run_at.astimezone(timezone.utc).isoformat()
+    return build_idempotency_key(
+        {"schedule_id": schedule_id, "intended_run_at": intended_utc},
+        namespace="schedule",
+    )
+
+
+def derive_job_id(idempotency_key: str, prefix: str = "job") -> str:
+    """Build stable job ID from idempotency key."""
+    digest = hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest()[:24]
+    return f"{prefix}_{digest}"
+
+
+def _ensure_column(
+    cursor: sqlite3.Cursor, table_name: str, column_name: str, column_def: str
+) -> None:
+    cursor.execute(f"PRAGMA table_info({table_name})")
+    existing_columns = {row[1] for row in cursor.fetchall()}
+    if column_name not in existing_columns:
+        cursor.execute(
+            f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_def}"
+        )
+
+
+def _ensure_database_schema(conn: sqlite3.Connection) -> None:
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS history (
+            id TEXT PRIMARY KEY,
+            params JSON NOT NULL,
+            result JSON,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            status TEXT DEFAULT 'pending'
+        )
+        """
+    )
+    _ensure_column(cursor, "history", "params", "JSON")
+    _ensure_column(cursor, "history", "result", "JSON")
+    _ensure_column(cursor, "history", "status", "TEXT DEFAULT 'pending'")
+    _ensure_column(
+        cursor, "history", "created_at", "TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+    )
+    _ensure_column(cursor, "history", "idempotency_key", "TEXT")
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schedules (
+            id TEXT PRIMARY KEY,
+            params JSON NOT NULL,
+            rrule TEXT NOT NULL,
+            next_run TIMESTAMP NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            enabled INTEGER DEFAULT 1
+        )
+        """
+    )
+    _ensure_column(cursor, "schedules", "is_test", "INTEGER DEFAULT 0")
+    _ensure_column(cursor, "schedules", "expires_at", "TEXT")
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS email_outbox (
+            send_key TEXT PRIMARY KEY,
+            job_id TEXT NOT NULL,
+            recipient TEXT NOT NULL,
+            subject_hash TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            last_error TEXT,
+            provider_message_id TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_history_created_at ON history(created_at)"
+    )
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_history_status ON history(status)")
+    cursor.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_history_idempotency_key ON history(idempotency_key) WHERE idempotency_key IS NOT NULL"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_schedules_next_run ON schedules(next_run)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_schedules_enabled ON schedules(enabled)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_email_outbox_status ON email_outbox(status)"
+    )
+
+    conn.commit()
+
+
+def ensure_database_schema(db_path: str) -> None:
+    """Run additive DB migrations and ensure runtime schema is complete."""
+    conn = sqlite3.connect(db_path)
+    try:
+        _ensure_database_schema(conn)
+    finally:
+        conn.close()
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    _ensure_database_schema(conn)
+    return conn
+
+
+def create_or_get_history_job(
+    db_path: str,
+    job_id: str,
+    params: Dict[str, Any],
+    idempotency_key: str | None,
+    status: str = "pending",
+) -> Tuple[str, bool, str]:
+    """Insert a new history row or return existing one by idempotency key."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        if idempotency_key:
+            cursor.execute(
+                "SELECT id, status FROM history WHERE idempotency_key = ?",
+                (idempotency_key,),
+            )
+            existing = cursor.fetchone()
+            if existing:
+                return existing[0], True, existing[1]
+
+        cursor.execute(
+            """
+            INSERT OR IGNORE INTO history (id, params, status, idempotency_key)
+            VALUES (?, ?, ?, ?)
+            """,
+            (job_id, canonical_json(params), status, idempotency_key),
+        )
+        conn.commit()
+        return job_id, False, status
+    finally:
+        conn.close()
+
+
+def ensure_history_row(
+    db_path: str,
+    job_id: str,
+    params: Dict[str, Any] | None = None,
+    status: str = "pending",
+    idempotency_key: str | None = None,
+) -> None:
+    """Ensure history row exists for a job."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT OR IGNORE INTO history (id, params, status, idempotency_key)
+            VALUES (?, ?, ?, ?)
+            """,
+            (job_id, canonical_json(params), status, idempotency_key),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def update_history_status(
+    db_path: str,
+    job_id: str,
+    status: str,
+    result: Dict[str, Any] | None = None,
+    params: Dict[str, Any] | None = None,
+    idempotency_key: str | None = None,
+) -> None:
+    """Update history status/result in one consistent path."""
+    ensure_history_row(
+        db_path=db_path,
+        job_id=job_id,
+        params=params,
+        status="pending",
+        idempotency_key=idempotency_key,
+    )
+
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        if result is None:
+            cursor.execute(
+                "UPDATE history SET status = ? WHERE id = ?",
+                (status, job_id),
+            )
+        else:
+            cursor.execute(
+                "UPDATE history SET status = ?, result = ? WHERE id = ?",
+                (status, canonical_json(result), job_id),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_history_row_by_idempotency_key(
+    db_path: str, idempotency_key: str
+) -> Optional[Dict[str, Any]]:
+    """Fetch a history row by idempotency key."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT id, status, result, params FROM history WHERE idempotency_key = ?",
+            (idempotency_key,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return {
+            "id": row[0],
+            "status": row[1],
+            "result": row[2],
+            "params": row[3],
+        }
+    finally:
+        conn.close()
+
+
+def get_history_row(db_path: str, job_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch a history row by job id."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT id, status, result, params, idempotency_key FROM history WHERE id = ?",
+            (job_id,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return {
+            "id": row[0],
+            "status": row[1],
+            "result": row[2],
+            "params": row[3],
+            "idempotency_key": row[4],
+        }
+    finally:
+        conn.close()
+
+
+def hash_subject(subject: str) -> str:
+    """Hash email subject for stable outbox keys."""
+    return hashlib.sha256(subject.encode("utf-8")).hexdigest()
+
+
+def get_or_create_outbox_record(
+    db_path: str,
+    send_key: str,
+    job_id: str,
+    recipient: str,
+    subject_hash: str,
+) -> str:
+    """Get outbox status or create pending record."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT status FROM email_outbox WHERE send_key = ?", (send_key,)
+        )
+        existing = cursor.fetchone()
+        if existing:
+            return str(existing[0])
+
+        cursor.execute(
+            """
+            INSERT INTO email_outbox (send_key, job_id, recipient, subject_hash, status)
+            VALUES (?, ?, ?, ?, 'pending')
+            """,
+            (send_key, job_id, recipient, subject_hash),
+        )
+        conn.commit()
+        return "pending"
+    finally:
+        conn.close()
+
+
+def mark_outbox_sent(
+    db_path: str, send_key: str, provider_message_id: str | None = None
+) -> None:
+    """Mark outbox record as sent."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            UPDATE email_outbox
+            SET status = 'sent',
+                attempt_count = attempt_count + 1,
+                last_error = NULL,
+                provider_message_id = ?,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE send_key = ?
+            """,
+            (provider_message_id, send_key),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def mark_outbox_failed(db_path: str, send_key: str, error_message: str) -> None:
+    """Mark outbox record as failed with error message."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            UPDATE email_outbox
+            SET status = 'failed',
+                attempt_count = attempt_count + 1,
+                last_error = ?,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE send_key = ?
+            """,
+            (error_message, send_key),
+        )
+        conn.commit()
+    finally:
+        conn.close()

--- a/web/init_database.py
+++ b/web/init_database.py
@@ -11,8 +11,13 @@ import sqlite3
 import sys
 from datetime import datetime
 
+try:
+    from db_state import ensure_database_schema
+except ImportError:
+    from web.db_state import ensure_database_schema  # pragma: no cover
 
-def create_database(db_path="storage.db"):
+
+def create_database(db_path: str = "storage.db") -> bool:
     """
     SQLite 데이터베이스와 필요한 테이블들을 생성합니다.
 
@@ -27,62 +32,15 @@ def create_database(db_path="storage.db"):
         os.rename(db_path, backup_path)
         print(f"📦 기존 데이터베이스를 백업했습니다: {backup_path}")
 
-    # 새 데이터베이스 생성
-    conn = sqlite3.connect(db_path)
-    cursor = conn.cursor()
-
-    print("📝 테이블 생성 중...")
-
-    # History table - 뉴스레터 생성 히스토리
-    cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS history (
-            id TEXT PRIMARY KEY,
-            params JSON NOT NULL,
-            result JSON,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            status TEXT DEFAULT 'pending'
-        )
-    """
-    )
-    print("  ✅ history 테이블 생성됨")
-
-    # Schedules table - 정기 발송 예약
-    cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS schedules (
-            id TEXT PRIMARY KEY,
-            params JSON NOT NULL,
-            rrule TEXT NOT NULL,
-            next_run TIMESTAMP NOT NULL,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            enabled INTEGER DEFAULT 1
-        )
-    """
-    )
-    print("  ✅ schedules 테이블 생성됨")
-
-    # 인덱스 생성
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_history_created_at ON history(created_at)"
-    )
-    cursor.execute("CREATE INDEX IF NOT EXISTS idx_history_status ON history(status)")
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_schedules_next_run ON schedules(next_run)"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_schedules_enabled ON schedules(enabled)"
-    )
-    print("  ✅ 인덱스 생성됨")
-
-    conn.commit()
-    conn.close()
+    print("📝 테이블/인덱스/마이그레이션 적용 중...")
+    ensure_database_schema(db_path)
+    print("  ✅ history/schedules/email_outbox 스키마 보장 완료")
 
     print(f"🎉 데이터베이스 초기화 완료: {db_path}")
     return True
 
 
-def verify_database(db_path="storage.db"):
+def verify_database(db_path: str = "storage.db") -> bool:
     """
     데이터베이스가 올바르게 생성되었는지 확인합니다.
 
@@ -100,7 +58,7 @@ def verify_database(db_path="storage.db"):
         cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
         tables = [row[0] for row in cursor.fetchall()]
 
-        required_tables = ["history", "schedules"]
+        required_tables = ["history", "schedules", "email_outbox"]
         missing_tables = [table for table in required_tables if table not in tables]
 
         if missing_tables:
@@ -123,20 +81,14 @@ def verify_database(db_path="storage.db"):
         return False
 
 
-def main():
+def main() -> None:
     """메인 실행 함수"""
     import argparse
 
     parser = argparse.ArgumentParser(description="웹 애플리케이션 데이터베이스 초기화")
-    parser.add_argument(
-        "--db-path", default="storage.db", help="데이터베이스 파일 경로"
-    )
-    parser.add_argument(
-        "--verify-only", action="store_true", help="검증만 수행 (생성하지 않음)"
-    )
-    parser.add_argument(
-        "--force", action="store_true", help="기존 데이터베이스 강제 재생성"
-    )
+    parser.add_argument("--db-path", default="storage.db", help="데이터베이스 파일 경로")
+    parser.add_argument("--verify-only", action="store_true", help="검증만 수행 (생성하지 않음)")
+    parser.add_argument("--force", action="store_true", help="기존 데이터베이스 강제 재생성")
 
     args = parser.parse_args()
 
@@ -155,9 +107,7 @@ def main():
     # 데이터베이스 존재 확인
     if os.path.exists(args.db_path) and not args.force:
         print(f"📁 데이터베이스 파일이 이미 존재합니다: {args.db_path}")
-        choice = (
-            input("기존 데이터베이스를 재생성하시겠습니까? (y/N): ").strip().lower()
-        )
+        choice = input("기존 데이터베이스를 재생성하시겠습니까? (y/N): ").strip().lower()
         if choice not in ["y", "yes"]:
             print("❌ 초기화를 취소했습니다.")
             sys.exit(0)


### PR DESCRIPTION
## Summary
- remove import-time dotenv side effects from settings/config paths
- make `test_mode` default production-safe (`False`) and keep test-only activation
- add additive auto-migration bootstrap for web DB schema convergence
- add import-only regression tests for side-effect safety

## Changes
- `newsletter/config_manager.py`
  - lazy dotenv loading (`_load_dotenv_if_needed`)
  - lazy config singleton proxy 유지
- `newsletter/centralized_settings.py`
  - import-time dotenv 제거
  - duplicated helper 정리
  - strict typing/mypy compatibility 보강
- `web/app.py`, `web/init_database.py`
  - `ensure_database_schema(...)` 기반 additive migration 호출
- `web/db_state.py` (new)
  - DB schema convergence helpers
  - history/schedules/email_outbox additive migration utilities
- `tests/unit_tests/test_config_import_side_effects.py` (new)
  - import-only side effect 검증

## Verification
- `./.venv/bin/pytest tests/unit_tests/test_config_import_side_effects.py -q`
- `make check-full`

## Rollback Notes
- 코드 롤백 시에도 DB는 additive 변경만 포함되어 호환 유지됩니다.
- 긴급 차단이 필요하면 기존 앱 버전으로 코드만 되돌려도 DB 삭제/다운그레이드가 필요 없습니다.
