### PR TITLE
build(ci): align full gate with canonical runtime coverage

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -274,7 +274,7 @@ jobs:
           POSTMARK_SERVER_TOKEN: dummy-token
           EMAIL_SENDER: test@example.com
         run: |
-          pytest -m unit --tb=short --junitxml=test-results-unit.xml --cov=newsletter --cov-report=xml --cov-report=html
+          pytest -m unit --tb=short --junitxml=test-results-unit.xml --cov=newsletter --cov=newsletter_core --cov=web --cov-report=xml --cov-report=html
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ doctor: ## 작업 경로/인터프리터 전제 조건 검증
 check: doctor test-quick docs-check skills-check ## 표준 로컬 게이트
 	@echo "✅ check 완료"
 
-check-full: doctor test-full docs-check skills-check ## PR 전 전체 게이트
+check-full: doctor test-full docs-check skills-check ops-safety-check ## PR 전 전체 게이트
 	@echo "✅ check-full 완료"
 
 install: ## 의존성 설치
@@ -185,7 +185,7 @@ test-all: ## 모든 테스트 실행
 
 test-coverage: ## 커버리지 포함 테스트
 	@echo "📊 커버리지 측정 중..."
-	MOCK_MODE=true $(PYTHON) -m pytest -m unit --cov=newsletter --cov-report=html --cov-report=term
+	MOCK_MODE=true $(PYTHON) -m pytest -m unit --cov=newsletter --cov=newsletter_core --cov=web --cov-report=html --cov-report=term
 
 ci-check: ## CI 검사 실행 (GitHub Actions와 동일)
 	@echo "🚀 CI 검사 실행 중..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ module = [
 ignore_errors = true
 
 [tool.coverage.run]
-source = ["newsletter"]
+source = ["newsletter", "newsletter_core", "web"]
 omit = [
     "tests/*",
     "newsletter/__main__.py",
@@ -218,6 +218,8 @@ addopts = [
     "--strict-markers",
     "--strict-config",
     "--cov=newsletter",
+    "--cov=newsletter_core",
+    "--cov=web",
     "--cov-report=term-missing",
     "--cov-report=html",
     "--cov-report=xml",

--- a/run_ci_checks.py
+++ b/run_ci_checks.py
@@ -447,13 +447,31 @@ class CIChecker:
 
     def run_tests(self, quick: bool = False) -> bool:
         """테스트 실행"""
-        self.print_header("단위 테스트 실행")
-
         if quick:
             print(f"  {Colors.WARNING}빠른 모드에서는 테스트를 건너뜁니다{Colors.ENDC}")
             return True
 
-        # 환경 변수 설정
+        return self._run_pytest_check(
+            check_name="단위 테스트",
+            header="단위 테스트 실행",
+            args=["-m", "unit", "--tb=short", "-q"],
+        )
+
+    def run_contract_tests(self) -> bool:
+        """Canonical runtime contract 테스트 실행"""
+        return self._run_pytest_check(
+            check_name="Canonical 계약 테스트",
+            header="Canonical Contract 테스트",
+            args=[
+                "tests/contract/test_generation_facade.py",
+                "tests/contract/test_web_runtime_contract.py",
+                "--tb=short",
+                "-q",
+            ],
+        )
+
+    def _build_test_env(self) -> dict[str, str]:
+        """로컬 테스트용 공통 환경 변수."""
         env = os.environ.copy()
         env.update(
             {
@@ -467,29 +485,39 @@ class CIChecker:
                 "EMAIL_SENDER": "test@example.com",
             }
         )
+        return env
 
-        cmd = [
-            sys.executable,
-            "-m",
-            "pytest",
-            "-m",
-            "unit",
-            "--tb=short",
-            "-q",
-        ]
-
+    def _run_pytest_check(
+        self,
+        *,
+        check_name: str,
+        header: str,
+        args: List[str],
+    ) -> bool:
+        """공통 pytest 실행기."""
+        self.print_header(header)
         print(f"  {Colors.OKCYAN}테스트 실행 중... (시간이 걸릴 수 있습니다){Colors.ENDC}")
-        result = subprocess.run(cmd, env=env, capture_output=True, text=True)
+
+        cmd = [sys.executable, "-m", "pytest"] + args
+        result = subprocess.run(
+            cmd,
+            env=self._build_test_env(),
+            capture_output=True,
+            text=True,
+        )
 
         if result.returncode == 0:
-            self.print_status("단위 테스트", True)
+            self.print_status(check_name, True)
             return True
-        else:
-            self.print_status("단위 테스트", False, "테스트 실패")
-            if result.stdout:
-                print(f"\n{Colors.FAIL}테스트 출력:{Colors.ENDC}")
-                print(result.stdout[-2000:])  # 마지막 2000자만 표시
-            return False
+
+        self.print_status(check_name, False, "테스트 실패")
+        if result.stdout:
+            print(f"\n{Colors.FAIL}테스트 출력:{Colors.ENDC}")
+            print(result.stdout[-2000:])
+        elif result.stderr:
+            print(f"\n{Colors.FAIL}테스트 오류:{Colors.ENDC}")
+            print(result.stderr[-2000:])
+        return False
 
     def check_pre_commit(self) -> bool:
         """Pre-commit hooks 설치 확인"""
@@ -549,6 +577,7 @@ class CIChecker:
         # 테스트는 full 모드에서만
         if full:
             checks.append(("단위 테스트", lambda: self.run_tests(quick=False)))
+            checks.append(("Canonical 계약 테스트", self.run_contract_tests))
 
         # Pre-commit hooks 확인
         checks.append(("Pre-commit hooks", self.check_pre_commit))


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Expand canonical coverage scope to include `newsletter_core` and `web`, add the missing contract suite to `run_ci_checks --full`, and make `check-full` execute the ops-safety gate so local full validation matches the runtime we actually ship.

## Scope
### In Scope
- include `newsletter_core` and `web` in default pytest/coverage configuration
- run canonical generation/web runtime contract tests during `run_ci_checks --full`
- include `ops-safety-check` in `make check-full`
- align GitHub Actions unit-test coverage arguments with the local coverage scope

### Out of Scope
- branch protection required-check reconfiguration
- broader CI workflow redesign
- documentation wording cleanup for KPI/performance claims

## Delivery Unit
- RR: #174
- Delivery Unit ID: DU-20260308-quality-gates-realignment
- Merge Boundary: local/CI gate and coverage configuration only
- Rollback Boundary: revert commit `$(git rev-parse --short HEAD)`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed):

### Commands and Results
```bash
MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/contract/test_generation_facade.py tests/contract/test_web_runtime_contract.py -q
# 5 passed

make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr09 check
# pass

make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr09 check-full
# pass
```

## Risk & Rollback
- Risk: `check-full` and CI coverage reports now touch a broader runtime surface, so previously green changes may fail until they satisfy canonical web/runtime contracts.
- Rollback: revert commit `$(git rev-parse --short HEAD)` to restore the prior coverage scope and gate composition.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: no runtime idempotency logic change.
- Outbox/send_key 중복 방지 결과: no change.
- import-time side effect 제거 여부: no change.

## Not Run (with reason)
- No live-email or real API tests were run; this RR only changes local/CI verification configuration.
