### PR TITLE
chore(repo-hygiene): add strict gate transition path

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -19,6 +19,8 @@ env:
   # Default interpreter for non-matrix jobs (quality/mock/integration/report)
   PYTHON_VERSION: '3.12'
   CACHE_VERSION: v1
+  # Prepared toggle for Phase 3 hard-gate transition.
+  REPO_HYGIENE_STRICT: 'false'
 
 jobs:
   # ========================================
@@ -133,10 +135,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          STRICT_ARGS=()
+          if [ "${REPO_HYGIENE_STRICT}" = "true" ]; then
+            STRICT_ARGS+=(--strict)
+            echo "Repo hygiene strict mode: ENABLED" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Repo hygiene strict mode: DISABLED (soft gate)" >> "$GITHUB_STEP_SUMMARY"
+          fi
           python scripts/repo_audit.py \
             --policy scripts/repo_hygiene_policy.json \
             --output-dir artifacts/repo-audit \
-            --check-policy
+            --check-policy \
+            "${STRICT_ARGS[@]}"
           cat artifacts/repo-audit/policy_warnings.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload repo audit artifact

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Newsletter Generator - Makefile
 # 개발 워크플로우 자동화를 위한 Makefile
 
-.PHONY: help bootstrap doctor check check-full format format-check lint architecture-check architecture-baseline test test-quick test-full test-nightly preflight-release validate-ci-manifest validate-scheduler-manifest validate-runtime-bootstrap-manifest apply-pr-metadata ci-check ci-fix clean install pre-commit pre-commit-run skill-ci-gate skill-docs-and-config-consistency skill-newsletter-smoke skill-web-smoke skill-scheduler-debug skill-release-integration skills-check docs-check repo-audit ops-safety-check ops-safety-smoke ops-safety-report
+.PHONY: help bootstrap doctor check check-full format format-check lint architecture-check architecture-baseline test test-quick test-full test-nightly preflight-release validate-ci-manifest validate-scheduler-manifest validate-runtime-bootstrap-manifest apply-pr-metadata ci-check ci-fix clean install pre-commit pre-commit-run skill-ci-gate skill-docs-and-config-consistency skill-newsletter-smoke skill-web-smoke skill-scheduler-debug skill-release-integration skills-check docs-check repo-audit repo-audit-strict ops-safety-check ops-safety-smoke ops-safety-report
 
 # 실행 경로/인터프리터 설정
 EXPECTED_CWD ?= /Users/hojungjung/development/newsletter-generator
@@ -219,6 +219,11 @@ repo-audit: ## 루트 인벤토리/Repo hygiene soft gate 리포트 생성
 	@echo "🧹 Repo audit 실행 중..."
 	$(PYTHON) scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy
 	@echo "✅ repo-audit 완료 (artifacts/repo-audit)"
+
+repo-audit-strict: ## 루트 인벤토리/Repo hygiene strict gate 리허설
+	@echo "🧱 Repo audit strict 실행 중..."
+	$(PYTHON) scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy --strict
+	@echo "✅ repo-audit-strict 완료 (artifacts/repo-audit)"
 
 pre-commit: ## Pre-commit hooks 설치
 	@echo "🔗 Pre-commit hooks 설치 중..."

--- a/docs/dev/CI_CD_GUIDE.md
+++ b/docs/dev/CI_CD_GUIDE.md
@@ -44,11 +44,13 @@ make doctor
 make check
 make check-full
 make repo-audit
+make repo-audit-strict
 ```
 
 - `make check`: 빠른 로컬 게이트
 - `make check-full`: PR 전 전체 게이트
 - `make repo-audit`: 루트 인벤토리 + repo hygiene soft gate 리포트 생성
+- `make repo-audit-strict`: hard gate 전환 전 strict 리허설
 - dev 유틸 실행 스크립트는 `scripts/devtools/`를 기본 경로로 사용합니다.
 
 ## Repo Hygiene Soft Gate
@@ -63,6 +65,7 @@ python scripts/repo_audit.py \
 ```
 
 - Week 1~2 운영: warning-only
+- 전환 준비: `REPO_HYGIENE_STRICT=true`일 때 `--strict` 모드로 실행되어 warning이 CI 실패로 승격
 - CI artifact:
   - `artifacts/repo-audit/repo_audit_report.md`
   - `artifacts/repo-audit/repo_audit_report.json`

--- a/docs/dev/LONG_TERM_REPO_STRATEGY.md
+++ b/docs/dev/LONG_TERM_REPO_STRATEGY.md
@@ -235,6 +235,8 @@ Delivery KPI:
   - 루트 호환 shim 도입(점진 제거 전략)
   - CI 빌드 경로 일부를 신규 위치로 전환
   - 루트 `README.md`를 개요/링크 중심 진입 문서로 슬림화
+- Week 3 준비 반영:
+  - `REPO_HYGIENE_STRICT` 토글 기반 hard gate 전환 경로를 CI/Makefile에 추가
 
 ## 10) 요청 표준(Agent/Skill + PR 중심)
 

--- a/docs/dev/REPO_HYGIENE_POLICY.md
+++ b/docs/dev/REPO_HYGIENE_POLICY.md
@@ -68,6 +68,9 @@
 - 위치: `.github/workflows/main-ci.yml`의 `quality-checks` stage
 - 실행 명령:
   - `python scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy`
+- strict 전환 준비 토글:
+  - `REPO_HYGIENE_STRICT=false`(기본): warning-only soft gate
+  - `REPO_HYGIENE_STRICT=true`: `--strict`가 활성화되어 warning 발견 시 CI 실패
 - 산출물(artifact):
   - `artifacts/repo-audit/repo_audit_report.md`
   - `artifacts/repo-audit/repo_audit_report.json`
@@ -108,6 +111,13 @@ python scripts/repo_audit.py \
   --output-dir artifacts/repo-audit \
   --check-policy \
   --strict
+```
+
+Makefile 단축 명령:
+
+```bash
+make repo-audit
+make repo-audit-strict
 ```
 
 ## Governance Notes


### PR DESCRIPTION
## Summary (what / why)
- Repo hygiene hard gate 전환을 안전하게 준비하기 위해 CI에 strict 토글 경로를 추가했습니다.
- 기본값은 기존과 동일한 soft gate(`REPO_HYGIENE_STRICT=false`)로 유지했습니다.
- 로컬 strict 리허설 명령(`make repo-audit-strict`)과 운영 문서를 동기화했습니다.
- RR: #90

## Scope
### In Scope
- `.github/workflows/main-ci.yml` repo audit 단계에 strict 토글 경로 추가
- `Makefile`에 `repo-audit-strict` 타깃 추가
- `docs/dev/REPO_HYGIENE_POLICY.md`, `docs/dev/CI_CD_GUIDE.md`, `docs/dev/LONG_TERM_REPO_STRATEGY.md` 동기화

### Out of Scope
- `REPO_HYGIENE_STRICT=true` 강제 전환
- allowlist 정책 재분류/루트 구조 이동

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): `make repo-audit`, `make repo-audit-strict`

### Commands and Results
```bash
make repo-audit          # PASS (warnings=0)
make repo-audit-strict   # PASS (warnings=0)
make check               # PASS
make check-full          # PASS
```

## Risk & Rollback
- Risk: CI 조건문 오작동으로 repo audit 단계 실패 가능
- Rollback: 본 PR squash commit revert 시 기존 soft gate 단일 경로로 즉시 복귀

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: N/A (protected paths 미변경)
- Outbox/send_key 중복 방지 결과: N/A
- import-time side effect 제거 여부: N/A

## Not Run (with reason)
- 없음
