### PR TITLE
refactor(config): route runtime settings through public accessors

### DIFF
--- a/newsletter/config_manager.py
+++ b/newsletter/config_manager.py
@@ -1,21 +1,9 @@
-import os
 from pathlib import Path
 from typing import Any, Dict
 
 import yaml  # type: ignore[import-untyped]
-from dotenv import load_dotenv
 
 DEFAULT_CONFIG_PATHS = ("config/config.yml", "config.yml")
-
-
-def _load_dotenv_if_needed() -> None:
-    """Load .env lazily to avoid import-time side effects."""
-    app_env = os.getenv("APP_ENV", "production")
-    testing = os.getenv("TESTING") == "1" or "pytest" in os.getenv(
-        "PYTEST_CURRENT_TEST", ""
-    )
-    if app_env == "development" and not testing:
-        load_dotenv(override=False)
 
 
 class ConfigManager:
@@ -52,7 +40,6 @@ class ConfigManager:
     def _load_environment_variables(self) -> None:
         """환경 변수 로딩 - Centralized Settings 사용"""
         try:
-            _load_dotenv_if_needed()
             from newsletter.centralized_settings import get_settings
 
             settings = get_settings()

--- a/newsletter_core/application/generation/compose.py
+++ b/newsletter_core/application/generation/compose.py
@@ -954,9 +954,9 @@ def load_newsletter_settings(config_file: str = "config.yml") -> Dict[str, Any]:
         Dict[str, Any]: 뉴스레터 설정 딕셔너리
     """
     try:
-        from newsletter.config_manager import config_manager
+        from newsletter_core.public.settings import get_newsletter_settings
 
-        return config_manager.get_newsletter_settings()
+        return get_newsletter_settings()
     except ImportError:
         # Fallback to original implementation
         default_settings = {

--- a/newsletter_core/public/settings.py
+++ b/newsletter_core/public/settings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from newsletter.centralized_settings import get_settings
 from newsletter.config_manager import config_manager, get_config_manager
 
@@ -19,11 +21,36 @@ def get_all_major_news_sources() -> list:
     return [*sources["tier1"], *sources["tier2"]]
 
 
+def get_newsletter_settings() -> dict[str, Any]:
+    return get_config_manager().get_newsletter_settings()
+
+
+def get_email_config() -> tuple[str | None, str | None]:
+    try:
+        settings = get_settings()
+        return (
+            settings.postmark_server_token.get_secret_value()
+            if settings.postmark_server_token
+            else None,
+            settings.email_sender,
+        )
+    except Exception:
+        manager = get_config_manager()
+        return manager.POSTMARK_SERVER_TOKEN, manager.EMAIL_SENDER
+
+
+def validate_email_config() -> dict[str, bool]:
+    return get_config_manager().validate_email_config()
+
+
 __all__ = [
     "config_manager",
+    "get_email_config",
     "get_all_major_news_sources",
     "get_config_manager",
     "get_llm_config",
     "get_major_news_sources",
+    "get_newsletter_settings",
     "get_settings",
+    "validate_email_config",
 ]

--- a/tests/test_web_mail.py
+++ b/tests/test_web_mail.py
@@ -104,13 +104,12 @@ class TestWebMail:
         with pytest.raises((RuntimeError, RetryError)):
             send_email(to="test@example.com", subject="Test", html="<h1>Test</h1>")
 
-    @patch("newsletter_core.public.settings.config_manager")
-    def test_check_email_configuration_complete(self, mock_config_manager):
+    @patch("newsletter_core.public.settings.validate_email_config")
+    def test_check_email_configuration_complete(self, mock_validate_email_config):
         """Test email configuration check with complete setup"""
         from web.mail import check_email_configuration
 
-        # Mock the config manager instance directly
-        mock_config_manager.validate_email_config.return_value = {
+        mock_validate_email_config.return_value = {
             "postmark_token_configured": True,
             "from_email_configured": True,
             "ready": True,
@@ -122,13 +121,12 @@ class TestWebMail:
         assert config["from_email_configured"] is True
         assert config["ready"] is True
 
-    @patch("newsletter_core.public.settings.config_manager")
-    def test_check_email_configuration_incomplete(self, mock_config_manager):
+    @patch("newsletter_core.public.settings.validate_email_config")
+    def test_check_email_configuration_incomplete(self, mock_validate_email_config):
         """Test email configuration check with incomplete setup"""
         from web.mail import check_email_configuration
 
-        # Mock the config manager instance directly
-        mock_config_manager.validate_email_config.return_value = {
+        mock_validate_email_config.return_value = {
             "postmark_token_configured": False,
             "from_email_configured": False,
             "ready": False,
@@ -141,18 +139,15 @@ class TestWebMail:
         assert config["from_email_configured"] is False
         assert config["ready"] is False
 
-    @patch("newsletter_core.public.settings.config_manager")
+    @patch("newsletter_core.public.settings.validate_email_config")
     @patch("web.mail._get_email_config")
     def test_check_email_configuration_fallback(
-        self, mock_get_email_config, mock_config_manager
+        self, mock_get_email_config, mock_validate_email_config
     ):
         """Test email configuration check with fallback logic"""
         from web.mail import check_email_configuration
 
-        # Mock config_manager to raise an exception, forcing fallback
-        mock_config_manager.validate_email_config.side_effect = ImportError(
-            "Test import error"
-        )
+        mock_validate_email_config.side_effect = ImportError("Test import error")
 
         # Mock _get_email_config to return None values for fallback
         mock_get_email_config.return_value = (None, None)

--- a/tests/unit_tests/test_config_import_side_effects.py
+++ b/tests/unit_tests/test_config_import_side_effects.py
@@ -88,8 +88,24 @@ def test_legacy_config_attributes_resolve_through_public_accessors(
         def get_major_news_sources(self) -> dict:
             return {"tier1": ["A"], "tier2": ["B"]}
 
+        def get_newsletter_settings(self) -> dict:
+            return {"newsletter_title": "Configured Title"}
+
+        def validate_email_config(self) -> dict:
+            return {
+                "postmark_token_configured": True,
+                "from_email_configured": True,
+                "ready": True,
+            }
+
+    class _DummySecret:
+        def get_secret_value(self) -> str:
+            return "postmark-test-token"
+
     class _DummySettings:
         mock_mode = True
+        email_sender = "sender@example.com"
+        postmark_server_token = _DummySecret()
 
     _clear_module_cache()
     public_settings = importlib.import_module("newsletter_core.public.settings")
@@ -106,6 +122,18 @@ def test_legacy_config_attributes_resolve_through_public_accessors(
     assert legacy_config.MAJOR_NEWS_SOURCES == {"tier1": ["A"], "tier2": ["B"]}
     assert legacy_config.ALL_MAJOR_NEWS_SOURCES == ["A", "B"]
     assert legacy_config.MOCK_MODE is True
+    assert public_settings.get_newsletter_settings() == {
+        "newsletter_title": "Configured Title"
+    }
+    assert public_settings.get_email_config() == (
+        "postmark-test-token",
+        "sender@example.com",
+    )
+    assert public_settings.validate_email_config() == {
+        "postmark_token_configured": True,
+        "from_email_configured": True,
+        "ready": True,
+    }
 
 
 @pytest.mark.unit

--- a/web/mail.py
+++ b/web/mail.py
@@ -1,6 +1,5 @@
 # web/mail.py
 import logging
-import os
 import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, cast
@@ -39,30 +38,20 @@ except ImportError:
 def _get_email_config() -> tuple[str | None, str | None]:
     """이메일 설정을 동적으로 가져옵니다 (테스트 호환성 고려)"""
     try:
-        # 1차 시도: Centralized Settings
-        from newsletter_core.public.settings import get_settings
+        from newsletter_core.public.settings import get_email_config
 
-        settings = get_settings()
-        return (
-            settings.postmark_server_token.get_secret_value()
-            if settings.postmark_server_token
-            else None,
-            settings.email_sender,
-        )
+        token, from_email = get_email_config()
+        return token, from_email
     except Exception:
-        try:
-            # 2차 시도: Config Manager
-            from newsletter_core.public.settings import config_manager
-
-            return config_manager.POSTMARK_SERVER_TOKEN, config_manager.EMAIL_SENDER
-        except (ImportError, AttributeError):
-            # 3차 시도: Direct env access (레거시)
-            postmark_token = os.getenv("POSTMARK_SERVER_TOKEN")
-            email_sender = os.getenv("EMAIL_SENDER") or os.getenv("POSTMARK_FROM_EMAIL")
-            return postmark_token, email_sender
+        return None, None
 
 
 def resolve_mail_send_callable() -> Callable[..., Any]:
+    for module_name in ("mail", "web.mail"):
+        module = sys.modules.get(module_name)
+        candidate = getattr(module, "send_email", None) if module else None
+        if callable(candidate):
+            return cast(Callable[..., Any], candidate)
     return cast(Callable[..., Any], send_email)
 
 
@@ -183,9 +172,9 @@ def send_email(to: str, subject: str, html: str, **kwargs: Any) -> Dict[str, Any
 def check_email_configuration() -> Dict[str, bool]:
     """이메일 설정 상태를 확인합니다."""
     try:
-        from newsletter_core.public.settings import config_manager
+        from newsletter_core.public.settings import validate_email_config
 
-        return cast(Dict[str, bool], config_manager.validate_email_config())
+        return cast(Dict[str, bool], validate_email_config())
     except (ImportError, AttributeError):
         # Fallback 로직
         token, from_email = _get_email_config()


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Route runtime newsletter/email settings through `newsletter_core.public.settings` so `newsletter/centralized_settings.py` remains the SSOT and `newsletter/config_manager.py` stays a thin compatibility adapter.

## Scope
### In Scope
- remove redundant dotenv loading from `newsletter/config_manager.py`
- add public newsletter/email config accessors and move runtime callers to them
- keep web mail route tests stable under repeated module cache resets

### Out of Scope
- broader config API removal outside touched runtime callers
- logging/ops cleanup work planned for RR-13

## Delivery Unit
- RR: #182
- Delivery Unit ID: DU-20260308-config-ssot-stage2
- Merge Boundary: config SSOT stage 2 compatibility layer and runtime consumer rewiring
- Rollback Boundary: revert commit `c112c04`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): ops-safety suite and mail/config regressions

### Commands and Results
```bash
export MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com
python3 - <<'PY'
from pathlib import Path
path = Path('/Users/hojungjung/development/newsletter-generator-rr12/web/storage.db')
if path.exists():
    path.unlink()
PY
/Users/hojungjung/development/newsletter-generator-rr12/.venv/bin/python -m pytest tests/test_web_mail.py tests/unit_tests/test_config_import_side_effects.py tests/contract/test_web_email_routes_contract.py -q
/Users/hojungjung/development/newsletter-generator-rr12/.venv/bin/python -m pytest tests/test_web_api.py -q
RUN_INTEGRATION_TESTS=1 /Users/hojungjung/development/newsletter-generator-rr12/.venv/bin/python -m pytest tests/integration/test_schedule_execution.py -q
/Users/hojungjung/development/newsletter-generator-rr12/.venv/bin/python -m pytest tests/unit_tests/test_schedule_time_sync.py -q
/Users/hojungjung/development/newsletter-generator-rr12/.venv/bin/python -m pytest tests/contract/test_web_email_routes_contract.py -q
/Users/hojungjung/development/newsletter-generator-rr12/.venv/bin/python -m pytest tests/unit_tests/test_config_import_side_effects.py -q
/Users/hojungjung/development/newsletter-generator-rr12/.venv/bin/python -m pytest tests/contract/test_web_runtime_contract.py -q
make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr12 check
make EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr12 check-full
```

## Risk & Rollback
- Risk: runtime config readers now converge on the public accessor layer; stale test imports were the main compatibility risk and are covered by regression tests.
- Rollback: revert `c112c04`; no schema/data rollback is needed.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 변경 없음. 기존 generation/send-email/schedule idempotency 경로는 그대로 유지됩니다.
- Outbox/send_key 중복 방지 결과: 변경 없음. `tests/contract/test_web_email_routes_contract.py -q` 및 `tests/test_web_api.py -q` 통과로 기존 dedupe 동작 유지 확인했습니다.
- import-time side effect 제거 여부: 추가하지 않았고, `config_manager.py`에서 중복 dotenv load 경로를 제거했습니다.

## Not Run (with reason)
- 없음
