### PR TITLE
PR-2: 멱등성/중복발송 잠금 (generate/scheduler/worker/outbox)

### DIFF
--- a/tests/contract/test_web_email_routes_contract.py
+++ b/tests/contract/test_web_email_routes_contract.py
@@ -43,6 +43,14 @@ def _delete_history_row(job_id: str) -> None:
     conn.close()
 
 
+def _delete_outbox_rows(job_id: str) -> None:
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM email_outbox WHERE job_id = ?", (job_id,))
+    conn.commit()
+    conn.close()
+
+
 def test_newsletter_html_returns_not_found_for_missing_job(client):
     response = client.get("/api/newsletter-html/non-existent-contract-job")
 
@@ -139,12 +147,58 @@ def test_send_email_sends_completed_newsletter(client, monkeypatch):
         payload = response.get_json()
 
         assert response.status_code == 200
-        assert payload == {
-            "success": True,
-            "message": "이메일이 성공적으로 발송되었습니다",
-        }
+        assert payload["success"] is True
+        assert payload["message"] == "이메일이 성공적으로 발송되었습니다"
+        assert payload["deduplicated"] is False
+        assert "send_key" in payload
         assert sent["to"] == "contract@example.com"
         assert sent["subject"] == "Newsletter: AI, ML"
         assert sent["html"] == expected_html
     finally:
         _delete_history_row(job_id)
+        _delete_outbox_rows(job_id)
+
+
+def test_send_email_deduplicates_with_outbox(client, monkeypatch):
+    try:
+        import mail as mail_module
+    except ImportError:
+        from web import mail as mail_module
+
+    send_calls: list[dict[str, str]] = []
+
+    def _fake_send_email(*, to: str, subject: str, html: str) -> None:
+        send_calls.append({"to": to, "subject": subject, "html": html})
+
+    monkeypatch.setitem(sys.modules, "mail", mail_module)
+    monkeypatch.setattr(mail_module, "send_email", _fake_send_email)
+
+    job_id = f"contract-send-dedup-{uuid.uuid4()}"
+    expected_html = "<html><body><h1>contract-send-dedup</h1></body></html>"
+    _insert_history_row(
+        job_id=job_id,
+        status="completed",
+        result={"html_content": expected_html},
+        params={"keywords": ["AI", "Reliability"]},
+    )
+
+    try:
+        first = client.post(
+            "/api/send-email",
+            json={"job_id": job_id, "email": "contract@example.com"},
+        )
+        second = client.post(
+            "/api/send-email",
+            json={"job_id": job_id, "email": "contract@example.com"},
+        )
+
+        first_payload = first.get_json()
+        second_payload = second.get_json()
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first_payload["deduplicated"] is False
+        assert second_payload["deduplicated"] is True
+        assert len(send_calls) == 1
+    finally:
+        _delete_history_row(job_id)
+        _delete_outbox_rows(job_id)

--- a/tests/integration/test_schedule_execution.py
+++ b/tests/integration/test_schedule_execution.py
@@ -79,10 +79,18 @@ class TestScheduleIntegration:
     def mock_newsletter_generation(self):
         """뉴스레터 생성 Mock"""
 
-        def mock_task(params, job_id, send_email=False):
+        def mock_task(
+            params,
+            job_id,
+            send_email=False,
+            idempotency_key=None,
+            database_path=None,
+        ):
             return {
                 "status": "completed",
                 "job_id": job_id,
+                "idempotency_key": idempotency_key,
+                "database_path": database_path,
                 "execution_time": 1.5,
                 "articles_count": 5,
             }
@@ -192,6 +200,10 @@ class TestScheduleIntegration:
                 "schedule_test_flow_schedule" in call_args[1]
             ), "Job ID should include schedule ID"
             assert call_args[2] is False, "send_email should be False for test"
+            assert (
+                "schedule:" in call_args[3]
+            ), "Idempotency key should be deterministic"
+            assert call_args[4] == temp_db, "Task should receive runner DB path"
 
     def test_multiple_schedules_execution_order(
         self, temp_db, schedule_runner_with_db, mock_newsletter_generation

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -6,14 +6,14 @@ Tests the Flask app with email functionality
 import json
 import os
 import sys
-from unittest.mock import MagicMock, patch
+import uuid
 
 import pytest
 
 # Add project root to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from web.app import app
+from web.app import app  # noqa: E402
 
 pytestmark = [pytest.mark.api, pytest.mark.email]
 
@@ -30,8 +30,9 @@ class TestWebAPI:
 
     def test_generate_newsletter_without_email(self, client):
         """Test newsletter generation without email"""
+        unique_topic = f"AI-{uuid.uuid4()}"
         data = {
-            "keywords": "AI, machine learning",
+            "keywords": f"{unique_topic}, machine learning",
             "template_style": "compact",
             "period": 14,
         }
@@ -47,8 +48,9 @@ class TestWebAPI:
 
     def test_generate_newsletter_with_email(self, client):
         """Test newsletter generation with email"""
+        unique_topic = f"AI-{uuid.uuid4()}"
         data = {
-            "keywords": "AI, machine learning",
+            "keywords": f"{unique_topic}, machine learning",
             "template_style": "compact",
             "period": 14,
             "email": "test@example.com",
@@ -62,6 +64,39 @@ class TestWebAPI:
         result = json.loads(response.data)
         assert "job_id" in result
         assert result["status"] in ["queued", "processing"]
+
+    def test_generate_newsletter_idempotency_reuses_job(self, client):
+        """Same Idempotency-Key should return same job_id with deduplicated flag."""
+        data = {
+            "keywords": "AI, machine learning",
+            "template_style": "compact",
+            "period": 14,
+        }
+        unique_key = f"web-api-idempotency-{uuid.uuid4()}"
+        headers = {"Idempotency-Key": unique_key}
+
+        first = client.post(
+            "/api/generate",
+            data=json.dumps(data),
+            content_type="application/json",
+            headers=headers,
+        )
+        second = client.post(
+            "/api/generate",
+            data=json.dumps(data),
+            content_type="application/json",
+            headers=headers,
+        )
+
+        assert first.status_code == 202
+        assert second.status_code == 202
+
+        first_payload = json.loads(first.data)
+        second_payload = json.loads(second.data)
+        assert first_payload["job_id"] == second_payload["job_id"]
+        assert first_payload["deduplicated"] is False
+        assert second_payload["deduplicated"] is True
+        assert second_payload["idempotency_key"] == unique_key
 
     def test_generate_newsletter_invalid_email(self, client):
         """Test newsletter generation with invalid email"""

--- a/web/routes_generation.py
+++ b/web/routes_generation.py
@@ -5,12 +5,32 @@
 import json
 import logging
 import sqlite3
+import threading
 import uuid
 from datetime import datetime
 from typing import Any, Callable
 
 from flask import Flask, jsonify, request
 from tasks import generate_newsletter_task
+
+try:
+    from db_state import (
+        build_idempotency_key,
+        build_schedule_idempotency_key,
+        create_or_get_history_job,
+        derive_job_id,
+        ensure_database_schema,
+        is_feature_enabled,
+    )
+except ImportError:
+    from web.db_state import (  # pragma: no cover
+        build_idempotency_key,
+        build_schedule_idempotency_key,
+        create_or_get_history_job,
+        derive_job_id,
+        ensure_database_schema,
+        is_feature_enabled,
+    )
 
 try:
     from newsletter_clients import MockNewsletterCLI, RealNewsletterCLI
@@ -37,12 +57,39 @@ def register_generation_routes(
     DATABASE_PATH = database_path
     RealNewsletterCLI = real_cli_class
     MockNewsletterCLI = mock_cli_class
+    ensure_database_schema(DATABASE_PATH)
 
     def resolve_newsletter_cli() -> Any:
         if get_newsletter_cli is None:
             return newsletter_cli
         resolved = get_newsletter_cli()
         return resolved if resolved is not None else newsletter_cli
+
+    def run_in_memory_job(
+        job_id: str,
+        data: dict[str, Any],
+        send_email: bool,
+        idempotency_key: str | None,
+    ) -> None:
+        try:
+            result = generate_newsletter_task(
+                data,
+                job_id,
+                send_email,
+                idempotency_key,
+                DATABASE_PATH,
+            )
+            in_memory_tasks[job_id] = {
+                "status": "completed",
+                "result": result,
+                "updated_at": datetime.now().isoformat(),
+            }
+        except Exception as exc:
+            in_memory_tasks[job_id] = {
+                "status": "failed",
+                "error": str(exc),
+                "updated_at": datetime.now().isoformat(),
+            }
 
     @app.route("/api/generate", methods=["POST"])
     def generate_newsletter():
@@ -81,160 +128,101 @@ def register_generation_routes(
             print(f"📋 Request data: {data}")
             print(f"📧 Send email: {send_email} to {email}")
 
-            # Create unique job ID
-            job_id = str(uuid.uuid4())
-            print(f"🆔 Generated job ID: {job_id}")
-
-            # Store request in history
-            conn = sqlite3.connect(DATABASE_PATH)
-            cursor = conn.cursor()
-            cursor.execute(
-                "INSERT INTO history (id, params, status) VALUES (?, ?, ?)",
-                (job_id, json.dumps(data), "pending"),
+            idempotency_enabled = is_feature_enabled(
+                "WEB_IDEMPOTENCY_ENABLED", default=True
             )
-            conn.commit()
-            conn.close()
-            print(f"💾 Stored request in database")
+            provided_idempotency_key = request.headers.get("Idempotency-Key")
+            idempotency_key = build_idempotency_key(
+                payload=data,
+                provided_key=provided_idempotency_key,
+                namespace="generate",
+            )
+            if not idempotency_enabled:
+                idempotency_key = f"generate:{uuid.uuid4()}"
 
-            # If Redis is available, queue the task
-            if task_queue:
-                print(f"📤 Queueing task with Redis")
-                job = task_queue.enqueue(
-                    generate_newsletter_task, data, job_id, send_email
+            proposed_job_id = (
+                derive_job_id(idempotency_key, prefix="job")
+                if idempotency_enabled
+                else str(uuid.uuid4())
+            )
+            job_id, deduplicated, stored_status = create_or_get_history_job(
+                db_path=DATABASE_PATH,
+                job_id=proposed_job_id,
+                params=data,
+                idempotency_key=idempotency_key if idempotency_enabled else None,
+                status="pending",
+            )
+            print(f"🆔 Resolved job ID: {job_id} (deduplicated={deduplicated})")
+
+            if deduplicated:
+                return (
+                    jsonify(
+                        {
+                            "job_id": job_id,
+                            "status": stored_status,
+                            "deduplicated": True,
+                            "idempotency_key": idempotency_key,
+                        }
+                    ),
+                    202,
                 )
-                return jsonify({"job_id": job_id, "status": "queued"}), 202
-            else:
-                print(f"🔄 Processing in-memory (Redis not available)")
-                # Fallback: process in background using in-memory tracking
-                import threading
 
-                # Store initial task status
-                in_memory_tasks[job_id] = {
-                    "status": "processing",
-                    "started_at": datetime.now().isoformat(),
-                }
+            if task_queue:
+                print("📤 Queueing task with Redis")
+                task_queue.enqueue(
+                    generate_newsletter_task,
+                    data,
+                    job_id,
+                    send_email,
+                    idempotency_key if idempotency_enabled else None,
+                    DATABASE_PATH,
+                    job_id=job_id,
+                )
+                return (
+                    jsonify(
+                        {
+                            "job_id": job_id,
+                            "status": "queued",
+                            "deduplicated": False,
+                            "idempotency_key": idempotency_key,
+                        }
+                    ),
+                    202,
+                )
 
-                # Process in background thread
-                def background_task():
-                    try:
-                        print(f"⚙️  Starting background processing for job {job_id}")
-                        print(f"⚙️  Data: {data}")
-                        print(f"⚙️  Current time: {datetime.now().isoformat()}")
+            print("🔄 Processing in-memory (Redis not available)")
+            in_memory_tasks[job_id] = {
+                "status": "processing",
+                "started_at": datetime.now().isoformat(),
+                "idempotency_key": idempotency_key,
+            }
 
-                        # 환경 체크
-                        print(
-                            f"⚙️  Using CLI type: {type(resolve_newsletter_cli()).__name__}"
-                        )
-
-                        process_newsletter_in_memory(data, job_id)
-
-                        # 메모리에서 결과 가져오기
-                        if job_id in in_memory_tasks:
-                            task_result = in_memory_tasks[job_id]
-                            print(f"💾 Updating database for job {job_id}")
-                            print(
-                                f"💾 Task status: {task_result.get('status', 'unknown')}"
-                            )
-
-                            # Update database with final result
-                            conn = sqlite3.connect(DATABASE_PATH)
-                            cursor = conn.cursor()
-
-                            if (
-                                task_result.get("status") == "completed"
-                                and "result" in task_result
-                            ):
-                                # 성공한 경우
-                                try:
-                                    result_json = json.dumps(task_result["result"])
-                                    cursor.execute(
-                                        "UPDATE history SET result = ?, status = ? WHERE id = ?",
-                                        (result_json, "completed", job_id),
-                                    )
-                                    print(
-                                        f"💾 Successfully updated database for job {job_id}"
-                                    )
-                                except (TypeError, ValueError) as json_error:
-                                    print(
-                                        f"❌ JSON serialization error for job {job_id}: {json_error}"
-                                    )
-                                    # JSON 직렬화 실패 시 기본 응답 저장
-                                    fallback_result = {
-                                        "status": "completed",
-                                        "title": "Newsletter Generated",
-                                        "html_content": task_result["result"].get(
-                                            "html_content",
-                                            task_result["result"].get(
-                                                "content",
-                                                "Newsletter content available",
-                                            ),
-                                        ),
-                                        "error": f"JSON serialization failed: {str(json_error)}",
-                                    }
-                                    cursor.execute(
-                                        "UPDATE history SET result = ?, status = ? WHERE id = ?",
-                                        (
-                                            json.dumps(fallback_result),
-                                            "completed",
-                                            job_id,
-                                        ),
-                                    )
-                            else:
-                                # 실패한 경우
-                                error_result = {
-                                    "error": task_result.get("error", "Unknown error"),
-                                    "status": "failed",
-                                }
-                                cursor.execute(
-                                    "UPDATE history SET result = ?, status = ? WHERE id = ?",
-                                    (json.dumps(error_result), "failed", job_id),
-                                )
-
-                            conn.commit()
-                            conn.close()
-                            print(f"✅ Completed background processing for job {job_id}")
-                        else:
-                            print(f"❌ Job {job_id} not found in in_memory_tasks")
-                            # 데이터베이스에 실패 상태 업데이트
-                            conn = sqlite3.connect(DATABASE_PATH)
-                            cursor = conn.cursor()
-                            cursor.execute(
-                                "UPDATE history SET result = ?, status = ? WHERE id = ?",
-                                (
-                                    json.dumps({"error": "Job not found in memory"}),
-                                    "failed",
-                                    job_id,
-                                ),
-                            )
-                            conn.commit()
-                            conn.close()
-
-                    except Exception as e:
-                        print(f"❌ Error in background processing for job {job_id}: {e}")
-                        import traceback
-
-                        print(f"❌ Traceback: {traceback.format_exc()}")
-
-                        # Update database with error
-                        try:
-                            conn = sqlite3.connect(DATABASE_PATH)
-                            cursor = conn.cursor()
-                            cursor.execute(
-                                "UPDATE history SET result = ?, status = ? WHERE id = ?",
-                                (json.dumps({"error": str(e)}), "failed", job_id),
-                            )
-                            conn.commit()
-                            conn.close()
-                        except Exception as db_error:
-                            print(
-                                f"❌ Failed to update database with error for job {job_id}: {db_error}"
-                            )
-
-                thread = threading.Thread(target=background_task)
-                thread.daemon = True
+            if not app.config.get("TESTING", False):
+                thread = threading.Thread(
+                    target=run_in_memory_job,
+                    kwargs={
+                        "job_id": job_id,
+                        "data": data,
+                        "send_email": send_email,
+                        "idempotency_key": (
+                            idempotency_key if idempotency_enabled else None
+                        ),
+                    },
+                    daemon=True,
+                )
                 thread.start()
 
-                return jsonify({"job_id": job_id, "status": "processing"}), 202
+            return (
+                jsonify(
+                    {
+                        "job_id": job_id,
+                        "status": "processing",
+                        "deduplicated": False,
+                        "idempotency_key": idempotency_key,
+                    }
+                ),
+                202,
+            )
 
         except Exception as e:
             print(f"❌ Error in generate_newsletter endpoint: {e}")
@@ -491,6 +479,7 @@ def register_generation_routes(
                 "job_id": job_id,
                 "status": task["status"],
                 "sent": task.get("sent", False),
+                "idempotency_key": task.get("idempotency_key"),
             }
 
             if "result" in task:
@@ -507,7 +496,8 @@ def register_generation_routes(
         conn = sqlite3.connect(DATABASE_PATH)
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT params, result, status FROM history WHERE id = ?", (job_id,)
+            "SELECT params, result, status, idempotency_key FROM history WHERE id = ?",
+            (job_id,),
         )
         row = cursor.fetchone()
         conn.close()
@@ -515,12 +505,13 @@ def register_generation_routes(
         if not row:
             return jsonify({"error": "Job not found"}), 404
 
-        params, result, status = row
+        params, result, status, idempotency_key = row
         response = {
             "job_id": job_id,
             "status": status,
             "params": json.loads(params) if params else None,
             "sent": False,
+            "idempotency_key": idempotency_key,
         }
 
         if result:
@@ -544,7 +535,7 @@ def register_generation_routes(
             # 모든 기록을 가져와서 completed 우선, 최신 순으로 정렬
             cursor.execute(
                 """
-                SELECT id, params, result, created_at, status
+                SELECT id, params, result, created_at, status, idempotency_key
                 FROM history
                 ORDER BY
                     CASE WHEN status = 'completed' THEN 0 ELSE 1 END,
@@ -563,7 +554,7 @@ def register_generation_routes(
 
         history = []
         for row in rows:
-            job_id, params, result, created_at, status = row
+            job_id, params, result, created_at, status, idempotency_key = row
             print(f"📚 Processing history record: {job_id} (status: {status})")
 
             try:
@@ -585,6 +576,7 @@ def register_generation_routes(
                     "result": parsed_result,
                     "created_at": created_at,
                     "status": status,
+                    "idempotency_key": idempotency_key,
                 }
             )
 
@@ -627,13 +619,26 @@ def register_generation_routes(
             "template_style": data.get("template_style", "compact"),
             "email_compatible": data.get("email_compatible", True),
             "period": data.get("period", 14),
+            "send_email": True,
         }
+        is_test = bool(data.get("is_test", False))
+        expires_at = data.get("expires_at")
 
         conn = sqlite3.connect(DATABASE_PATH)
         cursor = conn.cursor()
         cursor.execute(
-            "INSERT INTO schedules (id, params, rrule, next_run) VALUES (?, ?, ?, ?)",
-            (schedule_id, json.dumps(schedule_params), rrule_str, next_run.isoformat()),
+            """
+            INSERT INTO schedules (id, params, rrule, next_run, is_test, expires_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                schedule_id,
+                json.dumps(schedule_params),
+                rrule_str,
+                next_run.isoformat(),
+                int(is_test),
+                expires_at,
+            ),
         )
         conn.commit()
         conn.close()
@@ -712,34 +717,59 @@ def register_generation_routes(
                 return jsonify({"error": "Schedule is disabled"}), 400
 
             params = json.loads(params_json)
+            intended_run_at = datetime.now()
+            idempotency_enabled = is_feature_enabled(
+                "WEB_IDEMPOTENCY_ENABLED", default=True
+            )
+            idempotency_key = build_schedule_idempotency_key(
+                schedule_id=schedule_id,
+                intended_run_at=intended_run_at,
+            )
+            if not idempotency_enabled:
+                idempotency_key = (
+                    f"schedule:{schedule_id}:{intended_run_at.isoformat()}"
+                )
+            job_suffix = derive_job_id(idempotency_key, prefix="sched").split("_", 1)[1]
+            immediate_job_id = f"schedule_{schedule_id}_{job_suffix}"
 
             # 즉시 뉴스레터 생성 작업 큐에 추가
             if redis_conn and task_queue:
-                immediate_job_id = f"schedule_{schedule_id}_{uuid.uuid4().hex[:8]}"
                 job = task_queue.enqueue(
                     generate_newsletter_task,
                     params,
                     immediate_job_id,
                     params.get("send_email", False),
+                    idempotency_key if idempotency_enabled else None,
+                    DATABASE_PATH,
+                    job_id=immediate_job_id,
                     job_timeout="10m",
                 )
 
                 return jsonify(
                     {
                         "status": "queued",
-                        "job_id": job.id,
+                        "job_id": immediate_job_id,
                         "message": "Newsletter generation started",
+                        "idempotency_key": idempotency_key,
                     }
                 )
             else:
                 # Redis가 없는 경우 직접 실행
-                immediate_job_id = f"schedule_{schedule_id}_{uuid.uuid4().hex[:8]}"
                 result = generate_newsletter_task(
                     params,
                     immediate_job_id,
                     params.get("send_email", False),
+                    idempotency_key if idempotency_enabled else None,
+                    DATABASE_PATH,
                 )
-                return jsonify({"status": "completed", "result": result})
+                return jsonify(
+                    {
+                        "status": "completed",
+                        "result": result,
+                        "job_id": immediate_job_id,
+                        "idempotency_key": idempotency_key,
+                    }
+                )
 
         except Exception as e:
             logging.error(f"Failed to run schedule {schedule_id}: {e}")

--- a/web/routes_send_email.py
+++ b/web/routes_send_email.py
@@ -9,6 +9,23 @@ from typing import cast
 from flask import Flask, jsonify, request
 from flask.typing import ResponseReturnValue
 
+try:
+    from db_state import (
+        get_or_create_outbox_record,
+        hash_subject,
+        is_feature_enabled,
+        mark_outbox_failed,
+        mark_outbox_sent,
+    )
+except ImportError:
+    from web.db_state import (  # pragma: no cover
+        get_or_create_outbox_record,
+        hash_subject,
+        is_feature_enabled,
+        mark_outbox_failed,
+        mark_outbox_sent,
+    )
+
 
 def _resolve_mail_module() -> ModuleType:
     """Resolve mail module in both script and package execution modes."""
@@ -68,9 +85,59 @@ def register_send_email_route(app: Flask, database_path: str) -> None:
                 f"Newsletter: {', '.join(keywords) if keywords else 'Your Newsletter'}"
             )
 
-            mail_module.send_email(to=email, subject=subject, html=html_content)
+            outbox_enabled = is_feature_enabled("WEB_OUTBOX_ENABLED", default=True)
+            send_key = f"{job_id}:{email}:{hash_subject(subject)}"
 
-            return jsonify({"success": True, "message": "이메일이 성공적으로 발송되었습니다"})
+            if outbox_enabled:
+                outbox_status = get_or_create_outbox_record(
+                    db_path=database_path,
+                    send_key=send_key,
+                    job_id=job_id,
+                    recipient=email,
+                    subject_hash=hash_subject(subject),
+                )
+                if outbox_status == "sent":
+                    return jsonify(
+                        {
+                            "success": True,
+                            "message": "이미 발송된 이메일입니다",
+                            "deduplicated": True,
+                            "send_key": send_key,
+                        }
+                    )
+
+            try:
+                provider_response = mail_module.send_email(
+                    to=email, subject=subject, html=html_content
+                )
+                provider_message_id = (
+                    provider_response.get("MessageID")
+                    if isinstance(provider_response, dict)
+                    else None
+                )
+                if outbox_enabled:
+                    mark_outbox_sent(
+                        db_path=database_path,
+                        send_key=send_key,
+                        provider_message_id=provider_message_id,
+                    )
+            except Exception as send_exc:
+                if outbox_enabled:
+                    mark_outbox_failed(
+                        db_path=database_path,
+                        send_key=send_key,
+                        error_message=str(send_exc),
+                    )
+                raise
+
+            return jsonify(
+                {
+                    "success": True,
+                    "message": "이메일이 성공적으로 발송되었습니다",
+                    "deduplicated": False,
+                    "send_key": send_key,
+                }
+            )
 
         except Exception as e:
             logging.error(f"Email sending failed: {e}")

--- a/web/schedule_runner.py
+++ b/web/schedule_runner.py
@@ -12,11 +12,11 @@ import sqlite3
 import sys
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
 
 import redis
-from dateutil import tz
-from dateutil.rrule import rrulestr
+from dateutil import tz  # type: ignore[import-untyped]
+from dateutil.rrule import rrulestr  # type: ignore[import-untyped]
 from rq import Queue
 
 # Add current directory to path
@@ -25,6 +25,23 @@ sys.path.insert(0, current_dir)
 
 # Import task functions
 from tasks import generate_newsletter_task
+
+try:
+    from db_state import (
+        build_schedule_idempotency_key,
+        derive_job_id,
+        ensure_database_schema,
+        ensure_history_row,
+        is_feature_enabled,
+    )
+except ImportError:
+    from web.db_state import (  # pragma: no cover
+        build_schedule_idempotency_key,
+        derive_job_id,
+        ensure_database_schema,
+        ensure_history_row,
+        is_feature_enabled,
+    )
 
 # Import time utilities
 try:
@@ -45,8 +62,9 @@ REAL_DATETIME = datetime
 class ScheduleRunner:
     """RRULE 기반 스케줄 실행기"""
 
-    def __init__(self, db_path: str = "storage.db", redis_url: str = None):
+    def __init__(self, db_path: str = "storage.db", redis_url: str | None = None):
         self.db_path = db_path
+        ensure_database_schema(self.db_path)
         self.redis_url = redis_url or os.environ.get(
             "REDIS_URL", "redis://localhost:6379/0"
         )
@@ -107,7 +125,6 @@ class ScheduleRunner:
 
             # 스케줄 실행 대기열과 만료된 스케줄 분리 처리
             ready_for_execution = []
-            expired_schedules = []
             updated_count = 0
 
             # 정규 스케줄: 30분 윈도우, 테스트 스케줄: 10분 윈도우
@@ -234,12 +251,12 @@ class ScheduleRunner:
             return []
 
     def calculate_next_run(
-        self, rrule_str: str, after: datetime = None
+        self, rrule_str: str, after: datetime | None = None
     ) -> Optional[datetime]:
         """RRULE을 기반으로 다음 실행 시간을 계산합니다."""
         try:
             if after is None:
-                after = datetime.now(timezone.utc)
+                after = REAL_DATETIME.now(timezone.utc)
 
             # after가 timezone-aware인 경우 naive로 변환
             if after.tzinfo is not None:
@@ -254,8 +271,10 @@ class ScheduleRunner:
             next_occurrence_naive = rrule.after(after_naive)
 
             # UTC timezone을 추가하여 aware datetime으로 변환
-            if next_occurrence_naive:
-                next_occurrence = next_occurrence_naive.replace(tzinfo=timezone.utc)
+            if next_occurrence_naive is not None:
+                next_occurrence = cast(datetime, next_occurrence_naive).replace(
+                    tzinfo=timezone.utc
+                )
                 return next_occurrence
             else:
                 return None
@@ -355,6 +374,28 @@ class ScheduleRunner:
                 f"[EXECUTE] Starting execution for schedule {schedule_id} - {params.get('keywords', 'No keywords')}"
             )
 
+            intended_run_at = schedule.get("next_run", datetime.now(timezone.utc))
+            idempotency_enabled = is_feature_enabled(
+                "WEB_IDEMPOTENCY_ENABLED", default=True
+            )
+            if idempotency_enabled:
+                idempotency_key = build_schedule_idempotency_key(
+                    schedule_id=schedule_id,
+                    intended_run_at=intended_run_at,
+                )
+            else:
+                idempotency_key = f"schedule:{schedule_id}:{uuid.uuid4()}"
+
+            job_suffix = derive_job_id(idempotency_key, prefix="sched").split("_", 1)[1]
+            schedule_job_id = f"schedule_{schedule_id}_{job_suffix}"
+            ensure_history_row(
+                db_path=self.db_path,
+                job_id=schedule_job_id,
+                params=params,
+                status="pending",
+                idempotency_key=idempotency_key,
+            )
+
             # 뉴스레터 생성 작업을 큐에 추가
             redis_success = False
             if self.queue:
@@ -363,8 +404,11 @@ class ScheduleRunner:
                     job = self.queue.enqueue(
                         generate_newsletter_task,
                         params,
-                        f"schedule_{schedule_id}",  # job_id 매개변수 추가
+                        schedule_job_id,
                         params.get("send_email", False),  # send_email 매개변수 추가
+                        idempotency_key,
+                        self.db_path,
+                        job_id=schedule_job_id,
                         job_timeout="10m",
                         result_ttl=86400,  # 24시간 동안 결과 보관
                     )
@@ -384,9 +428,12 @@ class ScheduleRunner:
             if not redis_success:
                 # Redis가 없거나 연결에 실패한 경우 동기 실행 (fallback)
                 logger.info(f"Executing schedule {schedule_id} synchronously")
-                fallback_job_id = f"schedule_{schedule_id}_{uuid.uuid4().hex[:8]}"
                 result = generate_newsletter_task(
-                    params, fallback_job_id, params.get("send_email", False)
+                    params,
+                    schedule_job_id,
+                    params.get("send_email", False),
+                    idempotency_key,
+                    self.db_path,
                 )
                 logger.info(
                     f"Synchronous execution completed for schedule {schedule_id}: {result.get('status', 'unknown') if result else 'no result'}"
@@ -432,7 +479,7 @@ class ScheduleRunner:
         logger.info(f"Executed {executed_count} schedules")
         return executed_count
 
-    def run_continuous(self, check_interval: int = 60):
+    def run_continuous(self, check_interval: int = 60) -> None:
         """연속적으로 스케줄을 체크하고 실행합니다."""
         logger.info(
             f"Starting continuous schedule runner (check interval: {check_interval}s)"
@@ -453,7 +500,7 @@ class ScheduleRunner:
                 time.sleep(check_interval)
 
 
-def main():
+def main() -> None:
     """CLI 진입점"""
     import argparse
 

--- a/web/tasks.py
+++ b/web/tasks.py
@@ -7,7 +7,7 @@ import os
 import sqlite3
 import traceback
 from datetime import datetime, timedelta
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, cast
 
 from newsletter_core.public.generation import (
     GenerateNewsletterRequest,
@@ -15,47 +15,85 @@ from newsletter_core.public.generation import (
     generate_newsletter,
 )
 
+try:
+    from db_state import (
+        get_or_create_outbox_record,
+        hash_subject,
+        is_feature_enabled,
+        mark_outbox_failed,
+        mark_outbox_sent,
+        update_history_status,
+    )
+except ImportError:
+    from web.db_state import (  # pragma: no cover
+        get_or_create_outbox_record,
+        hash_subject,
+        is_feature_enabled,
+        mark_outbox_failed,
+        mark_outbox_sent,
+        update_history_status,
+    )
+
 DATABASE_PATH = os.path.join(os.path.dirname(__file__), "storage.db")
 
 
-def _ensure_history_row(job_id: str, params: Optional[Dict[str, Any]] = None) -> None:
-    conn = sqlite3.connect(DATABASE_PATH)
-    cursor = conn.cursor()
-    cursor.execute("SELECT id FROM history WHERE id = ?", (job_id,))
-    exists = cursor.fetchone() is not None
-
-    if not exists:
-        cursor.execute(
-            "INSERT INTO history (id, params, status) VALUES (?, ?, ?)",
-            (job_id, json.dumps(params or {}), "pending"),
-        )
-
-    conn.commit()
-    conn.close()
+def _resolve_database_path(database_path: str | None) -> str:
+    return database_path or DATABASE_PATH
 
 
-def update_job_status(
+def _resolve_mail_send_callable() -> Callable[..., Any]:
+    try:
+        from mail import send_email as send_email_fn
+
+        return cast(Callable[..., Any], send_email_fn)
+    except ImportError:
+        from .mail import send_email as send_email_fn  # pragma: no cover
+
+        return cast(Callable[..., Any], send_email_fn)
+
+
+def _send_email_with_outbox(
+    db_path: str,
     job_id: str,
-    status: str,
-    result: Optional[Dict[str, Any]] = None,
-    params: Optional[Dict[str, Any]] = None,
-) -> None:
-    """Update job status in database, creating the row if needed."""
-    _ensure_history_row(job_id, params)
+    to: str,
+    subject: str,
+    html: str,
+) -> Dict[str, Any]:
+    send_email_fn = _resolve_mail_send_callable()
+    outbox_enabled = is_feature_enabled("WEB_OUTBOX_ENABLED", default=True)
+    send_key = f"{job_id}:{to}:{hash_subject(subject)}"
 
-    conn = sqlite3.connect(DATABASE_PATH)
-    cursor = conn.cursor()
-
-    if result is not None:
-        cursor.execute(
-            "UPDATE history SET status = ?, result = ? WHERE id = ?",
-            (status, json.dumps(result), job_id),
+    if outbox_enabled:
+        outbox_status = get_or_create_outbox_record(
+            db_path=db_path,
+            send_key=send_key,
+            job_id=job_id,
+            recipient=to,
+            subject_hash=hash_subject(subject),
         )
-    else:
-        cursor.execute("UPDATE history SET status = ? WHERE id = ?", (status, job_id))
+        if outbox_status == "sent":
+            return {"sent": True, "skipped": True, "send_key": send_key}
 
-    conn.commit()
-    conn.close()
+    try:
+        provider_response = send_email_fn(to=to, subject=subject, html=html)
+        provider_message_id = (
+            provider_response.get("MessageID")
+            if isinstance(provider_response, dict)
+            else None
+        )
+        if outbox_enabled:
+            mark_outbox_sent(
+                db_path=db_path,
+                send_key=send_key,
+                provider_message_id=provider_message_id,
+            )
+        return {"sent": True, "skipped": False, "send_key": send_key}
+    except Exception as exc:
+        if outbox_enabled:
+            mark_outbox_failed(
+                db_path=db_path, send_key=send_key, error_message=str(exc)
+            )
+        raise
 
 
 def _build_request(data: Dict[str, Any]) -> GenerateNewsletterRequest:
@@ -73,10 +111,19 @@ def generate_newsletter_task(
     data: Dict[str, Any],
     job_id: str,
     send_email: bool = False,
+    idempotency_key: str | None = None,
+    database_path: str | None = None,
 ) -> Dict[str, Any]:
     """Generate newsletter in worker context with stable response schema."""
+    db_path = _resolve_database_path(database_path)
     print(f"🔄 Worker: starting newsletter generation for job {job_id}")
-    update_job_status(job_id, "processing", params=data)
+    update_history_status(
+        db_path=db_path,
+        job_id=job_id,
+        status="processing",
+        params=data,
+        idempotency_key=idempotency_key,
+    )
 
     email = data.get("email", "")
 
@@ -97,9 +144,9 @@ def generate_newsletter_task(
 
         if send_email and email:
             try:
-                from mail import send_email as mail_send_email
-
-                mail_send_email(
+                send_result = _send_email_with_outbox(
+                    db_path=db_path,
+                    job_id=job_id,
                     to=email,
                     subject=result["title"],
                     html=result["html_content"],
@@ -107,11 +154,20 @@ def generate_newsletter_task(
                 response["sent"] = True
                 response["email_sent"] = True
                 response["email_to"] = email
+                response["email_deduplicated"] = bool(send_result.get("skipped", False))
+                response["send_key"] = send_result.get("send_key")
             except Exception as exc:
                 response["email_sent"] = False
                 response["email_error"] = str(exc)
 
-        update_job_status(job_id, "completed", response)
+        update_history_status(
+            db_path=db_path,
+            job_id=job_id,
+            status="completed",
+            result=response,
+            params=data,
+            idempotency_key=idempotency_key,
+        )
         return response
 
     except NewsletterGenerationError as exc:
@@ -125,7 +181,14 @@ def generate_newsletter_task(
             "sent": False,
             "email_sent": False,
         }
-        update_job_status(job_id, "failed", error_response)
+        update_history_status(
+            db_path=db_path,
+            job_id=job_id,
+            status="failed",
+            result=error_response,
+            params=data,
+            idempotency_key=idempotency_key,
+        )
         raise
     except Exception as exc:
         error_response = {
@@ -139,7 +202,14 @@ def generate_newsletter_task(
             "sent": False,
             "email_sent": False,
         }
-        update_job_status(job_id, "failed", error_response)
+        update_history_status(
+            db_path=db_path,
+            job_id=job_id,
+            status="failed",
+            result=error_response,
+            params=data,
+            idempotency_key=idempotency_key,
+        )
         raise
 
 

--- a/web/types.py
+++ b/web/types.py
@@ -2,9 +2,10 @@
 Web application common types
 """
 
-from typing import NewType, Optional, Dict, Any, Literal, Union, List
-from pydantic import BaseModel, Field, field_validator, model_validator
 import re
+from typing import Any, Dict, List, Literal, NewType, Optional, Union
+
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # 이메일 주소 타입
 EmailAddress = NewType("EmailAddress", str)
@@ -27,7 +28,7 @@ class GenerateNewsletterRequest(BaseModel):
     period: int = Field(default=14)
     email: Optional[str] = None  # 즉시 발송용 이메일 주소
 
-    @field_validator("keywords")
+    @field_validator("keywords")  # type: ignore[untyped-decorator]
     @classmethod
     def validate_keywords(cls, v: Optional[Union[str, List[str]]]) -> Optional[str]:
         if v is None:
@@ -40,22 +41,22 @@ class GenerateNewsletterRequest(BaseModel):
         else:
             raise ValueError("Keywords must be a string or list of strings")
 
-    @field_validator("period")
+    @field_validator("period")  # type: ignore[untyped-decorator]
     @classmethod
     def validate_period(cls, v: int) -> int:
         if v not in [1, 7, 14, 30]:
             raise ValueError("Invalid period. Must be one of: 1, 7, 14, 30 days")
         return v
 
-    @field_validator("email")
+    @field_validator("email")  # type: ignore[untyped-decorator]
     @classmethod
     def validate_email(cls, v: Optional[str]) -> Optional[str]:
         if v is not None and not EMAIL_PATTERN.match(v):
             raise ValueError("Invalid email format")
         return v
 
-    @model_validator(mode="after")
-    def validate_keywords_or_domain(self):
+    @model_validator(mode="after")  # type: ignore[untyped-decorator]
+    def validate_keywords_or_domain(self) -> "GenerateNewsletterRequest":
         # keywords와 domain 중 하나는 반드시 있어야 함
         if not self.keywords and not self.domain:
             raise ValueError("Either keywords or domain must be provided")
@@ -71,6 +72,8 @@ class JobResponse(BaseModel):
     result: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
     sent: Optional[bool] = None  # 이메일 발송 여부
+    deduplicated: Optional[bool] = None
+    idempotency_key: Optional[str] = None
 
 
 # API 응답 기본 스키마


### PR DESCRIPTION
## Summary
- enforce request idempotency for generation and schedule execution
- keep duplicate response policy stable (`202`, existing `job_id`, `deduplicated=true`)
- unify runtime state transitions through shared DB helpers
- add outbox-based dedupe for email sends

## Changes
- `web/routes_generation.py`
  - `Idempotency-Key` header support
  - canonical payload hash fallback key
  - duplicate request returns `202` + existing `job_id`
  - response fields: `deduplicated`, `idempotency_key`
- `web/schedule_runner.py`
  - deterministic schedule key (`schedule_id + intended_run_at`)
  - deterministic schedule job id and shared history row upsert
- `web/tasks.py`
  - unified status updates via `db_state`
  - outbox-aware email sending
- `web/routes_send_email.py`
  - outbox dedupe for manual send endpoint
- `web/types.py`
  - response schema expanded for idempotency fields
- tests
  - `tests/test_web_api.py`
  - `tests/integration/test_schedule_execution.py`
  - `tests/contract/test_web_email_routes_contract.py`

## Verification
- `./.venv/bin/pytest tests/test_web_api.py -q`
- `RUN_INTEGRATION_TESTS=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/pytest tests/integration/test_schedule_execution.py -q`
- `./.venv/bin/pytest tests/contract/test_web_email_routes_contract.py -q`
- `./.venv/bin/pytest tests/unit_tests/test_schedule_time_sync.py -q`

## Rollback Notes
- runtime feature flags for immediate mitigation:
  - `WEB_IDEMPOTENCY_ENABLED=0`
  - `WEB_OUTBOX_ENABLED=0`
- DB objects are additive only; rollback is code-path based.
