### PR TITLE
refactor(settings): lazy-load legacy config shims

### DIFF
--- a/newsletter/config.py
+++ b/newsletter/config.py
@@ -1,96 +1,68 @@
-import os
+"""Lazy compatibility layer for legacy config imports.
+
+New runtime code should prefer `newsletter_core.public.settings`.
+"""
+
+from __future__ import annotations
+
 from typing import Any
 
-from .config_manager import config_manager
+from newsletter_core.public.settings import (
+    get_all_major_news_sources,
+    get_config_manager,
+    get_llm_config,
+    get_major_news_sources,
+    get_settings,
+)
+
+_CONFIG_MANAGER_FIELDS = {
+    "ADDITIONAL_RSS_FEEDS",
+    "ANTHROPIC_API_KEY",
+    "EMAIL_SENDER",
+    "GEMINI_API_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_CLIENT_ID",
+    "GOOGLE_CLIENT_SECRET",
+    "NAVER_CLIENT_ID",
+    "NAVER_CLIENT_SECRET",
+    "OPENAI_API_KEY",
+    "POSTMARK_SERVER_TOKEN",
+    "SERPER_API_KEY",
+}
+
+__all__ = sorted(
+    _CONFIG_MANAGER_FIELDS
+    | {
+        "ALL_MAJOR_NEWS_SOURCES",
+        "LLM_CONFIG",
+        "MAJOR_NEWS_SOURCES",
+        "MOCK_MODE",
+    }
+)
 
 
 def _cfg(name: str, default: Any = None) -> Any:
-    """Safely read lazy ConfigManager attributes during partial initialization."""
+    """Safely read compatibility attributes from the lazy config manager."""
     try:
-        return getattr(config_manager, name)
+        return getattr(get_config_manager(), name)
     except AttributeError:
         return default
 
 
-# 하위 호환성을 위한 변수들 (ConfigManager에서 가져옴)
-SERPER_API_KEY = _cfg("SERPER_API_KEY")
-GEMINI_API_KEY = _cfg("GEMINI_API_KEY")
-OPENAI_API_KEY = _cfg("OPENAI_API_KEY")
-ANTHROPIC_API_KEY = _cfg("ANTHROPIC_API_KEY")
-GOOGLE_APPLICATION_CREDENTIALS = _cfg("GOOGLE_APPLICATION_CREDENTIALS")
-NAVER_CLIENT_ID = _cfg("NAVER_CLIENT_ID")
-NAVER_CLIENT_SECRET = _cfg("NAVER_CLIENT_SECRET")
-ADDITIONAL_RSS_FEEDS = _cfg("ADDITIONAL_RSS_FEEDS", "")
-
-# 이메일 발송 설정 (Postmark 사용)
-POSTMARK_SERVER_TOKEN = _cfg("POSTMARK_SERVER_TOKEN")
-EMAIL_SENDER = _cfg("EMAIL_SENDER")
-
-# Google Drive 설정
-GOOGLE_CLIENT_ID = _cfg("GOOGLE_CLIENT_ID")
-GOOGLE_CLIENT_SECRET = _cfg("GOOGLE_CLIENT_SECRET")
-
-# LLM 설정
-LLM_CONFIG = config_manager.get_llm_config()
-
-# 주요 언론사 설정
-MAJOR_NEWS_SOURCES = config_manager.get_major_news_sources()
-
-# 호환성을 위한 flat한 주요 언론사 목록 (tier1 + tier2)
-ALL_MAJOR_NEWS_SOURCES = MAJOR_NEWS_SOURCES["tier1"] + MAJOR_NEWS_SOURCES["tier2"]
+def __getattr__(name: str) -> Any:
+    if name in _CONFIG_MANAGER_FIELDS:
+        default = "" if name == "ADDITIONAL_RSS_FEEDS" else None
+        return _cfg(name, default)
+    if name == "LLM_CONFIG":
+        return get_llm_config()
+    if name == "MAJOR_NEWS_SOURCES":
+        return get_major_news_sources()
+    if name == "ALL_MAJOR_NEWS_SOURCES":
+        return get_all_major_news_sources()
+    if name == "MOCK_MODE":
+        return bool(get_settings().mock_mode)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-# 경고 메시지 출력 (ConfigManager에서 처리하므로 간소화)
-def log_message(level: str, message: str) -> None:
-    """Startup-safe logging for environments without UTF-8 console support."""
-    print(f"[{level.upper()}] {message}")
-
-
-# 필수 API 키 검증
-if not SERPER_API_KEY:
-    log_message("warning", "Warning: SERPER_API_KEY not found in .env file.")
-if not GEMINI_API_KEY:
-    log_message(
-        "warning",
-        "Warning: GEMINI_API_KEY not found in .env file. Gemini-based features may not work.",
-    )
-
-# 새로 추가된 LLM API 키 경고
-if not OPENAI_API_KEY:
-    log_message(
-        "info",
-        "Note: OPENAI_API_KEY not found in .env file. OpenAI/ChatGPT features will be disabled.",
-    )
-if not ANTHROPIC_API_KEY:
-    log_message(
-        "info",
-        "Note: ANTHROPIC_API_KEY not found in .env file. Anthropic/Claude features will be disabled.",
-    )
-
-# 선택적 API 키
-if not GOOGLE_APPLICATION_CREDENTIALS:
-    log_message(
-        "warning",
-        "Warning: GOOGLE_APPLICATION_CREDENTIALS not found in .env file. Google Drive upload will not work.",
-    )
-
-# Postmark 설정 경고
-if not POSTMARK_SERVER_TOKEN:
-    log_message(
-        "warning",
-        "Warning: POSTMARK_SERVER_TOKEN not found in .env file. Email sending will not work.",
-    )
-
-# 새로 추가된 API 키에 대한 경고 (선택적)
-if not NAVER_CLIENT_ID or not NAVER_CLIENT_SECRET:
-    log_message(
-        "info",
-        "Note: Naver News API credentials not found. Naver News API source will be disabled.",
-    )
-
-# Mock 모드 설정 - 환경 변수에서 로드, 기본값은 False
-MOCK_MODE = os.getenv("MOCK_MODE", "false").lower() == "true"
-if MOCK_MODE:
-    log_message(
-        "warning", "Running in MOCK MODE - using sample data instead of real API calls"
-    )
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/newsletter_core/public/settings.py
+++ b/newsletter_core/public/settings.py
@@ -3,6 +3,27 @@
 from __future__ import annotations
 
 from newsletter.centralized_settings import get_settings
-from newsletter.config_manager import config_manager
+from newsletter.config_manager import config_manager, get_config_manager
 
-__all__ = ["config_manager", "get_settings"]
+
+def get_llm_config() -> dict:
+    return get_config_manager().get_llm_config()
+
+
+def get_major_news_sources() -> dict:
+    return get_config_manager().get_major_news_sources()
+
+
+def get_all_major_news_sources() -> list:
+    sources = get_major_news_sources()
+    return [*sources["tier1"], *sources["tier2"]]
+
+
+__all__ = [
+    "config_manager",
+    "get_all_major_news_sources",
+    "get_config_manager",
+    "get_llm_config",
+    "get_major_news_sources",
+    "get_settings",
+]

--- a/tests/unit_tests/test_config_import_side_effects.py
+++ b/tests/unit_tests/test_config_import_side_effects.py
@@ -11,8 +11,10 @@ import pytest
 
 def _clear_module_cache() -> None:
     prefixes = (
+        "newsletter.config",
         "newsletter.config_manager",
         "newsletter.centralized_settings",
+        "newsletter_core.public.settings",
     )
     for name in list(sys.modules):
         if name.startswith(prefixes):
@@ -49,3 +51,54 @@ def test_centralized_settings_import_does_not_call_load_dotenv(
     _clear_module_cache()
     importlib.import_module("newsletter.centralized_settings")
     assert calls["count"] == 0
+
+
+@pytest.mark.unit
+def test_legacy_config_import_is_lazy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_module_cache()
+    config_manager_module = importlib.import_module("newsletter.config_manager")
+    calls = {"count": 0}
+
+    def _fake_init(self) -> None:
+        calls["count"] += 1
+        self._initialized = True
+
+    monkeypatch.setattr(config_manager_module.ConfigManager, "__init__", _fake_init)
+    importlib.import_module("newsletter.config")
+    assert calls["count"] == 0
+
+
+@pytest.mark.unit
+def test_legacy_config_attributes_resolve_through_public_accessors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _DummyConfigManager:
+        SERPER_API_KEY = "serper-test-key"
+        ADDITIONAL_RSS_FEEDS = "https://example.com/rss.xml"
+
+        def get_llm_config(self) -> dict:
+            return {"default_provider": "gemini"}
+
+        def get_major_news_sources(self) -> dict:
+            return {"tier1": ["A"], "tier2": ["B"]}
+
+    class _DummySettings:
+        mock_mode = True
+
+    _clear_module_cache()
+    public_settings = importlib.import_module("newsletter_core.public.settings")
+    monkeypatch.setattr(
+        public_settings, "get_config_manager", lambda: _DummyConfigManager()
+    )
+    monkeypatch.setattr(public_settings, "get_settings", lambda: _DummySettings())
+
+    legacy_config = importlib.import_module("newsletter.config")
+
+    assert legacy_config.SERPER_API_KEY == "serper-test-key"
+    assert legacy_config.ADDITIONAL_RSS_FEEDS == "https://example.com/rss.xml"
+    assert legacy_config.LLM_CONFIG == {"default_provider": "gemini"}
+    assert legacy_config.MAJOR_NEWS_SOURCES == {"tier1": ["A"], "tier2": ["B"]}
+    assert legacy_config.ALL_MAJOR_NEWS_SOURCES == ["A", "B"]
+    assert legacy_config.MOCK_MODE is True


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Replace eager `newsletter.config` globals with lazy compatibility accessors so runtime config stays anchored on `newsletter/centralized_settings.py`.
- Expose shared config access helpers from `newsletter_core/public/settings.py` for runtime adapters and future cleanup work.

## Scope
### In Scope
- Lazy compatibility access for legacy `newsletter.config` imports.
- Canonical public settings helpers for config-manager derived values.
- Regression coverage for lazy import behavior and derived config access.

### Out of Scope
- Removing legacy config-manager fallback paths.
- CLI or LLM provider import-side-effect cleanup.

## Delivery Unit
- RR: #166
- Delivery Unit ID: DU-20260308-settings-ssot-stage1
- Merge Boundary: This PR only covers settings accessor unification and lazy legacy config access.
- Rollback Boundary: Revert this PR to restore eager `newsletter.config` constants.

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): `tests/unit_tests/test_config_import_side_effects.py`, `tests/unit_tests/test_config_manager.py`, `tests/test_config_fix.py`

### Commands and Results
```bash
./.venv/bin/python -m pytest tests/unit_tests/test_config_import_side_effects.py tests/unit_tests/test_config_manager.py tests/test_config_fix.py -q
# 24 passed

MOCK_MODE=true TESTING=1 ./.venv/bin/python -m pytest tests/unit_tests/test_config_import_side_effects.py -q
# 4 passed

make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr05 check
# pass

make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr05 check-full
# pass
```

## Risk & Rollback
- Risk: legacy callers that implicitly relied on eager module initialization now read through lazy accessors.
- Rollback: revert this PR.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 변경 없음.
- Outbox/send_key 중복 방지 결과: 변경 없음.
- import-time side effect 제거 여부: `newsletter.config`의 eager config expansion과 startup warnings를 제거하고 lazy access로 대체했습니다.

## Not Run (with reason)
- `tests/unit_tests/test_centralized_settings.py`: existing expectation mismatch on optional Postmark validation is outside this PR scope.
