### PR TITLE
P0-3: dedupe duplicate push and PR CI runs

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -2,7 +2,7 @@ name: Main CI Pipeline
 
 on:
   push:
-    branches: [main, develop, 'feature/**', 'feat/**', 'fix/**', 'chore/**', 'docs/**', 'refactor/**', 'release/**', 'codex/**']
+    branches: [main, develop, 'release/**']
   pull_request:
     branches: [main, develop]
 
@@ -12,7 +12,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Use PR number when present to cancel superseded reruns on the same PR.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary (what / why)
- Remove duplicate CI runs caused by triggering `Main CI` on both push and pull_request for feature/codex branches.
- Keep required branch checks while reducing queue time and redundant Windows build executions.

## Scope
- Restrict `push` trigger to long-lived branches only: `main`, `develop`, `release/**`.
- Keep `pull_request` trigger for `main`, `develop`.
- Update CI concurrency key to use PR number when available for superseded rerun cancellation.

## Delivery Unit
- RR: #130
- Delivery Unit ID: ci-p0-3-dedupe-main-ci-trigger
- Merge Boundary: single-pr
- Rollback Boundary: revert-commit

## Test & Evidence
- `make check` -> PASS
- Prior symptom reproduced on PR #128/#129: duplicated `Code Quality & Security` and duplicated `Build Check (windows-latest)` check runs.

## Risk & Rollback
- Risk: medium (CI trigger policy change)
- Rollback: revert this PR commit to restore broad push triggers

## Ops-Safety Addendum (if touching protected paths)
- No runtime or data-path logic changed; workflow trigger policy only.

## Not Run (with reason)
- No local equivalent for GitHub trigger matrix behavior; validated via PR checks.
