### PR TITLE
fix(web): normalize schedule route timestamps to utc

### DIFF
--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -5,6 +5,7 @@ Tests the Flask app with email functionality
 
 import json
 import os
+import sqlite3
 import sys
 import uuid
 
@@ -13,9 +14,38 @@ import pytest
 # Add project root to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from web.app import app  # noqa: E402
+from web.app import DATABASE_PATH, app  # noqa: E402
 
 pytestmark = [pytest.mark.api, pytest.mark.email]
+
+
+def _delete_schedule(schedule_id: str) -> None:
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM schedules WHERE id = ?", (schedule_id,))
+    conn.commit()
+    conn.close()
+
+
+def _insert_schedule_row(
+    *,
+    schedule_id: str,
+    params: dict,
+    rrule: str,
+    next_run: str,
+    created_at: str,
+) -> None:
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT OR REPLACE INTO schedules (id, params, rrule, next_run, created_at, enabled)
+        VALUES (?, ?, ?, ?, ?, 1)
+        """,
+        (schedule_id, json.dumps(params), rrule, next_run, created_at),
+    )
+    conn.commit()
+    conn.close()
 
 
 class TestWebAPI:
@@ -220,6 +250,61 @@ class TestWebAPI:
 
         result = json.loads(response.data)
         assert isinstance(result, list)
+
+    def test_schedule_creation_returns_utc_next_run(self, client):
+        schedule_id = None
+        response = client.post(
+            "/api/schedule",
+            data=json.dumps(
+                {
+                    "keywords": ["AI", "ML"],
+                    "email": "schedule@example.com",
+                    "rrule": "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+                }
+            ),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 201
+        result = json.loads(response.data)
+        schedule_id = result["schedule_id"]
+
+        try:
+            assert result["next_run"].endswith("Z")
+
+            conn = sqlite3.connect(DATABASE_PATH)
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT next_run FROM schedules WHERE id = ?", (schedule_id,)
+            )
+            stored_next_run = cursor.fetchone()[0]
+            conn.close()
+
+            assert stored_next_run.endswith("Z")
+        finally:
+            if schedule_id:
+                _delete_schedule(schedule_id)
+
+    def test_schedules_endpoint_normalizes_timestamp_fields_to_utc(self, client):
+        schedule_id = f"schedule-utc-{uuid.uuid4()}"
+        _insert_schedule_row(
+            schedule_id=schedule_id,
+            params={"keywords": ["AI"], "send_email": False},
+            rrule="FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+            next_run="2026-03-08 09:30:00",
+            created_at="2026-03-08 08:15:00",
+        )
+
+        try:
+            response = client.get("/api/schedules")
+            assert response.status_code == 200
+            schedules = json.loads(response.data)
+
+            matching = next(item for item in schedules if item["id"] == schedule_id)
+            assert matching["next_run"] == "2026-03-08T09:30:00Z"
+            assert matching["created_at"] == "2026-03-08T08:15:00Z"
+        finally:
+            _delete_schedule(schedule_id)
 
 
 if __name__ == "__main__":

--- a/web/routes_generation.py
+++ b/web/routes_generation.py
@@ -40,6 +40,16 @@ except ImportError:
         RealNewsletterCLI,
     )
 
+try:
+    from time_utils import get_utc_now, parse_sqlite_timestamp, to_iso_utc, to_utc
+except ImportError:
+    from web.time_utils import (  # pragma: no cover
+        get_utc_now,
+        parse_sqlite_timestamp,
+        to_iso_utc,
+        to_utc,
+    )
+
 
 def register_generation_routes(
     app: Flask,
@@ -64,6 +74,11 @@ def register_generation_routes(
             return newsletter_cli
         resolved = get_newsletter_cli()
         return resolved if resolved is not None else newsletter_cli
+
+    def _serialize_schedule_timestamp(value: str | None) -> str | None:
+        if not value:
+            return None
+        return to_iso_utc(parse_sqlite_timestamp(value))
 
     def run_in_memory_job(
         job_id: str,
@@ -600,11 +615,14 @@ def register_generation_routes(
             from dateutil.rrule import rrulestr
 
             rrule_str = data["rrule"]
-            rrule = rrulestr(rrule_str, dtstart=datetime.now())
-            next_run = rrule.after(datetime.now())
+            now_utc = get_utc_now()
+            rrule = rrulestr(rrule_str, dtstart=now_utc.replace(tzinfo=None))
+            next_run = rrule.after(now_utc.replace(tzinfo=None))
 
             if not next_run:
                 return jsonify({"error": "Invalid RRULE: no future occurrences"}), 400
+
+            next_run_utc = to_utc(next_run)
 
         except Exception as e:
             return jsonify({"error": f"Invalid RRULE: {str(e)}"}), 400
@@ -635,7 +653,7 @@ def register_generation_routes(
                 schedule_id,
                 json.dumps(schedule_params),
                 rrule_str,
-                next_run.isoformat(),
+                to_iso_utc(next_run_utc),
                 int(is_test),
                 expires_at,
             ),
@@ -648,7 +666,7 @@ def register_generation_routes(
                 {
                     "status": "scheduled",
                     "schedule_id": schedule_id,
-                    "next_run": next_run.isoformat(),
+                    "next_run": to_iso_utc(next_run_utc),
                 }
             ),
             201,
@@ -673,8 +691,8 @@ def register_generation_routes(
                     "id": schedule_id,
                     "params": json.loads(params) if params else None,
                     "rrule": rrule,
-                    "next_run": next_run,
-                    "created_at": created_at,
+                    "next_run": _serialize_schedule_timestamp(next_run),
+                    "created_at": _serialize_schedule_timestamp(created_at),
                     "enabled": bool(enabled),
                 }
             )
@@ -717,7 +735,7 @@ def register_generation_routes(
                 return jsonify({"error": "Schedule is disabled"}), 400
 
             params = json.loads(params_json)
-            intended_run_at = datetime.now()
+            intended_run_at = get_utc_now()
             idempotency_enabled = is_feature_enabled(
                 "WEB_IDEMPOTENCY_ENABLED", default=True
             )
@@ -727,7 +745,7 @@ def register_generation_routes(
             )
             if not idempotency_enabled:
                 idempotency_key = (
-                    f"schedule:{schedule_id}:{intended_run_at.isoformat()}"
+                    f"schedule:{schedule_id}:{to_iso_utc(intended_run_at)}"
                 )
             job_suffix = derive_job_id(idempotency_key, prefix="sched").split("_", 1)[1]
             immediate_job_id = f"schedule_{schedule_id}_{job_suffix}"


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Normalize schedule timestamps at the route layer so create/list/run-now paths use UTC `Z` values consistently with the scheduler runtime.

## Scope
### In Scope
- store and return `/api/schedule` `next_run` values in UTC ISO format
- normalize `/api/schedules` `next_run` and `created_at` fields before responding
- align run-now fallback idempotency key timestamps with UTC serialization
- add API regression tests for UTC persistence and response normalization

### Out of Scope
- schedule edit/pause/resume endpoints
- frontend timezone UX changes
- DB schema changes or data backfill

## Delivery Unit
- RR: #172
- Delivery Unit ID: DU-20260308-schedule-time-consistency
- Merge Boundary: this PR only changes schedule route serialization and its regression tests
- Rollback Boundary: revert commit `bf7b4f2`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed):

### Commands and Results
```bash
MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/test_web_api.py -q
# 15 passed, 1 skipped

MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/unit_tests/test_schedule_time_sync.py tests/contract/test_web_email_routes_contract.py tests/unit_tests/test_config_import_side_effects.py -q
# 13 passed

RUN_INTEGRATION_TESTS=1 MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/integration/test_schedule_execution.py -q
# 7 passed, 1 skipped

make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr08 check
# pass

make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr08 check-full
# pass
```

## Risk & Rollback
- Risk: external consumers that implicitly relied on naive SQLite timestamp strings may now observe normalized `YYYY-MM-DDTHH:MM:SSZ` values.
- Rollback: revert `bf7b4f2` to restore previous route serialization behavior. No schema migration is involved.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: `/api/schedule/<id>/run` fallback key now uses `get_utc_now()` and `to_iso_utc(...)`.
- Outbox/send_key 중복 방지 결과: no change.
- import-time side effect 제거 여부: no change.

## Not Run (with reason)
- Real external email delivery test was not run because it requires live Postmark credentials.
