### PR TITLE
fix(web): restore preview and run-now actions

### DIFF
--- a/tests/unit_tests/test_web_preview_and_run_now_routes.py
+++ b/tests/unit_tests/test_web_preview_and_run_now_routes.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from flask import Flask
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+import routes_generation  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def _build_generation_app(database_path: str) -> Flask:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    routes_generation.register_generation_routes(
+        app=app,
+        database_path=database_path,
+        newsletter_cli=object(),
+        in_memory_tasks={},
+        task_queue=None,
+        redis_conn=None,
+    )
+    return app
+
+
+def test_generate_route_accepts_preview_only_field(tmp_path: Path) -> None:
+    app = _build_generation_app(str(tmp_path / "storage.db"))
+
+    with app.test_client() as client:
+        response = client.post(
+            "/api/generate",
+            data=json.dumps(
+                {
+                    "keywords": ["AI", "robotics"],
+                    "preview_only": True,
+                }
+            ),
+            content_type="application/json",
+        )
+
+    assert response.status_code == 202
+    payload = response.get_json()
+    assert payload is not None
+    assert payload["status"] == "processing"
+    assert payload["deduplicated"] is False
+
+
+def test_schedule_run_now_executes_scheduled_job(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database_path = str(tmp_path / "storage.db")
+    app = _build_generation_app(database_path)
+
+    observed: dict[str, Any] = {}
+
+    def fake_generate_newsletter_task(
+        data: dict[str, Any],
+        job_id: str,
+        send_email: bool = False,
+        idempotency_key: str | None = None,
+        database_path: str | None = None,
+    ) -> dict[str, Any]:
+        observed["data"] = data
+        observed["job_id"] = job_id
+        observed["send_email"] = send_email
+        observed["idempotency_key"] = idempotency_key
+        observed["database_path"] = database_path
+        return {
+            "status": "success",
+            "html_content": "<html><body>ok</body></html>",
+            "title": "Scheduled Newsletter",
+            "generation_stats": {},
+            "input_params": data,
+            "error": None,
+            "sent": False,
+            "email_sent": False,
+        }
+
+    monkeypatch.setattr(
+        routes_generation, "generate_newsletter_task", fake_generate_newsletter_task
+    )
+
+    with app.test_client() as client:
+        create_response = client.post(
+            "/api/schedule",
+            data=json.dumps(
+                {
+                    "keywords": ["AI", "robotics"],
+                    "email": "test@example.com",
+                    "rrule": "FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=9;BYMINUTE=0",
+                }
+            ),
+            content_type="application/json",
+        )
+        created_payload = create_response.get_json()
+        assert create_response.status_code == 201
+        assert created_payload is not None
+
+        schedule_id = created_payload["schedule_id"]
+        run_response = client.post(f"/api/schedule/{schedule_id}/run")
+
+    assert run_response.status_code == 200
+    run_payload = run_response.get_json()
+    assert run_payload is not None
+    assert run_payload["status"] == "completed"
+    assert run_payload["job_id"].startswith(f"schedule_{schedule_id}_")
+    assert run_payload["result"]["title"] == "Scheduled Newsletter"
+    assert observed["send_email"] is True
+    assert observed["database_path"] == database_path
+    assert observed["data"]["email"] == "test@example.com"

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -129,13 +129,21 @@ class NewsletterApp {
     }
 
     async generateNewsletter() {
-        const data = this.collectFormData();
+        const data = this.collectFormData({ includeSchedule: true, includeEmail: true });
         if (!data) return;
 
         if (data.schedule) {
             await this.createSchedule(data);
             return;
         }
+
+        await this.submitGeneration(data);
+    }
+
+    async submitGeneration(data) {
+        const requestData = { ...data };
+        delete requestData.schedule;
+        delete requestData.rrule;
 
         this.showProgress();
 
@@ -145,7 +153,7 @@ class NewsletterApp {
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify(data)
+                body: JSON.stringify(requestData)
             });
 
             const result = await response.json();
@@ -196,18 +204,16 @@ class NewsletterApp {
     }
 
     async previewNewsletter() {
-        // Similar to generate but without email sending
-        const data = this.collectFormData();
+        const data = this.collectFormData({ includeSchedule: false, includeEmail: false });
         if (!data) return;
 
-        // Remove email from preview
-        delete data.email;
         data.preview_only = true;
-
-        this.generateNewsletter();
+        await this.submitGeneration(data);
     }
 
-    collectFormData() {
+    collectFormData(options = {}) {
+        const includeSchedule = options.includeSchedule !== false;
+        const includeEmail = options.includeEmail !== false;
         const method = document.querySelector('input[name="inputMethod"]:checked').value;
         const data = {};
 
@@ -228,13 +234,13 @@ class NewsletterApp {
         }
 
         const email = document.getElementById('email').value.trim();
-        if (email) {
+        if (includeEmail && email) {
             data.email = email;
         }
 
         // Schedule data
         const enableSchedule = document.getElementById('enableSchedule').checked;
-        if (enableSchedule) {
+        if (includeSchedule && enableSchedule) {
             if (!email) {
                 this.showError('예약 발송을 위해서는 이메일 주소가 필요합니다.');
                 return null;
@@ -266,6 +272,7 @@ class NewsletterApp {
     }
 
     showProgress() {
+        this.stopPolling();
         document.getElementById('progressSection').classList.remove('hidden');
         document.getElementById('resultsSection').classList.add('hidden');
 
@@ -692,6 +699,7 @@ class NewsletterApp {
 
             if (response.ok) {
                 this.loadSchedules(); // Reload schedules
+                this.showSuccess('예약이 취소되었습니다.');
             } else {
                 const result = await response.json();
                 alert('취소 실패: ' + (result.error || 'Unknown error'));
@@ -702,8 +710,38 @@ class NewsletterApp {
     }
 
     async runScheduleNow(scheduleId) {
-        // This would trigger immediate execution of a scheduled newsletter
-        alert('즉시 실행 기능은 추후 구현됩니다.');
+        try {
+            const response = await fetch(`/api/schedule/${scheduleId}/run`, {
+                method: 'POST'
+            });
+
+            const result = await response.json();
+
+            if (!response.ok) {
+                this.showError(result.error || 'Immediate execution failed');
+                return;
+            }
+
+            this.switchTab('generateTab');
+
+            if (result.status === 'completed' && result.result) {
+                result.result.job_id = result.job_id;
+                this.currentJobId = result.job_id;
+                this.showResults(result.result);
+                this.showSuccess('예약 작업이 즉시 실행되었습니다.');
+            } else if (result.status === 'queued' && result.job_id) {
+                this.currentJobId = result.job_id;
+                this.showProgress();
+                this.startPolling(result.job_id);
+                this.showSuccess('예약 작업이 큐에 등록되었습니다.');
+            } else {
+                this.showSuccess('예약 작업 실행이 요청되었습니다.');
+            }
+
+            this.loadSchedules();
+        } catch (error) {
+            this.showError('Network error: ' + error.message);
+        }
     }
 
     async viewHistoryItem(itemId) {


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Restore preview-only requests and schedule run-now actions on top of the schedule-submit branch.

## Scope
### In Scope
- Send preview requests as `preview_only` generate calls
- Connect schedule run-now button to `/api/schedule/<id>/run`
- Prevent overlapping polling on repeated actions
- Add preview/run-now regression tests

### Out of Scope
- Schedule creation flow changes
- Schedule edit/pause/resume features

## Delivery Unit
- RR: #161
- Delivery Unit ID: DU-20260307-preview-run-now
- Merge Boundary: `codex/feat-web-schedule-submit`
- Rollback Boundary: Restore placeholder run-now behavior and legacy preview flow

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): `node --check web/static/js/app.js`, `pytest tests/unit_tests/test_web_preview_and_run_now_routes.py -q`

### Commands and Results
```bash
node --check /Users/hojungjung/development/newsletter-generator-rr04/web/static/js/app.js
# pass

MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com /Users/hojungjung/development/newsletter-generator/.venv/bin/python -m pytest tests/unit_tests/test_web_preview_and_run_now_routes.py -q
# 2 passed

make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr04 check
# ✅ check 완료

make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr04 check-full
# ✅ check-full 완료
```

## Risk & Rollback
- Risk: Preview and immediate execution now change frontend state more aggressively and rely on API response variants.
- Rollback: Revert the preview/request helper changes and restore the placeholder run-now path.

## Ops-Safety Addendum (if touching protected paths)
- Not applicable. Protected ops-safety paths were not modified.

## Not Run (with reason)
- None.
