### PR TITLE
P0-2: prioritize Windows build check for fail-fast gating

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -471,12 +471,12 @@ jobs:
   # ========================================
   build-check:
     name: Build Check (${{ matrix.os }})
-    needs: [mock-api-tests]
+    needs: [quality-checks]
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -529,6 +529,7 @@ jobs:
           retry_pip_install pyinstaller build requests
 
       - name: Test package build
+        if: matrix.os != 'windows-latest'
         run: |
           python -m build
 


### PR DESCRIPTION
## Summary (what / why)
- Move Windows build gating earlier so EXE build failures surface immediately after quality checks.
- Reduce wasted pipeline time by running Windows EXE path before long downstream test stages complete.

## Scope
- Changed `build-check` dependency from `mock-api-tests` to `quality-checks`.
- Switched matrix order to start with `windows-latest` and enabled matrix `fail-fast`.
- Skipped `python -m build` on Windows so EXE path is prioritized; package build remains on Ubuntu.

## Delivery Unit
- RR: #129
- Delivery Unit ID: ci-p0-2-windows-failfast-order
- Merge Boundary: single-pr
- Rollback Boundary: revert-commit

## Test & Evidence
- `make check` -> PASS

## Risk & Rollback
- Risk: low-medium (CI workflow ordering change)
- Rollback: revert this PR commit to restore previous build-check ordering

## Ops-Safety Addendum (if touching protected paths)
- No runtime business logic path changed; CI orchestration only.

## Not Run (with reason)
- Direct GitHub workflow dry-run is not available locally; verified via PR CI.
