### PR TITLE
P0-4: automate Windows burn-in gate on main

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [main, develop]
 
 permissions:
+  actions: read
   contents: read
   checks: write
   pull-requests: write
@@ -618,3 +619,38 @@ jobs:
             *.exe
             *.spec
           if-no-files-found: warn
+
+  # ========================================
+  # Stage 7: Main Branch Burn-in Gate
+  # ========================================
+  windows-burnin-gate:
+    name: Windows Burn-in Gate (main)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build-check]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Evaluate Windows CI burn-in success rate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/devtools/windows_ci_burnin_report.py \
+            --workflow "Main CI Pipeline" \
+            --branch main \
+            --limit 10 \
+            --min-success-rate 95 \
+            --output artifacts/windows-ci-burnin.json
+
+      - name: Upload windows burn-in artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-ci-burnin-${{ github.run_id }}
+          path: artifacts/windows-ci-burnin.json
+          if-no-files-found: error

--- a/docs/setup/WINDOWS_EXE_OPERATIONS.md
+++ b/docs/setup/WINDOWS_EXE_OPERATIONS.md
@@ -70,8 +70,9 @@ python scripts/devtools/create_support_bundle.py --artifact dist/newsletter_web.
   - `Build Check (windows-latest)`
 - burn-in 기준:
   - 최근 10회 `Build Check (windows-latest)` 성공률 95% 이상
+  - `cancelled/skipped/neutral/unknown` 결론은 burn-in 샘플에서 제외(중복 런 취소/진행중 런 노이즈 제거)
 - 측정 명령:
 
 ```bash
-python scripts/devtools/windows_ci_burnin_report.py --workflow "Main CI Pipeline" --branch main --limit 10 --min-success-rate 95
+python scripts/devtools/windows_ci_burnin_report.py --workflow "Main CI Pipeline" --branch main --limit 10 --min-success-rate 95 --ignore-conclusions cancelled,skipped,neutral,unknown
 ```

--- a/scripts/devtools/windows_ci_burnin_report.py
+++ b/scripts/devtools/windows_ci_burnin_report.py
@@ -64,8 +64,21 @@ def main() -> int:
     parser.add_argument("--limit", type=int, default=10)
     parser.add_argument("--scan-limit", type=int, default=60)
     parser.add_argument("--min-success-rate", type=float, default=95.0)
+    parser.add_argument(
+        "--ignore-conclusions",
+        default="cancelled,skipped,neutral,unknown",
+        help=(
+            "Comma-separated window-job conclusions to exclude from burn-in "
+            "sample collection (default: cancelled,skipped,neutral,unknown)."
+        ),
+    )
     parser.add_argument("--output", default="")
     args = parser.parse_args()
+    ignored_conclusions = {
+        item.strip().lower()
+        for item in args.ignore_conclusions.split(",")
+        if item.strip()
+    }
 
     runs = _gh_json(
         [
@@ -83,6 +96,7 @@ def main() -> int:
     )
 
     candidate_results: list[RunResult] = []
+    ignored_runs = 0
     for run in runs:
         run_id = int(run["databaseId"])
         detail = _gh_json(
@@ -98,7 +112,11 @@ def main() -> int:
         windows_job, windows_conclusion = _resolve_windows_job(jobs)
         if windows_job == "missing":
             continue
-        passed = windows_conclusion == "success"
+        normalized_conclusion = windows_conclusion.lower()
+        if normalized_conclusion in ignored_conclusions:
+            ignored_runs += 1
+            continue
+        passed = normalized_conclusion == "success"
         candidate_results.append(
             RunResult(
                 run_id=run_id,
@@ -116,7 +134,7 @@ def main() -> int:
         raise SystemExit(
             "insufficient windows build-check history: "
             f"requested={args.limit}, found={len(candidate_results)} "
-            f"(scan_limit={args.scan_limit})"
+            f"(scan_limit={args.scan_limit}, ignored={ignored_runs})"
         )
 
     results = candidate_results
@@ -127,6 +145,8 @@ def main() -> int:
         "workflow": args.workflow,
         "branch": args.branch,
         "scan_limit": args.scan_limit,
+        "ignored_conclusions": sorted(ignored_conclusions),
+        "ignored_runs": ignored_runs,
         "sample_size": len(results),
         "minimum_success_rate": args.min_success_rate,
         "success_rate": success_rate,


### PR DESCRIPTION
## Summary (what / why)
- Add an automated burn-in gate that evaluates recent Windows build-check stability on `main`.
- Prevent noisy cancellations/in-progress runs from incorrectly failing the burn-in metric.

## Scope
- Added `windows-burnin-gate` job to `Main CI Pipeline` (runs on `push` to `main`, after `build-check`).
- Added `actions: read` workflow permission for GitHub run history queries.
- Updated `windows_ci_burnin_report.py` to ignore `cancelled/skipped/neutral/unknown` conclusions by default.
- Updated Windows EXE operations doc with the burn-in sampling rule and command.

## Delivery Unit
- RR: #131
- Delivery Unit ID: ci-p0-4-windows-burnin-gate
- Merge Boundary: single-pr
- Rollback Boundary: revert-commit

## Test & Evidence
- `make check` -> PASS
- `python scripts/devtools/windows_ci_burnin_report.py --workflow "Main CI Pipeline" --branch main --limit 10 --min-success-rate 95` -> PASS (100.0%, ignored_runs=2)

## Risk & Rollback
- Risk: medium (new CI governance gate on main pushes)
- Rollback: revert this PR commit to remove Stage 7 burn-in job and restore prior report behavior

## Ops-Safety Addendum (if touching protected paths)
- No production runtime code path changed; CI/reporting governance only.

## Not Run (with reason)
- Burn-in gate job itself only executes on `main` push; PR CI cannot execute this branch condition directly.
