### PR TITLE
chore(repo-hygiene): enable strict repo gate by default

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -19,8 +19,8 @@ env:
   # Default interpreter for non-matrix jobs (quality/mock/integration/report)
   PYTHON_VERSION: '3.12'
   CACHE_VERSION: v1
-  # Prepared toggle for Phase 3 hard-gate transition.
-  REPO_HYGIENE_STRICT: 'false'
+  # Hard gate is enabled by default; allow temporary override only if needed.
+  REPO_HYGIENE_STRICT: 'true'
 
 jobs:
   # ========================================
@@ -131,7 +131,7 @@ jobs:
           python scripts/architecture/check_import_boundaries.py --mode ratchet
           python scripts/architecture/check_import_cycles.py
 
-      - name: Repo hygiene audit (soft gate)
+      - name: Repo hygiene audit (gate)
         shell: bash
         run: |
           set -euo pipefail
@@ -140,7 +140,7 @@ jobs:
             STRICT_ARGS+=(--strict)
             echo "Repo hygiene strict mode: ENABLED" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "Repo hygiene strict mode: DISABLED (soft gate)" >> "$GITHUB_STEP_SUMMARY"
+            echo "Repo hygiene strict mode: DISABLED (temporary soft gate override)" >> "$GITHUB_STEP_SUMMARY"
           fi
           python scripts/repo_audit.py \
             --policy scripts/repo_hygiene_policy.json \

--- a/docs/dev/CI_CD_GUIDE.md
+++ b/docs/dev/CI_CD_GUIDE.md
@@ -50,12 +50,12 @@ make repo-audit-strict
 - `make check`: 빠른 로컬 게이트
 - `make check-full`: PR 전 전체 게이트
 - `make repo-audit`: 루트 인벤토리 + repo hygiene soft gate 리포트 생성
-- `make repo-audit-strict`: hard gate 전환 전 strict 리허설
+- `make repo-audit-strict`: CI hard gate와 동일(strict) 경로 점검
 - dev 유틸 실행 스크립트는 `scripts/devtools/`를 기본 경로로 사용합니다.
 
-## Repo Hygiene Soft Gate
+## Repo Hygiene Gate
 
-`main-ci.yml`의 `quality-checks` 단계에서 아래 soft gate를 실행합니다.
+`main-ci.yml`의 `quality-checks` 단계에서 repo hygiene gate를 실행합니다.
 
 ```bash
 python scripts/repo_audit.py \
@@ -64,8 +64,8 @@ python scripts/repo_audit.py \
   --check-policy
 ```
 
-- Week 1~2 운영: warning-only
-- 전환 준비: `REPO_HYGIENE_STRICT=true`일 때 `--strict` 모드로 실행되어 warning이 CI 실패로 승격
+- 현재 기본 운영: `REPO_HYGIENE_STRICT=true` (hard gate)
+- 임시 예외 경로: `REPO_HYGIENE_STRICT=false`로 soft gate override 가능(권장하지 않음)
 - CI artifact:
   - `artifacts/repo-audit/repo_audit_report.md`
   - `artifacts/repo-audit/repo_audit_report.json`

--- a/docs/dev/LONG_TERM_REPO_STRATEGY.md
+++ b/docs/dev/LONG_TERM_REPO_STRATEGY.md
@@ -240,6 +240,9 @@ Delivery KPI:
 - Week 4 실행 반영:
   - 루트 shim 9종 제거 완료 (`scripts/devtools/*` 단일 경로로 전환)
   - `pyinstaller_hooks/`를 `scripts/devtools/pyinstaller_hooks/`로 이관
+- Week 5 실행 반영:
+  - main CI의 repo hygiene gate 기본 모드를 `REPO_HYGIENE_STRICT=true`로 승격
+  - hard gate 운영 기준을 정책/CI 가이드 문서에 동기화
 
 ## 10) 요청 표준(Agent/Skill + PR 중심)
 

--- a/docs/dev/REPO_HYGIENE_POLICY.md
+++ b/docs/dev/REPO_HYGIENE_POLICY.md
@@ -1,4 +1,4 @@
-# Repo Hygiene Policy (Week 1-2 Baseline)
+# Repo Hygiene Policy
 
 이 문서는 루트 구조 정리 정책의 실행 정본(SSOT)입니다.
 
@@ -6,12 +6,13 @@
 - 정책 파일: `scripts/repo_hygiene_policy.json`
 - 인벤토리 도구: `scripts/repo_audit.py`
 - Week 2-4 반영: 루트 유틸 이관 + 루트 shim 9종 제거 완료
+- Week 5 반영: CI hard gate(`REPO_HYGIENE_STRICT=true`) 기본 활성화
 
 ## Scope
 
 - 루트 엔트리 분류(유지/이관/삭제/ignore)
 - dot 디렉터리(`.vscode`, `.agents`, `.githooks`) 추적 범위 고정
-- CI soft gate(warning-only) 운영 기준
+- CI repo hygiene gate 운영 기준
 
 ## Root Classification Table
 
@@ -36,7 +37,7 @@
 
 ## Dot Directory Tracking Agreement
 
-아래 범위만 추적합니다. 그 외 파일은 CI soft gate에서 경고합니다.
+아래 범위만 추적합니다. 그 외 파일은 CI repo hygiene gate에서 경고/실패 처리됩니다.
 
 ### `.vscode`
 
@@ -64,27 +65,27 @@
   - `.githooks/pre-push`
 - 금지: 개인 훅/로컬 자동생성 스크립트
 
-## CI Soft Gate
+## CI Repo Hygiene Gate
 
 - 위치: `.github/workflows/main-ci.yml`의 `quality-checks` stage
 - 실행 명령:
   - `python scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy`
-- strict 전환 준비 토글:
-  - `REPO_HYGIENE_STRICT=false`(기본): warning-only soft gate
-  - `REPO_HYGIENE_STRICT=true`: `--strict`가 활성화되어 warning 발견 시 CI 실패
+- strict 토글:
+  - `REPO_HYGIENE_STRICT=true`(기본): `--strict` 활성화, warning 발견 시 CI 실패(hard gate)
+  - `REPO_HYGIENE_STRICT=false`: 임시 soft gate override(경고만 출력)
 - 산출물(artifact):
   - `artifacts/repo-audit/repo_audit_report.md`
   - `artifacts/repo-audit/repo_audit_report.json`
   - `artifacts/repo-audit/policy_warnings.md`
 - 운영 원칙:
-  - Week 1~2: warning-only(실패로 승격하지 않음)
-  - Phase 3: hard gate 전환 검토
+  - Week 1~4: warning-only soft gate로 준비 단계 운영
+  - Week 5+: hard gate 기본 운영, 예외 시에만 일시 override 검토
 
 ### Shim Policy (Week 4)
 
 - 루트 shim은 더 이상 유지하지 않습니다.
 - 실행/유틸 스크립트 경로는 `scripts/devtools/*`로 단일화합니다.
-- soft/strict gate 모두 루트 shim 파일 생성을 허용하지 않습니다.
+- soft/strict 모드 모두 루트 shim 파일 생성을 허용하지 않습니다.
 
 ## Local Runbook
 
@@ -95,7 +96,7 @@ python scripts/repo_audit.py \
   --check-policy
 ```
 
-strict 모드(향후 hard gate용):
+strict 모드(CI 기본):
 
 ```bash
 python scripts/repo_audit.py \
@@ -114,6 +115,6 @@ make repo-audit-strict
 
 ## Governance Notes
 
-- 본 문서는 Week 1~2 기준선입니다.
+- 본 문서는 Week 1 기준선에서 현재 운영 상태로 지속 업데이트합니다.
 - 정책 변경은 반드시 PR로 수행하고, `scripts/repo_hygiene_policy.json`과 함께 변경합니다.
 - root 예외 추가 시 사유와 제거 목표 시점을 PR 설명에 명시합니다.


### PR DESCRIPTION
## Summary (what / why)
- Enable repo hygiene hard gate by default in main CI (`REPO_HYGIENE_STRICT=true`) now that Week 4 cleanup milestones are complete.
- Synchronize policy and CI guide docs so contributors follow the same default behavior and rollback path.
- RR: #100

## Scope
### In Scope
- Switch main CI repo hygiene default from soft gate to hard gate.
- Update repo hygiene policy wording and runbook to reflect strict-default operation.
- Update CI/CD guide and long-term strategy execution memo.

### Out of Scope
- Policy allowlist/denylist changes.
- Additional root file/folder relocation.

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): `make repo-audit`

### Commands and Results
```bash
make repo-audit
# PASS (top-level entries=52 warnings=0)

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: latent repo hygiene warnings now fail CI in PR/main.
- Rollback: revert commit `7b9df50` to restore `REPO_HYGIENE_STRICT=false` default.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: N/A (protected ops-safety paths not touched)
- Outbox/send_key 중복 방지 결과: N/A
- import-time side effect 제거 여부: N/A

## Not Run (with reason)
- `make repo-audit-strict`: skipped because CI default is now strict and `make check`/`make check-full` passed under updated policy.
