### PR TITLE
docs(release): record solo main review policy

### DIFF
--- a/docs/setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md
+++ b/docs/setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md
@@ -89,8 +89,8 @@
 
 1. 최신 `main` 재점검:
    - HEAD: `ae45c62` (`chore(ci): clarify agent guidance and delivery unit policy (#151)`)
-2. 운영 drift 발견:
-   - `main` branch protection의 `requiredApprovingReviewCount`가 `0`으로 풀려 있었음
+2. 운영 상태 점검:
+   - `main` branch protection의 `requiredApprovingReviewCount`가 `0`으로 설정되어 있었음
 3. 즉시 대응:
    - `main` rule (`BPR_kwDOOnCa4M4EXTTS`)을 `requiredApprovingReviewCount=1`로 원복
    - 원복 후 GraphQL 재조회로 rule 상태 재검증 완료
@@ -100,6 +100,16 @@
 5. 여전히 남은 운영 과제:
    - `WINDOWS_OV_CERT_SHA1`, `WINDOWS_OV_CERT_PFX_BASE64`, `WINDOWS_OV_CERT_PASSWORD`는 실제 운영 OV 인증서 값으로 교체되지 않았음
    - 현재 repo secret 등록 시각은 `2026-02-25 00:33 UTC` 기준이며, dry-run 인증서 교체 후 release dry-run 1회 재검증이 필요
+
+## 2026-03-07 추가 업데이트 2
+
+1. 운영 기준 재확인:
+   - 현재 저장소는 solo-developer 모드로 운영 중이므로 `main`의 `requiredApprovingReviewCount`는 `0`으로 유지
+2. 정책 반영:
+   - `main` rule (`BPR_kwDOOnCa4M4EXTTS`)을 다시 `requiredApprovingReviewCount=0`으로 조정
+3. 최종 확인:
+   - `main`: `required check=Build Check (windows-latest)`, `requiredApprovingReviewCount=0`, `isAdminEnforced=true`, `allowsDeletions=false`
+   - `release`, `release/*`: `required check=Build Check (windows-latest)`, `requiredApprovingReviewCount=1`, `isAdminEnforced=true`, `allowsDeletions=false`
 
 ## 롤백 메모
 


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Log the latest `main` branch-protection review and the final solo-developer policy for `main`
- Keep the Windows release admin log aligned with the actual GitHub branch protection state after confirming `main.requiredApprovingReviewCount=0`

## Scope
### In Scope
- Add GraphQL re-check evidence to the Windows release admin log
- Record the final branch-protection policy split: `main=0`, `release/release/*=1`
- Align the March 7 admin log wording with the confirmed operating mode

### Out of Scope
- Replacing `WINDOWS_OV_CERT_*` with real OV production values
- Running a new release dry-run

## Delivery Unit
- RR: #152
- Delivery Unit ID: DU-20260307-main-review-gate-restore
- Merge Boundary: docs/setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md only
- Rollback Boundary: revert commits `8987de8`, `c97d476`, and `404a9e1`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [ ] Additional tests (if needed): not needed for docs-only change

### Commands and Results
```bash
make check
# RESULT: PASSED (preflight), docs-check completed, skills-check completed, check completed
make check-full
# RESULT: PASSED (preflight), docs-check completed, skills-check completed, check-full completed
gh api graphql ... branchProtectionRules ...
# RESULT: main.requiredApprovingReviewCount=0, release/release/*=1,
#         required check Build Check (windows-latest), isAdminEnforced=true
```

## Risk & Rollback
- Risk: low-risk docs/admin evidence update only; the admin change is limited to `main.requiredApprovingReviewCount=0` for solo development
- Rollback: revert this PR and, if collaboration mode changes, update branch protection via GitHub GraphQL back to the desired review count

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: N/A
- Outbox/send_key 중복 방지 결과: N/A
- import-time side effect 제거 여부: N/A

## Not Run (with reason)
- No extra ops-safety pytest set, because protected runtime paths were not changed
