### PR TITLE
P1: lock canonical web.types references

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -138,19 +138,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if command -v rg >/dev/null 2>&1; then
-            FORBIDDEN_REFS="$(rg -n 'web/web_types\.py|web\.web_types' web scripts tests \
-              --glob '!web/runtime_hook.py' || true)"
-          else
-            FORBIDDEN_REFS="$(grep -RInE 'web/web_types\.py|web\.web_types' web scripts tests \
-              --exclude='runtime_hook.py' || true)"
-          fi
-          if [ -n "$FORBIDDEN_REFS" ]; then
-            echo "Legacy web_types references are not allowed outside runtime compatibility alias:"
-            echo "$FORBIDDEN_REFS"
-            exit 1
-          fi
-          echo "No legacy web_types references detected."
+          python scripts/devtools/check_legacy_web_types_paths.py
 
       - name: Guard runtime output literals (ASCII-safe)
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Newsletter Generator - Makefile
 # 개발 워크플로우 자동화를 위한 Makefile
 
-.PHONY: help bootstrap doctor check check-full format format-check lint architecture-check architecture-baseline test test-quick test-full test-nightly preflight-release validate-ci-manifest validate-scheduler-manifest validate-runtime-bootstrap-manifest apply-pr-metadata ci-check ci-fix clean install pre-commit pre-commit-run skill-ci-gate skill-docs-and-config-consistency skill-newsletter-smoke skill-web-smoke skill-scheduler-debug skill-release-integration skills-check docs-check repo-audit repo-audit-strict runtime-ascii-guard ops-safety-check ops-safety-smoke ops-safety-report build-web-exe windows-release-artifacts verify-windows-artifact-checksum support-bundle windows-sign-exe validate-windows-release-artifacts windows-update-manifest windows-ci-burnin-report
+.PHONY: help bootstrap doctor check check-full format format-check lint architecture-check architecture-baseline test test-quick test-full test-nightly preflight-release validate-ci-manifest validate-scheduler-manifest validate-runtime-bootstrap-manifest apply-pr-metadata ci-check ci-fix clean install pre-commit pre-commit-run skill-ci-gate skill-docs-and-config-consistency skill-newsletter-smoke skill-web-smoke skill-scheduler-debug skill-release-integration skills-check docs-check repo-audit repo-audit-strict runtime-ascii-guard legacy-web-types-guard ops-safety-check ops-safety-smoke ops-safety-report build-web-exe windows-release-artifacts verify-windows-artifact-checksum support-bundle windows-sign-exe validate-windows-release-artifacts windows-update-manifest windows-ci-burnin-report
 
 # 실행 경로/인터프리터 설정
 EXPECTED_CWD ?= /Users/hojungjung/development/newsletter-generator
@@ -265,6 +265,11 @@ runtime-ascii-guard: ## Ensure runtime print/logger literals stay ASCII-safe
 	@echo "🔡 Runtime ASCII 출력 가드 실행 중..."
 	$(PYTHON) scripts/devtools/check_runtime_ascii_output.py
 	@echo "✅ runtime-ascii-guard 완료"
+
+legacy-web-types-guard: ## Ensure only runtime compatibility files mention legacy web_types refs
+	@echo "🧭 Legacy web_types 참조 가드 실행 중..."
+	$(PYTHON) scripts/devtools/check_legacy_web_types_paths.py
+	@echo "✅ legacy-web-types-guard 완료"
 
 pre-commit: ## Pre-commit hooks 설치
 	@echo "🔗 Pre-commit hooks 설치 중..."

--- a/docs/setup/PYINSTALLER_WINDOWS.md
+++ b/docs/setup/PYINSTALLER_WINDOWS.md
@@ -34,6 +34,7 @@ python scripts/devtools/build_web_exe_enhanced.py
 완료되면 `dist\newsletter_web.exe` 파일이 생성됩니다. 이 파일은 Python 환경 없이 바로 실행할 수 있습니다.
 
 > 참고: `python scripts/devtools/build_web_exe.py`는 호환용 shim이며 내부적으로 `build_web_exe_enhanced.py`를 호출합니다.
+> 타입 로딩 기준은 `web.types`가 canonical이며, `web.web_types`/`web_types`는 런타임 호환 alias로만 유지됩니다.
 
 ## 4. 실행 및 데이터베이스 초기화
 
@@ -51,6 +52,7 @@ python scripts/devtools/generate_windows_release_artifacts.py --artifact dist/ne
 python scripts/devtools/verify_windows_artifact_checksum.py --artifact dist/newsletter_web.exe --checksum-file dist/SHA256SUMS.txt
 python scripts/devtools/create_support_bundle.py --artifact dist/newsletter_web.exe --dist-dir dist --output dist/support-bundle.zip
 python scripts/devtools/validate_windows_release_artifacts.py --dist-dir dist
+python scripts/devtools/check_legacy_web_types_paths.py
 ```
 
 - `dist\release-metadata.json`: 버전/빌드시각/Git SHA/Smoke 결과 등 릴리즈 메타데이터

--- a/scripts/devtools/README.md
+++ b/scripts/devtools/README.md
@@ -19,6 +19,7 @@
 - `validate_windows_release_artifacts.py`
 - `generate_windows_update_manifest.py`
 - `windows_ci_burnin_report.py`
+- `check_legacy_web_types_paths.py`
 - `newsletter-test.sh`
 - `newsletter-test.bat`
 

--- a/scripts/devtools/check_legacy_web_types_paths.py
+++ b/scripts/devtools/check_legacy_web_types_paths.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Fail CI when legacy web_types references reappear outside allowlisted files."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_ROOTS = ("web", "scripts", "tests")
+ALLOWLIST = {
+    Path("web/runtime_hook.py"),
+    Path("tests/unit_tests/web/test_runtime_hook_bootstrap.py"),
+}
+PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("legacy module path", re.compile(r"web/web_types\.py")),
+    ("legacy dotted import", re.compile(r"\bweb\.web_types\b")),
+    (
+        "legacy dynamic module name",
+        re.compile(r"""spec_from_file_location\(\s*["']web_types["']"""),
+    ),
+    (
+        "legacy import statement",
+        re.compile(r"^\s*(?:from|import)\s+web_types\b", re.MULTILINE),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    rel_path: Path
+    line: int
+    rule: str
+    snippet: str
+
+
+def _line_number(text: str, index: int) -> int:
+    return text.count("\n", 0, index) + 1
+
+
+def _scan_file(rel_path: Path, text: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for rule, pattern in PATTERNS:
+        for match in pattern.finditer(text):
+            findings.append(
+                Finding(
+                    rel_path=rel_path,
+                    line=_line_number(text, match.start()),
+                    rule=rule,
+                    snippet=match.group(0).strip(),
+                )
+            )
+    return findings
+
+
+def _iter_python_files(repo_root: Path, roots: tuple[str, ...]) -> list[Path]:
+    files: list[Path] = []
+    for root in roots:
+        root_path = repo_root / root
+        if not root_path.exists():
+            continue
+        files.extend(root_path.rglob("*.py"))
+    return sorted(set(files))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--roots",
+        nargs="*",
+        default=list(DEFAULT_ROOTS),
+        help="Relative roots to scan (default: web scripts tests).",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    roots = tuple(args.roots)
+    findings: list[Finding] = []
+
+    for file_path in _iter_python_files(repo_root, roots):
+        rel_path = file_path.relative_to(repo_root)
+        if rel_path in ALLOWLIST:
+            continue
+
+        text = file_path.read_text(encoding="utf-8", errors="replace")
+        findings.extend(_scan_file(rel_path, text))
+
+    if findings:
+        print(
+            "Legacy web_types references are not allowed outside compatibility files:"
+        )
+        for item in findings:
+            print(f"- {item.rel_path}:{item.line} [{item.rule}] {item.snippet}")
+        return 1
+
+    print("No legacy web_types references detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/routes_generation.py
+++ b/web/routes_generation.py
@@ -111,12 +111,12 @@ def register_generation_routes(
                 current_dir = os.path.dirname(os.path.abspath(__file__))
 
                 spec = importlib.util.spec_from_file_location(
-                    "web_types", os.path.join(current_dir, "types.py")
+                    "web.types", os.path.join(current_dir, "types.py")
                 )
-                web_types = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(web_types)
+                web_types_module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(web_types_module)
 
-                validated_data = web_types.GenerateNewsletterRequest(**data)
+                validated_data = web_types_module.GenerateNewsletterRequest(**data)
             except (ValueError, Exception) as e:
                 print(f"❌ Validation error: {e}")
                 return jsonify({"error": f"Invalid request: {str(e)}"}), 400


### PR DESCRIPTION
## Summary (what / why)
- `web/routes_generation.py`에서 동적 타입 로딩 모듈명을 `web_types`에서 canonical `web.types`로 변경했습니다.
- `scripts/devtools/check_legacy_web_types_paths.py`를 추가해 legacy 타입 경로/모듈 참조(`web.web_types`, `web_types`)가 호환 허용 파일 외에 재유입되지 않도록 가드했습니다.
- CI의 `Guard legacy web_types paths` 단계와 Makefile 타깃을 새 가드 스크립트 기반으로 통일했습니다.
- Windows PyInstaller 가이드에 canonical 타입/가드 명령을 반영했습니다.

## Scope
- `.github/workflows/main-ci.yml`
- `Makefile`
- `web/routes_generation.py`
- `scripts/devtools/check_legacy_web_types_paths.py`
- `scripts/devtools/README.md`
- `docs/setup/PYINSTALLER_WINDOWS.md`

## Delivery Unit
- RR: #133
- Delivery Unit ID: DU-20260224-p1-types-canonical
- Merge Boundary: canonical `web.types` migration + legacy reference guard adoption in CI/Makefile/docs
- Rollback Boundary: revert merge commit of this PR to restore prior guard logic and module alias usage

## Test & Evidence
- Local:
  - `python scripts/devtools/check_legacy_web_types_paths.py`
  - `make legacy-web-types-guard`
  - `make check`
- PR CI:
  - `Code Quality & Security`
  - `Build Check (windows-latest)`

## Risk & Rollback
- Risk: 새 가드 패턴이 정상 케이스를 오탐지할 수 있음.
- Mitigation: allowlist를 `web/runtime_hook.py`, `tests/unit_tests/web/test_runtime_hook_bootstrap.py`로 제한해 호환 alias 구간만 허용.
- Rollback: PR 머지 후 문제 발생 시 merge commit revert 1건으로 원복 가능.

## Ops-Safety Addendum (if touching protected paths)
- Protected path 수정 없음 (`newsletter/security`, `scripts/ops_*`, `.github/workflows/deploy*.yml` 비대상).

## Not Run (with reason)
- GitHub branch protection rule 자체 변경: 리포지토리 관리자 설정 영역이라 코드 PR 범위에서 수행 불가.
