### PR TITLE
fix(web): gate debug helper routes by environment

### DIFF
--- a/tests/unit_tests/test_web_ops_route_controls.py
+++ b/tests/unit_tests/test_web_ops_route_controls.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+import routes_ops  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def test_ops_routes_are_disabled_by_default(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("ENABLE_DEBUG_ROUTES", raising=False)
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.delenv("FLASK_ENV", raising=False)
+
+    app = Flask(__name__)
+    routes_ops.register_ops_routes(app, str(tmp_path / "storage.db"))
+
+    registered_routes = {rule.rule for rule in app.url_map.iter_rules()}
+    assert "/debug/history-table" not in registered_routes
+    assert "/debug/clear-pending" not in registered_routes
+    assert "/test" not in registered_routes
+    assert "/manual-test" not in registered_routes
+
+
+def test_ops_routes_are_enabled_for_testing_app(tmp_path: Path) -> None:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    routes_ops.register_ops_routes(app, str(tmp_path / "storage.db"))
+
+    registered_routes = {rule.rule for rule in app.url_map.iter_rules()}
+    assert "/debug/history-table" in registered_routes
+    assert "/debug/clear-pending" in registered_routes
+    assert "/test" in registered_routes
+    assert "/manual-test" in registered_routes

--- a/web/routes_ops.py
+++ b/web/routes_ops.py
@@ -7,8 +7,33 @@ from flask import Flask, jsonify, render_template
 from flask.typing import ResponseReturnValue
 
 
-def register_ops_routes(app: Flask, database_path: str) -> None:
+def _should_enable_debug_routes(
+    app: Flask, enable_debug_routes: bool | None = None
+) -> bool:
+    """Return whether debug/test helper routes should be exposed."""
+    if enable_debug_routes is not None:
+        return enable_debug_routes
+
+    override = os.getenv("ENABLE_DEBUG_ROUTES")
+    if override is not None:
+        return override.strip().lower() in {"1", "true", "yes", "on"}
+
+    if app.config.get("TESTING"):
+        return True
+
+    app_env = os.getenv("APP_ENV", "").strip().lower()
+    flask_env = os.getenv("FLASK_ENV", "").strip().lower()
+    return app_env == "development" or flask_env == "development"
+
+
+def register_ops_routes(
+    app: Flask,
+    database_path: str,
+    enable_debug_routes: bool | None = None,
+) -> None:
     """Register operational routes on the given Flask app."""
+    if not _should_enable_debug_routes(app, enable_debug_routes):
+        return
 
     @app.route("/debug/history-table")  # type: ignore[untyped-decorator]
     def debug_history_table() -> ResponseReturnValue:


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Gate Flask debug/test/manual helper routes so they are hidden by default in production-safe environments.

## Scope
### In Scope
- Environment-based gating for `web/routes_ops.py`
- Regression tests for default-disabled and testing-enabled route registration

### Out of Scope
- AuthN/AuthZ changes
- Scheduler/email runtime changes

## Delivery Unit
- RR: #160
- Delivery Unit ID: DU-20260307-debug-route-gating
- Merge Boundary: `main`
- Rollback Boundary: Re-enable route registration via `ENABLE_DEBUG_ROUTES=1` or revert the route guard

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): `pytest tests/unit_tests/test_web_ops_route_controls.py -q`

### Commands and Results
```bash
MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com /Users/hojungjung/development/newsletter-generator/.venv/bin/python -m pytest tests/unit_tests/test_web_ops_route_controls.py -q
# 2 passed

make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr01 check
# ✅ check 완료

make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr01 check-full
# ✅ check-full 완료
```

## Risk & Rollback
- Risk: Local/manual helper routes are no longer exposed unless explicitly enabled.
- Rollback: Set `ENABLE_DEBUG_ROUTES=1` in non-production environments or revert this PR.

## Ops-Safety Addendum (if touching protected paths)
- Not applicable. Protected ops-safety paths were not modified.

## Not Run (with reason)
- None.
