### PR TITLE
docs(release): record wrap-up backlog

### DIFF
--- a/docs/setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md
+++ b/docs/setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md
@@ -124,6 +124,16 @@
    - 실제 운영 OV 인증서 원본이 현재 작업 환경에 없어서 `WINDOWS_OV_CERT_*` 교체와 release dry-run 재검증은 이번 차수에서 진행 불가
    - 실제 완료를 위해서는 운영 OV `.pfx`, 비밀번호, 기대 thumbprint를 안전한 경로로 별도 제공받아야 함
 
+## 2026-03-07 추가 업데이트 4
+
+1. 후속 작업 backlog 고정:
+   - 운영 OV `.pfx`, 비밀번호, 기대 thumbprint를 안전한 경로로 확보
+   - `WINDOWS_OV_CERT_SHA1`, `WINDOWS_OV_CERT_PFX_BASE64`, `WINDOWS_OV_CERT_PASSWORD`를 실제 운영값으로 교체
+   - release 브랜치에서 dry-run 1회 재실행 후 `sign -> smoke -> update-manifest -> checksum/validate` 전 단계 통과 증적 추가
+2. 차수 종료 정리:
+   - 저장소 변경사항은 admin log 기준으로 `main`에 반영 완료
+   - 로컬 생성 산출물(`artifacts/`)과 병합 완료 작업 브랜치는 이번 차수 종료 시점에 정리 대상
+
 ## 롤백 메모
 
 - branch protection 롤백: GitHub Branch Protection에서 대상 패턴의 required check/admin enforcement를 원복


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Record the remaining Windows release follow-up tasks in the admin log
- Close the current delivery unit with an explicit backlog and cleanup note

## Scope
### In Scope
- Add a final March 7 wrap-up section to the Windows release admin log
- Record the exact remaining OV-certificate follow-up tasks
- Record the local cleanup target for generated artifacts and merged work branches

### Out of Scope
- Replacing `WINDOWS_OV_CERT_*` with actual OV values
- Running a new release dry-run
- Any workflow or release script changes

## Delivery Unit
- RR: #156
- Delivery Unit ID: DU-20260307-windows-release-wrapup
- Merge Boundary: docs/setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md only
- Rollback Boundary: revert commit `8f8f1bf`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [ ] Additional tests (if needed): not needed for docs-only change

### Commands and Results
```bash
make check
# RESULT: PASSED
make check-full
# RESULT: PASSED
git status --short --branch
# RESULT: only local generated `artifacts/` remains untracked before final cleanup
```

## Risk & Rollback
- Risk: low-risk docs-only update; no runtime or release workflow changes
- Rollback: revert this PR if the follow-up backlog wording needs to be revised

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: N/A
- Outbox/send_key 중복 방지 결과: N/A
- import-time side effect 제거 여부: N/A

## Not Run (with reason)
- No release dry-run was run in this delivery unit because the actual OV `.pfx`, password, and expected thumbprint remain unavailable
