### PR TITLE
docs(shim): cut over operational references to devtools paths

### DIFF
--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -79,7 +79,7 @@ newsletter-generator/
 ├── 📄 requirements.txt          # Production dependencies
 ├── 📄 requirements-dev.txt      # Development dependencies
 ├── 📄 requirements-minimal.txt  # Minimal CI dependencies
-├── 📄 run_tests.py              # Test runner script
+├── 📄 scripts/devtools/run_tests.py              # Test runner script
 └── 📄 config.yml                # Application configuration (updated with Multi-LLM)
 ```
 

--- a/docs/dev/DEVELOPMENT_GUIDE.md
+++ b/docs/dev/DEVELOPMENT_GUIDE.md
@@ -111,7 +111,7 @@ newsletter-generator/
 ├── pyproject.toml             # 프로젝트 설정
 ├── setup.py                   # 패키지 설정
 ├── .pre-commit-config.yaml    # pre-commit 설정
-└── run_tests.py               # 테스트 실행 스크립트
+└── scripts/devtools/run_tests.py               # 테스트 실행 스크립트
 ```
 
 ### 핵심 모듈 설명
@@ -199,7 +199,7 @@ refactor(graph): simplify workflow state management
 
 ```bash
 # 모든 품질 검사 실행
-python run_tests.py quality
+python run_ci_checks.py --quick
 
 # 개별 도구 실행
 black newsletter tests                    # 포맷팅
@@ -276,12 +276,12 @@ tests/
 
 ```bash
 # 모든 테스트 실행
-python run_tests.py all
+python scripts/devtools/run_tests.py ci
 
 # 환경별 테스트
-python run_tests.py dev      # 개발 환경
-python run_tests.py ci       # CI 환경
-python run_tests.py prod     # 프로덕션 환경
+python scripts/devtools/run_tests.py dev      # 개발 환경
+python scripts/devtools/run_tests.py ci       # CI 환경
+python scripts/devtools/run_tests.py integration  # 통합/프로덕션 검증
 
 # 특정 테스트 파일
 pytest tests/unit_tests/test_compose.py
@@ -555,7 +555,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 # 테스트 실행
-python run_tests.py ci
+python scripts/devtools/run_tests.py ci
 if [ $? -ne 0 ]; then
     echo "Tests failed"
     exit 1
@@ -593,10 +593,10 @@ echo "Release $VERSION completed"
 source .venv/bin/activate
 
 # 코드 품질 검사
-python run_tests.py quality
+python run_ci_checks.py --quick
 
 # 테스트 실행
-python run_tests.py dev
+python scripts/devtools/run_tests.py dev
 
 # 패키지 재설치
 pip install -e . --force-reinstall

--- a/docs/dev/MAIN_INTEGRATION_EXECUTION_PLAN.md
+++ b/docs/dev/MAIN_INTEGRATION_EXECUTION_PLAN.md
@@ -68,7 +68,7 @@ git restore --source=work -- \
   .pre-commit-config.yaml \
   .githooks/pre-push \
   run_ci_checks.py \
-  check_quality.py \
+  scripts/devtools/check_quality.py \
   Makefile \
   LOCAL_CI_GUIDE.md
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -80,13 +80,13 @@ python -m pytest tests/unit_tests/ -v
 python tests/run_essential_tests.py
 
 # 3. Mock API 포함 전체 테스트 (E2E 제외)
-python run_tests.py dev
+python scripts/devtools/run_tests.py dev
 ```
 
 ### 기능 완성 후 (통합 검증)
 ```bash
 # 1. 통합 테스트 포함
-RUN_INTEGRATION_TESTS=1 python run_tests.py dev
+python scripts/devtools/run_tests.py integration
 
 # 2. 웹 서버 실행 후 E2E 테스트
 # Terminal 1: cd web && python app.py
@@ -96,7 +96,7 @@ RUN_INTEGRATION_TESTS=1 python run_tests.py dev
 ### 배포 전 (전체 검증)
 ```bash
 # 실제 API 사용 전체 테스트
-python run_tests.py full
+python scripts/devtools/run_tests.py integration
 ```
 
 ### 배포 후 (운영 검증)

--- a/tests/TEST_CLASSIFICATION_SUMMARY.md
+++ b/tests/TEST_CLASSIFICATION_SUMMARY.md
@@ -81,7 +81,7 @@ export RUN_INTEGRATION_TESTS=1
 
 ### ✅ GitHub Actions 호환 테스트
 ```bash
-python run_tests.py ci
+python scripts/devtools/run_tests.py ci
 # 결과: 128 passed, 15 skipped (Real API 제외)
 # 시간: ~7분 (대부분 LLM 모킹 시간)
 ```
@@ -95,7 +95,7 @@ python -m pytest tests/test_email_delivery.py -v
 
 ### ✅ 단위 테스트만 실행
 ```bash
-python run_tests.py unit
+python scripts/devtools/run_tests.py unit
 # 결과: 117 passed, 5 skipped
 # 시간: ~6분
 ```
@@ -105,19 +105,19 @@ python run_tests.py unit
 ### 개발 중
 ```bash
 # 빠른 검증 (Mock API + 단위 테스트)
-python run_tests.py dev
+python scripts/devtools/run_tests.py dev
 ```
 
 ### PR 생성 시
 ```bash
 # GitHub Actions에서 자동 실행
-python run_tests.py ci
+python scripts/devtools/run_tests.py ci
 ```
 
 ### 배포 전
 ```bash
 # 실제 API 포함 완전 검증
-python run_tests.py integration
+python scripts/devtools/run_tests.py integration
 ```
 
 ### 이메일 기능 개발 시

--- a/tests/TEST_EXECUTION_GUIDE.md
+++ b/tests/TEST_EXECUTION_GUIDE.md
@@ -3,7 +3,7 @@
 ## 🎯 현재 발생한 문제와 해결 방안
 
 ### ❌ 문제점
-- `python run_tests.py dev` 실행 시 E2E 테스트가 포함되어 웹 서버 연결 오류 발생
+- `python scripts/devtools/run_tests.py dev` 실행 시 E2E 테스트가 포함되어 웹 서버 연결 오류 발생
 - 7개 E2E 테스트가 실패하여 전체 테스트 결과가 왜곡됨
 - 테스트 분류가 불명확하여 의존성 문제 발생
 
@@ -17,7 +17,7 @@
 ### 1. 일반 개발 시 (권장)
 ```bash
 # 단위 테스트 + Mock API 테스트 (가장 빠름)
-python run_tests.py dev
+python scripts/devtools/run_tests.py dev
 
 # 또는 필수 테스트만
 python tests/run_essential_tests.py
@@ -26,7 +26,7 @@ python tests/run_essential_tests.py
 ### 2. 기능 개발 완료 후
 ```bash
 # 통합 테스트 포함 (실제 API 키 필요)
-RUN_INTEGRATION_TESTS=1 python run_tests.py integration
+RUN_INTEGRATION_TESTS=1 python scripts/devtools/run_tests.py integration
 ```
 
 ### 3. E2E 테스트 실행 (웹 서버 필요)
@@ -156,9 +156,9 @@ External API dependency failed: API key error
 **해결**: `.env` 파일에 API 키 설정 또는 Mock 테스트로 전환
 
 ### 테스트 실행 시간 최적화
-- 개발 중: `python run_tests.py dev` (< 30초)
+- 개발 중: `python scripts/devtools/run_tests.py dev` (< 30초)
 - 기능 검증: `python tests/run_essential_tests.py` (< 20초)
-- 전체 검증: `RUN_INTEGRATION_TESTS=1 python run_tests.py integration` (< 2분)
+- 전체 검증: `RUN_INTEGRATION_TESTS=1 python scripts/devtools/run_tests.py integration` (< 2분)
 
 ## 📊 테스트 성능 목표
 
@@ -173,7 +173,7 @@ External API dependency failed: API key error
 ## 🚨 주의사항
 
 1. **E2E 테스트는 웹 서버 실행 필수**
-   - `run_tests.py dev`에서 자동 제외됨
+   - `scripts/devtools/run_tests.py dev`에서 자동 제외됨
    - 수동으로 웹 서버 시작 후 실행
 
 2. **실제 API 테스트는 할당량 소모**

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,11 +8,11 @@ Newsletter Generator Tests
 - _backup/: 사용되지 않는 이전 테스트 (참고용)
 
 테스트 실행:
-- 모든 테스트 실행: python run_tests.py --all
-- API 테스트만 실행: python run_tests.py --api
-- 단위 테스트만 실행: python run_tests.py --unit
-- 테스트 목록 확인: python run_tests.py --list
-- 특정 테스트 실행: python run_tests.py --test [test_name]
+- 모든 테스트 실행: python scripts/devtools/run_tests.py ci
+- API 테스트만 실행: python scripts/devtools/run_tests.py --api
+- 단위 테스트만 실행: python scripts/devtools/run_tests.py --unit-tests
+- 테스트 목록 확인: python scripts/devtools/run_tests.py --list --all
+- 특정 테스트 실행: python scripts/devtools/run_tests.py --test [test_name]
 
 자세한 내용은 tests/README.md 파일을 참조하세요.
 """

--- a/tests/api_tests/__init__.py
+++ b/tests/api_tests/__init__.py
@@ -19,5 +19,5 @@
 - test_improved_search.py, test_search_improved.py: 향상된 검색 기능 테스트
 
 전체 API 테스트 실행:
-python run_tests.py --api
+python scripts/devtools/run_tests.py --api
 """

--- a/tests/unit_tests/__init__.py
+++ b/tests/unit_tests/__init__.py
@@ -10,6 +10,6 @@
 - 날짜 스크래핑 (test_scrape_dates.py)
 - 실제 뉴스레터 시나리오 (test_real_newsletter.py)
 
-전체 테스트 실행:
-python run_tests.py --unit
+단위 테스트 실행:
+python scripts/devtools/run_tests.py --unit-tests
 """


### PR DESCRIPTION
## Summary (what / why)
- 실사용 테스트/개발 문서에서 루트 shim 호출(`run_tests.py`, `check_quality.py`)을 `scripts/devtools/*` 기준으로 전면 치환했습니다.
- 함께 잘못된 실행 예시(`full`, `prod`, `--unit`)를 현재 스크립트 인터페이스에 맞게 정리했습니다.
- 목적은 U2에서 루트 shim 파일 9개를 안전하게 삭제하기 위한 선행 호환 정리입니다.
- RR: #92

## Scope
### In Scope
- `tests/*` 및 개발 문서의 run-tests/check-quality 경로 전환
- 잘못된 테스트 실행 예시를 유효 명령으로 보정

### Out of Scope
- 루트 shim 파일 삭제
- repo hygiene policy의 shim allowlist 정리

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): `make repo-audit`

### Commands and Results
```bash
make repo-audit   # PASS (warnings=0)
make check        # PASS
make check-full   # PASS
```

## Risk & Rollback
- Risk: 문서 예시 변경으로 일부 운영 절차 혼선 가능
- Rollback: 본 PR squash commit revert 시 문서 경로 즉시 원복

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: N/A (protected paths 미변경)
- Outbox/send_key 중복 방지 결과: N/A
- import-time side effect 제거 여부: N/A

## Not Run (with reason)
- 없음
