### PR TITLE
refactor(web): share email outbox send helper

### DIFF
--- a/tests/test_web_mail.py
+++ b/tests/test_web_mail.py
@@ -164,6 +164,44 @@ class TestWebMail:
         assert config["from_email_configured"] is False
         assert config["ready"] is False
 
+    def test_get_newsletter_subject_prefers_generated_title(self):
+        """Generated result title should win over keyword-derived fallback."""
+        from web.mail import get_newsletter_subject
+
+        subject = get_newsletter_subject(
+            result={"title": "Generated Weekly Brief"},
+            params={"keywords": ["AI", "ML"]},
+        )
+
+        assert subject == "Generated Weekly Brief"
+
+    @patch("web.mail.get_or_create_outbox_record", return_value="sent")
+    @patch("web.mail.is_feature_enabled", return_value=True)
+    @patch("web.mail.resolve_mail_send_callable")
+    def test_send_email_with_outbox_skips_previously_sent_email(
+        self,
+        mock_resolve_send_callable,
+        mock_feature_enabled,
+        mock_get_or_create_outbox_record,
+    ):
+        """Shared helper should short-circuit when the outbox already marked sent."""
+        from web.mail import send_email_with_outbox
+
+        result = send_email_with_outbox(
+            db_path=":memory:",
+            job_id="job-1",
+            to="test@example.com",
+            subject="Newsletter: AI",
+            html="<h1>Newsletter</h1>",
+        )
+
+        assert result["sent"] is True
+        assert result["skipped"] is True
+        assert result["send_key"].startswith("job-1:test@example.com:")
+        mock_feature_enabled.assert_called_once_with("WEB_OUTBOX_ENABLED", default=True)
+        mock_get_or_create_outbox_record.assert_called_once()
+        mock_resolve_send_callable.assert_not_called()
+
     @pytest.mark.skip(reason="Requires actual email service and may hit API limits")
     def test_send_test_email(self):
         """Test sending test email - skipped to avoid API calls"""

--- a/web/mail.py
+++ b/web/mail.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 from pathlib import Path
+from typing import Any, Callable, Dict, cast
 
 from postmarker.core import PostmarkClient
 from tenacity import retry, stop_after_attempt
@@ -12,15 +13,42 @@ project_root = Path(__file__).parent.parent
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
+_POSTMARK_TOKEN_PLACEHOLDERS = {
+    "your" + "_postmark_server_token_here",
+    "your" + "-postmark-server-token-here",
+}
 
-def _get_email_config():
+try:
+    from db_state import (
+        get_or_create_outbox_record,
+        hash_subject,
+        is_feature_enabled,
+        mark_outbox_failed,
+        mark_outbox_sent,
+    )
+except ImportError:
+    from web.db_state import (  # pragma: no cover
+        get_or_create_outbox_record,
+        hash_subject,
+        is_feature_enabled,
+        mark_outbox_failed,
+        mark_outbox_sent,
+    )
+
+
+def _get_email_config() -> tuple[str | None, str | None]:
     """이메일 설정을 동적으로 가져옵니다 (테스트 호환성 고려)"""
     try:
         # 1차 시도: Centralized Settings
         from newsletter_core.public.settings import get_settings
 
         settings = get_settings()
-        return settings.postmark_server_token.get_secret_value(), settings.email_sender
+        return (
+            settings.postmark_server_token.get_secret_value()
+            if settings.postmark_server_token
+            else None,
+            settings.email_sender,
+        )
     except Exception:
         try:
             # 2차 시도: Config Manager
@@ -34,8 +62,85 @@ def _get_email_config():
             return postmark_token, email_sender
 
 
-@retry(stop=stop_after_attempt(3))
-def send_email(to: str, subject: str, html: str, **kwargs):
+def resolve_mail_send_callable() -> Callable[..., Any]:
+    return cast(Callable[..., Any], send_email)
+
+
+def generate_subject(params: Dict[str, Any]) -> str:
+    """Generate newsletter subject based on parameters."""
+    keywords = params.get("keywords")
+    domain = params.get("domain")
+
+    if keywords:
+        if isinstance(keywords, list):
+            return f"Newsletter: {', '.join(str(k) for k in keywords[:3])}"
+        return f"Newsletter: {keywords}"
+    if domain:
+        return f"Newsletter: {domain} Insights"
+    return "Your Newsletter"
+
+
+def get_newsletter_subject(
+    *, result: Dict[str, Any] | None = None, params: Dict[str, Any] | None = None
+) -> str:
+    """Prefer generated title and fall back to parameter-derived subject."""
+    if result:
+        title = result.get("title")
+        if isinstance(title, str) and title.strip():
+            return title
+    return generate_subject(params or {})
+
+
+def send_email_with_outbox(
+    *,
+    db_path: str,
+    job_id: str,
+    to: str,
+    subject: str,
+    html: str,
+    send_email_fn: Callable[..., Any] | None = None,
+) -> Dict[str, Any]:
+    """Send email with shared outbox/send_key duplicate prevention."""
+    outbox_enabled = is_feature_enabled("WEB_OUTBOX_ENABLED", default=True)
+    subject_hash = hash_subject(subject)
+    send_key = f"{job_id}:{to}:{subject_hash}"
+
+    if outbox_enabled:
+        outbox_status = get_or_create_outbox_record(
+            db_path=db_path,
+            send_key=send_key,
+            job_id=job_id,
+            recipient=to,
+            subject_hash=subject_hash,
+        )
+        if outbox_status == "sent":
+            return {"sent": True, "skipped": True, "send_key": send_key}
+
+    try:
+        send_fn = send_email_fn or resolve_mail_send_callable()
+        provider_response = send_fn(to=to, subject=subject, html=html)
+        provider_message_id = (
+            provider_response.get("MessageID")
+            if isinstance(provider_response, dict)
+            else None
+        )
+        if outbox_enabled:
+            mark_outbox_sent(
+                db_path=db_path,
+                send_key=send_key,
+                provider_message_id=provider_message_id,
+            )
+        return {"sent": True, "skipped": False, "send_key": send_key}
+    except Exception as exc:
+        if outbox_enabled:
+            mark_outbox_failed(
+                db_path=db_path, send_key=send_key, error_message=str(exc)
+            )
+        raise
+
+
+@retry(stop=stop_after_attempt(3))  # type: ignore[untyped-decorator]
+def send_email(to: str, subject: str, html: str, **kwargs: Any) -> Dict[str, Any]:
     """단일 수신자용 Postmark 발송 래퍼."""
     # 동적으로 설정 가져오기
     token, from_email = _get_email_config()
@@ -67,7 +172,7 @@ def send_email(to: str, subject: str, html: str, **kwargs):
         logging.info(
             f"이메일 발송 성공: {to} (Message ID: {response.get('MessageID', 'N/A')})"
         )
-        return response
+        return cast(Dict[str, Any], response)
 
     except Exception as e:
         error_msg = f"Postmark 이메일 발송 실패: {str(e)}"
@@ -75,21 +180,19 @@ def send_email(to: str, subject: str, html: str, **kwargs):
         raise RuntimeError(error_msg)
 
 
-def check_email_configuration():
+def check_email_configuration() -> Dict[str, bool]:
     """이메일 설정 상태를 확인합니다."""
     try:
         from newsletter_core.public.settings import config_manager
 
-        return config_manager.validate_email_config()
+        return cast(Dict[str, bool], config_manager.validate_email_config())
     except (ImportError, AttributeError):
         # Fallback 로직
         token, from_email = _get_email_config()
 
         return {
             "postmark_token_configured": bool(
-                token
-                and token != "your_postmark_server_token_here"
-                and token != "your-postmark-server-token-here"
+                token and token not in _POSTMARK_TOKEN_PLACEHOLDERS
             ),
             "from_email_configured": bool(
                 from_email
@@ -99,18 +202,14 @@ def check_email_configuration():
             "ready": bool(
                 token
                 and from_email
-                and token
-                not in [
-                    "your_postmark_server_token_here",
-                    "your-postmark-server-token-here",
-                ]
+                and token not in _POSTMARK_TOKEN_PLACEHOLDERS
                 and from_email
                 not in ["noreply@yourdomain.com", "your_verified_email@yourdomain.com"]
             ),
         }
 
 
-def send_test_email(to: str):
+def send_test_email(to: str) -> Dict[str, Any]:
     """테스트 이메일을 발송합니다."""
     import datetime
 
@@ -136,4 +235,7 @@ def send_test_email(to: str):
         token_masked=("***" + (token or "")[-4:] if token else "Not Set"),
     )
 
-    return send_email(to=to, subject="Newsletter Generator 테스트 이메일", html=test_html)
+    return cast(
+        Dict[str, Any],
+        send_email(to=to, subject="Newsletter Generator 테스트 이메일", html=test_html),
+    )

--- a/web/routes_send_email.py
+++ b/web/routes_send_email.py
@@ -3,40 +3,14 @@
 import json
 import logging
 import sqlite3
-from types import ModuleType
-from typing import cast
 
 from flask import Flask, jsonify, request
 from flask.typing import ResponseReturnValue
 
 try:
-    from db_state import (
-        get_or_create_outbox_record,
-        hash_subject,
-        is_feature_enabled,
-        mark_outbox_failed,
-        mark_outbox_sent,
-    )
+    from mail import get_newsletter_subject, send_email_with_outbox
 except ImportError:
-    from web.db_state import (  # pragma: no cover
-        get_or_create_outbox_record,
-        hash_subject,
-        is_feature_enabled,
-        mark_outbox_failed,
-        mark_outbox_sent,
-    )
-
-
-def _resolve_mail_module() -> ModuleType:
-    """Resolve mail module in both script and package execution modes."""
-    try:
-        import mail
-
-        return cast(ModuleType, mail)
-    except ImportError:
-        from . import mail  # pragma: no cover
-
-        return cast(ModuleType, mail)
+    from .mail import get_newsletter_subject, send_email_with_outbox  # pragma: no cover
 
 
 def register_send_email_route(app: Flask, database_path: str) -> None:
@@ -75,60 +49,25 @@ def register_send_email_route(app: Flask, database_path: str) -> None:
             if not html_content:
                 return jsonify({"error": "발송할 콘텐츠가 없습니다"}), 400
 
-            mail_module = _resolve_mail_module()
-
-            keywords = params.get("keywords", [])
-            if isinstance(keywords, str):
-                keywords = [keywords]
-
-            subject = (
-                f"Newsletter: {', '.join(keywords) if keywords else 'Your Newsletter'}"
+            subject = get_newsletter_subject(result=result, params=params)
+            send_result = send_email_with_outbox(
+                db_path=database_path,
+                job_id=job_id,
+                to=email,
+                subject=subject,
+                html=html_content,
             )
+            send_key = send_result["send_key"]
 
-            outbox_enabled = is_feature_enabled("WEB_OUTBOX_ENABLED", default=True)
-            send_key = f"{job_id}:{email}:{hash_subject(subject)}"
-
-            if outbox_enabled:
-                outbox_status = get_or_create_outbox_record(
-                    db_path=database_path,
-                    send_key=send_key,
-                    job_id=job_id,
-                    recipient=email,
-                    subject_hash=hash_subject(subject),
+            if send_result.get("skipped"):
+                return jsonify(
+                    {
+                        "success": True,
+                        "message": "이미 발송된 이메일입니다",
+                        "deduplicated": True,
+                        "send_key": send_key,
+                    }
                 )
-                if outbox_status == "sent":
-                    return jsonify(
-                        {
-                            "success": True,
-                            "message": "이미 발송된 이메일입니다",
-                            "deduplicated": True,
-                            "send_key": send_key,
-                        }
-                    )
-
-            try:
-                provider_response = mail_module.send_email(
-                    to=email, subject=subject, html=html_content
-                )
-                provider_message_id = (
-                    provider_response.get("MessageID")
-                    if isinstance(provider_response, dict)
-                    else None
-                )
-                if outbox_enabled:
-                    mark_outbox_sent(
-                        db_path=database_path,
-                        send_key=send_key,
-                        provider_message_id=provider_message_id,
-                    )
-            except Exception as send_exc:
-                if outbox_enabled:
-                    mark_outbox_failed(
-                        db_path=database_path,
-                        send_key=send_key,
-                        error_message=str(send_exc),
-                    )
-                raise
 
             return jsonify(
                 {

--- a/web/tasks.py
+++ b/web/tasks.py
@@ -7,7 +7,7 @@ import os
 import sqlite3
 import traceback
 from datetime import datetime, timedelta
-from typing import Any, Callable, Dict, cast
+from typing import Any, Dict
 
 from newsletter_core.public.generation import (
     GenerateNewsletterRequest,
@@ -16,84 +16,20 @@ from newsletter_core.public.generation import (
 )
 
 try:
-    from db_state import (
-        get_or_create_outbox_record,
-        hash_subject,
-        is_feature_enabled,
-        mark_outbox_failed,
-        mark_outbox_sent,
-        update_history_status,
-    )
+    from db_state import update_history_status
 except ImportError:
-    from web.db_state import (  # pragma: no cover
-        get_or_create_outbox_record,
-        hash_subject,
-        is_feature_enabled,
-        mark_outbox_failed,
-        mark_outbox_sent,
-        update_history_status,
-    )
+    from web.db_state import update_history_status  # pragma: no cover
+
+try:
+    from mail import get_newsletter_subject, send_email_with_outbox
+except ImportError:
+    from .mail import get_newsletter_subject, send_email_with_outbox  # pragma: no cover
 
 DATABASE_PATH = os.path.join(os.path.dirname(__file__), "storage.db")
 
 
 def _resolve_database_path(database_path: str | None) -> str:
     return database_path or DATABASE_PATH
-
-
-def _resolve_mail_send_callable() -> Callable[..., Any]:
-    try:
-        from mail import send_email as send_email_fn
-
-        return cast(Callable[..., Any], send_email_fn)
-    except ImportError:
-        from .mail import send_email as send_email_fn  # pragma: no cover
-
-        return cast(Callable[..., Any], send_email_fn)
-
-
-def _send_email_with_outbox(
-    db_path: str,
-    job_id: str,
-    to: str,
-    subject: str,
-    html: str,
-) -> Dict[str, Any]:
-    send_email_fn = _resolve_mail_send_callable()
-    outbox_enabled = is_feature_enabled("WEB_OUTBOX_ENABLED", default=True)
-    send_key = f"{job_id}:{to}:{hash_subject(subject)}"
-
-    if outbox_enabled:
-        outbox_status = get_or_create_outbox_record(
-            db_path=db_path,
-            send_key=send_key,
-            job_id=job_id,
-            recipient=to,
-            subject_hash=hash_subject(subject),
-        )
-        if outbox_status == "sent":
-            return {"sent": True, "skipped": True, "send_key": send_key}
-
-    try:
-        provider_response = send_email_fn(to=to, subject=subject, html=html)
-        provider_message_id = (
-            provider_response.get("MessageID")
-            if isinstance(provider_response, dict)
-            else None
-        )
-        if outbox_enabled:
-            mark_outbox_sent(
-                db_path=db_path,
-                send_key=send_key,
-                provider_message_id=provider_message_id,
-            )
-        return {"sent": True, "skipped": False, "send_key": send_key}
-    except Exception as exc:
-        if outbox_enabled:
-            mark_outbox_failed(
-                db_path=db_path, send_key=send_key, error_message=str(exc)
-            )
-        raise
 
 
 def _build_request(data: Dict[str, Any]) -> GenerateNewsletterRequest:
@@ -144,11 +80,11 @@ def generate_newsletter_task(
 
         if send_email and email:
             try:
-                send_result = _send_email_with_outbox(
+                send_result = send_email_with_outbox(
                     db_path=db_path,
                     job_id=job_id,
                     to=email,
-                    subject=result["title"],
+                    subject=get_newsletter_subject(result=result, params=data),
                     html=result["html_content"],
                 )
                 response["sent"] = True
@@ -211,20 +147,6 @@ def generate_newsletter_task(
             idempotency_key=idempotency_key,
         )
         raise
-
-
-def generate_subject(params: Dict[str, Any]) -> str:
-    """Generate newsletter subject based on parameters."""
-    keywords = params.get("keywords")
-    domain = params.get("domain")
-
-    if keywords:
-        if isinstance(keywords, list):
-            return f"Newsletter: {', '.join(str(k) for k in keywords[:3])}"
-        return f"Newsletter: {keywords}"
-    if domain:
-        return f"Newsletter: {domain} Insights"
-    return f"Newsletter - {datetime.now().strftime('%Y-%m-%d')}"
 
 
 def create_schedule_entry(params: Dict[str, Any], job_id: str) -> str:


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Consolidate web email send-key/outbox duplicate prevention in one helper.
- Make worker and `/api/send-email` route use the same subject resolution and outbox behavior.

## Scope
### In Scope
- Shared newsletter subject resolution and outbox-protected send helper in `web/mail.py`.
- Worker and send-email route refactor to use the shared helper.
- Regression coverage for helper behavior plus existing route contract.

### Out of Scope
- Email provider changes.
- Scheduler timezone or settings cleanup.

## Delivery Unit
- RR: #170
- Delivery Unit ID: DU-20260308-web-email-dedupe-service
- Merge Boundary: This PR only covers web email dedupe/service extraction.
- Rollback Boundary: Revert this PR to restore duplicated route/worker logic.

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): web email contract/unit tests plus ops-safety regression set

### Commands and Results
```bash
MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/contract/test_web_email_routes_contract.py tests/test_web_mail.py -q
# 14 passed, 3 skipped

MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/test_web_api.py -q
# 13 passed, 1 skipped

RUN_INTEGRATION_TESTS=1 MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/integration/test_schedule_execution.py -q
# 7 passed, 1 skipped

MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/unit_tests/test_schedule_time_sync.py tests/contract/test_web_email_routes_contract.py tests/unit_tests/test_config_import_side_effects.py -q
# 13 passed

make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr07 check
# pass

make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr07 check-full
# pass
```

## Risk & Rollback
- Risk: centralizing subject/send_key logic could alter dedupe semantics if one path relied on route-specific behavior.
- Rollback: revert this PR.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 변경 없음.
- Outbox/send_key 중복 방지 결과: worker와 send-email route가 동일 helper를 사용하도록 통합했고, existing contract + helper unit tests로 dedupe skip/sent paths를 고정했습니다.
- import-time side effect 제거 여부: 변경 없음.

## Not Run (with reason)
- No real email provider tests were run; verification stayed in mock/test mode.
