### PR TITLE
fix(release): trust self-signed dry-run cert on CI runner

### DIFF
--- a/docs/setup/WINDOWS_EXE_OPERATIONS.md
+++ b/docs/setup/WINDOWS_EXE_OPERATIONS.md
@@ -31,6 +31,7 @@
   2. certificate store에서 thumbprint 조회
   3. store에 없으면 `WINDOWS_OV_CERT_PFX_BASE64` + `WINDOWS_OV_CERT_PASSWORD`로 임시 import
   4. import 후 thumbprint 일치 확인
+  5. self-signed dry-run 인증서인 경우 CI runner에서 `CurrentUser\\Root`, `CurrentUser\\TrustedPublisher` 신뢰 저장소를 임시 보강
 - 2~4 과정 중 하나라도 실패하면 sign 단계로 넘어가지 않고 CI를 즉시 실패 처리합니다.
 
 #### 운영 준비 예시 (PFX -> GitHub Secret)

--- a/docs/setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md
+++ b/docs/setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md
@@ -44,6 +44,14 @@
 4. 대응:
    - `scripts/devtools/provision_windows_signing_cert.ps1`에서 단일/배열 반환을 모두 처리하도록 hotfix 적용
 
+## 2026-02-25 추가 업데이트
+
+1. main 머지 후 release dry-run 재실행: `22377306953` (`release/dry-run-20260225-4`)
+2. 실패 원인:
+   - `Sign Windows artifact (OV pilot)` 단계에서 `signtool verify /pa`가 self-signed dry-run 인증서를 신뢰 체인으로 검증하지 못해 실패
+3. 대응:
+   - `scripts/devtools/provision_windows_signing_cert.ps1`에서 self-signed 인증서 감지 시 CI runner `CurrentUser\\Root`, `CurrentUser\\TrustedPublisher` 저장소를 임시 보강하도록 수정
+
 ## 롤백 메모
 
 - branch protection 롤백: GitHub Branch Protection에서 대상 패턴의 required check/admin enforcement를 원복

--- a/scripts/devtools/provision_windows_signing_cert.ps1
+++ b/scripts/devtools/provision_windows_signing_cert.ps1
@@ -51,6 +51,48 @@ function Mask-Thumbprint {
     return "{0}...{1}" -f $normalized.Substring(0, 4), $normalized.Substring($normalized.Length - 4)
 }
 
+function Ensure-CertificateTrustForDryRun {
+    param([System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate)
+
+    if ($null -eq $Certificate) {
+        return
+    }
+
+    # Self-signed dry-run certificates are not trusted on fresh runners by default.
+    if ($Certificate.Subject -ne $Certificate.Issuer) {
+        return
+    }
+
+    $normalized = Normalize-Thumbprint $Certificate.Thumbprint
+    if ([string]::IsNullOrWhiteSpace($normalized)) {
+        return
+    }
+
+    Write-Host ("[SIGN-PROVISION] Self-signed certificate detected: {0}" -f (Mask-Thumbprint $normalized))
+
+    $runnerTemp = [System.Environment]::GetEnvironmentVariable("RUNNER_TEMP")
+    if ([string]::IsNullOrWhiteSpace($runnerTemp)) {
+        $runnerTemp = [System.IO.Path]::GetTempPath()
+    }
+    $cerPath = Join-Path $runnerTemp "windows-ov-signing-cert.cer"
+
+    try {
+        Export-Certificate -Cert $Certificate -FilePath $cerPath -Type CERT -Force | Out-Null
+        $trustStores = @("Cert:\CurrentUser\Root", "Cert:\CurrentUser\TrustedPublisher")
+        foreach ($store in $trustStores) {
+            $existing = Get-ChildItem -Path $store -ErrorAction SilentlyContinue |
+                Where-Object { (Normalize-Thumbprint $_.Thumbprint) -eq $normalized } |
+                Select-Object -First 1
+            if ($null -eq $existing) {
+                Import-Certificate -FilePath $cerPath -CertStoreLocation $store | Out-Null
+                Write-Host ("[SIGN-PROVISION] Added certificate to store: {0}" -f $store)
+            }
+        }
+    } finally {
+        Remove-Item -Path $cerPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
 $normalizedSha1 = Normalize-Thumbprint $CertSha1
 $hasPfx = -not [string]::IsNullOrWhiteSpace($PfxBase64)
 $required = $RequireSignature.IsPresent
@@ -120,6 +162,7 @@ if (-not [string]::IsNullOrWhiteSpace($normalizedSha1)) {
     if ($null -eq $resolvedCert) {
         throw ("Certificate not found after provisioning: {0}" -f (Mask-Thumbprint $normalizedSha1))
     }
+    Ensure-CertificateTrustForDryRun -Certificate $resolvedCert
     Write-Host ("[SIGN-PROVISION] Certificate ready: {0}" -f (Mask-Thumbprint $normalizedSha1))
 } elseif ($required) {
     throw "Signing is required but no certificate thumbprint is available."


### PR DESCRIPTION
## Summary (what / why)
- Fix release dry-run failure where `signtool verify /pa` rejects self-signed dry-run cert trust chain.
- Preserve strict signing verification behavior for normal OV certificate releases.

## Scope
- `scripts/devtools/provision_windows_signing_cert.ps1`
- `docs/setup/WINDOWS_EXE_OPERATIONS.md`
- `docs/setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md`

## Delivery Unit
- RR: #142
- Delivery Unit ID: DU-20260225-windows-selfsigned-trust-fix
- Merge Boundary: PR #143
- Rollback Boundary: revert commit `3f0ef97` (or revert PR #143)

## Test & Evidence
- Local gate: `make check` passed on branch `codex/windows-release-selfsigned-trust`.
- PR gate: `Build Check (windows-latest)` running on PR #143.
- Failure evidence captured: release dry-run run `22377306953` failed at signing verification due untrusted self-signed root.

## Risk & Rollback
- Risk: release-path certificate provisioning behavior change.
- Guardrail: trust-store bootstrap executes only when certificate is self-signed (`Subject == Issuer`).
- Rollback: revert commit `3f0ef97` and rerun CI.

## Ops-Safety Addendum (if touching protected paths)
- No GitHub admin controls (branch protection, secrets, variables) changed by this PR.
- Changes are repository code/docs only; protected-path runtime behavior remains CI-gated.

## Not Run (with reason)
- Production OV certificate end-to-end signing not run here because production cert material and operator context are not available in this branch validation.
