### PR TITLE
fix(ci): main-ci mypy 인자 조합 오류 수정

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -139,18 +139,33 @@ jobs:
             echo "Skip mypy: no runtime Python file changes."
             exit 0
           fi
-          MYPY_ARGS=()
+
+          FILE_TARGETS=()
+          MODULE_TARGETS=()
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             if [[ "$file" == web/*.py ]]; then
               module="${file%.py}"
               module="${module//\//.}"
-              MYPY_ARGS+=("-m" "$module")
+              MODULE_TARGETS+=("$module")
             else
-              MYPY_ARGS+=("$file")
+              FILE_TARGETS+=("$file")
             fi
           done <<< "$STRICT_RUNTIME_FILES"
-          mypy --ignore-missing-imports --follow-imports=skip "${MYPY_ARGS[@]}"
+
+          BASE_MYPY_ARGS=(--ignore-missing-imports --follow-imports=skip)
+
+          if [ "${#FILE_TARGETS[@]}" -gt 0 ]; then
+            mypy "${BASE_MYPY_ARGS[@]}" "${FILE_TARGETS[@]}"
+          fi
+
+          if [ "${#MODULE_TARGETS[@]}" -gt 0 ]; then
+            MODULE_MYPY_ARGS=()
+            for module in "${MODULE_TARGETS[@]}"; do
+              MODULE_MYPY_ARGS+=("-m" "$module")
+            done
+            mypy "${BASE_MYPY_ARGS[@]}" "${MODULE_MYPY_ARGS[@]}"
+          fi
 
       - name: Basic security scan (Bandit)
         shell: bash


### PR DESCRIPTION
## Summary
- main CI의 mypy 단계에서 `file + -m module` 혼합 전달로 실패하던 문제를 수정합니다.
- mypy 타깃을 파일 모드/모듈 모드로 분리 실행해 CLI 규칙을 준수합니다.

## Root Cause
- 기존 스크립트는 변경 파일 중 `web/*.py`는 `-m`으로, 나머지는 파일 경로로 하나의 mypy 호출에 함께 전달했습니다.
- mypy는 파일 인자와 `-m` 인자를 한 번에 혼합할 수 없어 exit code 2로 실패했습니다.

## Change
- `.github/workflows/main-ci.yml`
  - `FILE_TARGETS`, `MODULE_TARGETS`를 분리 수집
  - mypy를 최대 2회 호출(파일 대상 1회 + 모듈 대상 1회)

## Verification
- 로컬 재현 입력으로 분리 실행 검증:
  - file targets: `newsletter/centralized_settings.py`, `newsletter/config_manager.py`
  - module targets: `web.app`, `web.db_state`, `web.init_database`
  - 결과: 각각 `Success: no issues found ...`
