### PR TITLE
refactor(web): structure canonical runtime ops logging

### DIFF
--- a/tests/unit_tests/test_web_ops_logging.py
+++ b/tests/unit_tests/test_web_ops_logging.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from web.ops_logging import build_log_message
+
+
+@pytest.mark.unit
+def test_build_log_message_sorts_and_serializes_fields() -> None:
+    message = build_log_message(
+        "schedule.execute.started",
+        schedule_id="sched-1",
+        params={"keywords": ["AI"]},
+        intended_run_at=datetime(2026, 3, 8, 12, 30, tzinfo=timezone.utc),
+        ignored=None,
+    )
+
+    assert message.startswith("schedule.execute.started ")
+    assert "intended_run_at=2026-03-08T12:30:00+00:00" in message
+    assert 'params={"keywords": ["AI"]}' in message
+    assert 'schedule_id="sched-1"' in message
+    assert "ignored=" not in message

--- a/web/app.py
+++ b/web/app.py
@@ -52,6 +52,11 @@ try:
 except ImportError:
     from web.db_state import ensure_database_schema  # pragma: no cover
 
+try:
+    from ops_logging import log_exception, log_info, log_warning
+except ImportError:
+    from web.ops_logging import log_exception, log_info, log_warning  # pragma: no cover
+
 # Import web types module - will be loaded later to avoid conflicts
 
 
@@ -103,9 +108,16 @@ configure_access_control(app)
 
 # Enable detailed logging
 logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    level=os.getenv("LOG_LEVEL", "INFO").upper(),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
-print("[INFO] Flask app initialized with detailed logging")
+logger = logging.getLogger("web.app")
+log_info(
+    logger,
+    "app.initialized",
+    template_folder=resolve_template_dir(),
+    static_folder=resolve_static_dir(),
+)
 
 # Configuration
 app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "dev-key-change-in-production")
@@ -120,7 +132,7 @@ try:
 
     # Windows에서는 RQ Worker가 제대로 작동하지 않으므로 직접 처리 사용
     if platform.system() == "Windows":
-        print("Windows detected: Using direct processing instead of Redis Queue")
+        log_warning(logger, "app.redis.disabled_for_windows")
         redis_conn = None
         task_queue = None
     else:
@@ -129,9 +141,19 @@ try:
         redis_conn = redis.from_url(app.config["REDIS_URL"])
         redis_conn.ping()  # Test connection
         task_queue = Queue(QUEUE_NAME, connection=redis_conn)
-        print("Redis connected successfully")
+        log_info(
+            logger,
+            "app.redis.connected",
+            queue_name=QUEUE_NAME,
+            redis_url=app.config["REDIS_URL"],
+        )
 except Exception as e:
-    print(f"Redis connection failed: {e}. Using in-memory processing.")
+    log_exception(
+        logger,
+        "app.redis.connection_failed",
+        e,
+        redis_url=app.config["REDIS_URL"],
+    )
     redis_conn = None
     task_queue = None
 
@@ -155,14 +177,17 @@ init_db()
 def index() -> str | tuple[str, int]:
     """Main dashboard page"""
     try:
-        print(f"Template folder: {app.template_folder}")
-        print(f"App root path: {app.root_path}")
-        template_path = os.path.join(app.template_folder, "index.html")
-        print(f"Template path: {template_path}")
-        print(f"Template exists: {os.path.exists(template_path)}")
         return cast(str, render_template("index.html"))
     except Exception as e:
-        print(f"Template rendering error: {e}")
+        template_path = os.path.join(app.template_folder, "index.html")
+        log_exception(
+            logger,
+            "app.template.render_failed",
+            e,
+            template_folder=app.template_folder,
+            template_path=template_path,
+            template_exists=os.path.exists(template_path),
+        )
         return f"Template error: {str(e)}", 500
 
 
@@ -238,5 +263,5 @@ app.register_blueprint(suggest_bp)
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", 5000))
     debug = os.environ.get("FLASK_ENV") == "development"
-    print(f"Starting Flask app on port {port}, debug={debug}")
+    log_info(logger, "app.starting", port=port, debug=debug)
     app.run(host="0.0.0.0", port=port, debug=debug)

--- a/web/ops_logging.py
+++ b/web/ops_logging.py
@@ -1,0 +1,60 @@
+"""Small helpers for stable, field-oriented operational logging."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime
+from typing import Any
+
+
+def _serialize_log_value(value: Any) -> str:
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, (dict, list, tuple, set)):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
+def build_log_message(event: str, **fields: Any) -> str:
+    parts = [event]
+    for key in sorted(fields):
+        value = fields[key]
+        if value is None:
+            continue
+        parts.append(f"{key}={_serialize_log_value(value)}")
+    return " ".join(parts)
+
+
+def log_event(logger: logging.Logger, level: int, event: str, **fields: Any) -> None:
+    logger.log(level, build_log_message(event, **fields))
+
+
+def log_debug(logger: logging.Logger, event: str, **fields: Any) -> None:
+    log_event(logger, logging.DEBUG, event, **fields)
+
+
+def log_info(logger: logging.Logger, event: str, **fields: Any) -> None:
+    log_event(logger, logging.INFO, event, **fields)
+
+
+def log_warning(logger: logging.Logger, event: str, **fields: Any) -> None:
+    log_event(logger, logging.WARNING, event, **fields)
+
+
+def log_error(logger: logging.Logger, event: str, **fields: Any) -> None:
+    log_event(logger, logging.ERROR, event, **fields)
+
+
+def log_exception(
+    logger: logging.Logger, event: str, error: Exception, **fields: Any
+) -> None:
+    log_error(
+        logger,
+        event,
+        error=str(error),
+        error_type=type(error).__name__,
+        **fields,
+    )

--- a/web/routes_generation.py
+++ b/web/routes_generation.py
@@ -50,6 +50,14 @@ except ImportError:
         to_utc,
     )
 
+try:
+    from ops_logging import log_debug, log_exception, log_info
+except ImportError:
+    from web.ops_logging import log_debug, log_exception, log_info  # pragma: no cover
+
+
+logger = logging.getLogger("web.routes_generation")
+
 
 def register_generation_routes(
     app: Flask,
@@ -109,12 +117,10 @@ def register_generation_routes(
     @app.route("/api/generate", methods=["POST"])
     def generate_newsletter():
         """Generate newsletter based on keywords or domain with optional email sending"""
-        print(f"📨 Newsletter generation request received")
-
         try:
             data = request.get_json()
             if not data:
-                print("❌ No data provided in request")
+                log_info(logger, "generate.request.empty")
                 return jsonify({"error": "No data provided"}), 400
 
             # Validate request using Pydantic
@@ -133,15 +139,21 @@ def register_generation_routes(
 
                 validated_data = web_types_module.GenerateNewsletterRequest(**data)
             except (ValueError, Exception) as e:
-                print(f"❌ Validation error: {e}")
+                log_exception(logger, "generate.request.invalid", e)
                 return jsonify({"error": f"Invalid request: {str(e)}"}), 400
 
             # Extract email for sending
             email = validated_data.email
             send_email = bool(email)
-
-            print(f"📋 Request data: {data}")
-            print(f"📧 Send email: {send_email} to {email}")
+            log_info(
+                logger,
+                "generate.request.received",
+                has_domain=bool(validated_data.domain),
+                has_keywords=bool(validated_data.keywords),
+                email=email,
+                send_email=send_email,
+            )
+            log_debug(logger, "generate.request.payload", payload=data)
 
             idempotency_enabled = is_feature_enabled(
                 "WEB_IDEMPOTENCY_ENABLED", default=True
@@ -167,7 +179,14 @@ def register_generation_routes(
                 idempotency_key=idempotency_key if idempotency_enabled else None,
                 status="pending",
             )
-            print(f"🆔 Resolved job ID: {job_id} (deduplicated={deduplicated})")
+            log_info(
+                logger,
+                "generate.job.resolved",
+                job_id=job_id,
+                deduplicated=deduplicated,
+                idempotency_key=idempotency_key,
+                stored_status=stored_status,
+            )
 
             if deduplicated:
                 return (
@@ -183,7 +202,7 @@ def register_generation_routes(
                 )
 
             if task_queue:
-                print("📤 Queueing task with Redis")
+                log_info(logger, "generate.job.queued", job_id=job_id, via="redis")
                 task_queue.enqueue(
                     generate_newsletter_task,
                     data,
@@ -205,7 +224,7 @@ def register_generation_routes(
                     202,
                 )
 
-            print("🔄 Processing in-memory (Redis not available)")
+            log_info(logger, "generate.job.queued", job_id=job_id, via="in_memory")
             in_memory_tasks[job_id] = {
                 "status": "processing",
                 "started_at": datetime.now().isoformat(),
@@ -240,7 +259,7 @@ def register_generation_routes(
             )
 
         except Exception as e:
-            print(f"❌ Error in generate_newsletter endpoint: {e}")
+            log_exception(logger, "generate.request.failed", e)
             return jsonify({"error": str(e)}), 500
 
     @app.route("/newsletter", methods=["GET"])
@@ -269,7 +288,13 @@ def register_generation_routes(
                     400,
                 )
 
-            print(f"🔍 Newsletter request - Keywords: {keywords}, Period: {period}")
+            log_info(
+                logger,
+                "newsletter.preview.requested",
+                keywords=keywords,
+                period=period,
+                template_style=template_style,
+            )
 
             # 뉴스레터 생성
             active_newsletter_cli = resolve_newsletter_cli()
@@ -298,16 +323,17 @@ def register_generation_routes(
                 )
 
         except Exception as e:
-            print(f"❌ Error in newsletter endpoint: {e}")
+            log_exception(logger, "newsletter.preview.failed", e)
             return jsonify({"error": str(e)}), 500
 
     def process_newsletter_sync(data):
         """Process newsletter synchronously (fallback when Redis is not available)"""
         try:
-            print(f"🔄 Starting synchronous newsletter processing")
             active_newsletter_cli = resolve_newsletter_cli()
-            print(
-                f"📊 Current newsletter_cli type: {type(active_newsletter_cli).__name__}"
+            log_info(
+                logger,
+                "generate.sync.started",
+                cli_type=type(active_newsletter_cli).__name__,
             )
 
             # Extract parameters
@@ -318,19 +344,25 @@ def register_generation_routes(
             period = data.get("period", 14)
             email = data.get("email", "")  # 이메일 주소 추가
 
-            print(f"📋 Processing parameters:")
-            print(f"   Keywords: {keywords}")
-            print(f"   Domain: {domain}")
-            print(f"   Template style: {template_style}")
-            print(f"   Email compatible: {email_compatible}")
-            print(f"   Period: {period}")
-            print(f"   Email: {email}")
+            log_debug(
+                logger,
+                "generate.sync.parameters",
+                keywords=keywords,
+                domain=domain,
+                template_style=template_style,
+                email_compatible=email_compatible,
+                period=period,
+                email=email,
+            )
 
             # Use newsletter CLI with proper parameters
             try:
                 if keywords:
-                    print(
-                        f"🔧 Generating newsletter with keywords using {type(active_newsletter_cli).__name__}"
+                    log_info(
+                        logger,
+                        "generate.sync.invoke",
+                        mode="keywords",
+                        cli_type=type(active_newsletter_cli).__name__,
                     )
                     result = active_newsletter_cli.generate_newsletter(
                         keywords=keywords,
@@ -339,8 +371,11 @@ def register_generation_routes(
                         period=period,
                     )
                 elif domain:
-                    print(
-                        f"🔧 Generating newsletter with domain using {type(active_newsletter_cli).__name__}"
+                    log_info(
+                        logger,
+                        "generate.sync.invoke",
+                        mode="domain",
+                        cli_type=type(active_newsletter_cli).__name__,
                     )
                     result = active_newsletter_cli.generate_newsletter(
                         domain=domain,
@@ -351,18 +386,25 @@ def register_generation_routes(
                 else:
                     raise ValueError("Either keywords or domain must be provided")
 
-                print(f"📊 CLI result status: {result['status']}")
-                print(f"📊 CLI result type: {type(result)}")
-                print(
-                    f"📊 CLI result keys: {list(result.keys()) if isinstance(result, dict) else 'Not a dict'}"
+                log_info(
+                    logger,
+                    "generate.sync.result",
+                    status=result.get("status"),
+                    result_type=type(result).__name__,
+                    result_keys=(
+                        list(result.keys()) if isinstance(result, dict) else None
+                    ),
                 )
 
             except Exception as cli_error:
-                print(f"❌ CLI generation failed: {str(cli_error)}")
-                print(f"❌ CLI error type: {type(cli_error).__name__}")
                 import traceback
 
-                print(f"❌ CLI error traceback: {traceback.format_exc()}")
+                log_exception(
+                    logger,
+                    "generate.sync.cli_failed",
+                    cli_error,
+                    traceback=traceback.format_exc(),
+                )
                 # Set result to error status for fallback logic
                 result = {"status": "error", "error": str(cli_error)}
 
@@ -370,7 +412,7 @@ def register_generation_routes(
             if result["status"] == "error":
                 # If CLI failed and returned error, try mock as fallback
                 if isinstance(active_newsletter_cli, RealNewsletterCLI):
-                    print("⚠️  Real CLI failed, trying mock fallback...")
+                    log_info(logger, "generate.sync.fallback_mock")
                     mock_cli = MockNewsletterCLI()
                     if keywords:
                         result = mock_cli.generate_newsletter(
@@ -386,13 +428,17 @@ def register_generation_routes(
                             email_compatible=email_compatible,
                             period=period,
                         )
-                    print(f"📊 Mock fallback result status: {result['status']}")
+                    log_info(
+                        logger,
+                        "generate.sync.fallback_result",
+                        status=result.get("status"),
+                    )
 
             # 이메일 발송 기능 추가
             email_sent = False
             if email and result.get("content") and not data.get("preview_only"):
                 try:
-                    print(f"📧 Attempting to send email to {email}")
+                    log_info(logger, "generate.sync.email_sending", email=email)
                     # 이메일 발송 - try-except로 import 처리
                     try:
                         import mail
@@ -421,9 +467,14 @@ def register_generation_routes(
                     # 이메일 발송
                     send_email_func(to=email, subject=subject, html=result["content"])
                     email_sent = True
-                    print(f"✅ Successfully sent email to {email}")
+                    log_info(logger, "generate.sync.email_sent", email=email)
                 except Exception as e:
-                    print(f"❌ Failed to send email to {email}: {str(e)}")
+                    log_exception(
+                        logger,
+                        "generate.sync.email_failed",
+                        e,
+                        email=email,
+                    )
                     # 이메일 발송 실패해도 뉴스레터 생성은 성공으로 처리
 
             response = {
@@ -447,18 +498,23 @@ def register_generation_routes(
                 },
             }
 
-            print(f"✅ Processing completed successfully")
+            log_info(
+                logger,
+                "generate.sync.completed",
+                status=response["status"],
+                email_sent=email_sent,
+            )
             return response
 
         except Exception as e:
             error_msg = f"Newsletter generation failed: {str(e)}"
-            print(f"❌ {error_msg}")
+            log_exception(logger, "generate.sync.failed", e)
             raise Exception(error_msg)
 
     def process_newsletter_in_memory(data, job_id):
         """Process newsletter in memory and update task status"""
         try:
-            print(f"📊 Starting newsletter processing for job {job_id}")
+            log_info(logger, "generate.in_memory.started", job_id=job_id)
             result = process_newsletter_sync(data)
 
             # 메모리에 결과 저장
@@ -468,15 +524,17 @@ def register_generation_routes(
                 "updated_at": datetime.now().isoformat(),
             }
 
-            print(f"📊 Newsletter processing completed for job {job_id}")
-            print(f"📊 Result status: {result.get('status', 'unknown')}")
-            print(
-                f"📊 Result keys: {list(result.keys()) if isinstance(result, dict) else 'Not a dict'}"
+            log_info(
+                logger,
+                "generate.in_memory.completed",
+                job_id=job_id,
+                status=result.get("status", "unknown"),
+                result_keys=list(result.keys()) if isinstance(result, dict) else None,
             )
 
             return result
         except Exception as e:
-            print(f"❌ Error in process_newsletter_in_memory for job {job_id}: {e}")
+            log_exception(logger, "generate.in_memory.failed", e, job_id=job_id)
             in_memory_tasks[job_id] = {
                 "status": "failed",
                 "error": str(e),
@@ -541,8 +599,6 @@ def register_generation_routes(
     @app.route("/api/history")
     def get_history():
         """Get recent newsletter generation history"""
-        print(f"📚 Fetching history from database")
-
         try:
             conn = sqlite3.connect(DATABASE_PATH)
             cursor = conn.cursor()
@@ -560,28 +616,26 @@ def register_generation_routes(
             )
             rows = cursor.fetchall()
             conn.close()
-
-            print(f"📚 Found {len(rows)} history records")
+            log_info(logger, "history.loaded", count=len(rows))
 
         except Exception as e:
-            print(f"❌ Database error in get_history: {e}")
+            log_exception(logger, "history.load_failed", e)
             return jsonify({"error": f"Database error: {str(e)}"}), 500
 
         history = []
         for row in rows:
             job_id, params, result, created_at, status, idempotency_key = row
-            print(f"📚 Processing history record: {job_id} (status: {status})")
 
             try:
                 parsed_params = json.loads(params) if params else None
             except json.JSONDecodeError as e:
-                print(f"❌ Failed to parse params for job {job_id}: {e}")
+                log_exception(logger, "history.params_parse_failed", e, job_id=job_id)
                 parsed_params = None
 
             try:
                 parsed_result = json.loads(result) if result else None
             except json.JSONDecodeError as e:
-                print(f"❌ Failed to parse result for job {job_id}: {e}")
+                log_exception(logger, "history.result_parse_failed", e, job_id=job_id)
                 parsed_result = None
 
             history.append(
@@ -595,7 +649,7 @@ def register_generation_routes(
                 }
             )
 
-        print(f"📚 Returning {len(history)} history records")
+        log_info(logger, "history.returned", count=len(history))
         return jsonify(history)
 
     @app.route("/api/schedule", methods=["POST"])
@@ -790,5 +844,5 @@ def register_generation_routes(
                 )
 
         except Exception as e:
-            logging.error(f"Failed to run schedule {schedule_id}: {e}")
+            log_exception(logger, "schedule.run_now.failed", e, schedule_id=schedule_id)
             return jsonify({"error": f"Failed to execute schedule: {str(e)}"}), 500

--- a/web/routes_send_email.py
+++ b/web/routes_send_email.py
@@ -12,6 +12,14 @@ try:
 except ImportError:
     from .mail import get_newsletter_subject, send_email_with_outbox  # pragma: no cover
 
+try:
+    from ops_logging import log_exception, log_info
+except ImportError:
+    from web.ops_logging import log_exception, log_info  # pragma: no cover
+
+
+logger = logging.getLogger("web.routes_send_email")
+
 
 def register_send_email_route(app: Flask, database_path: str) -> None:
     """Register send-email route on the given Flask app."""
@@ -60,6 +68,13 @@ def register_send_email_route(app: Flask, database_path: str) -> None:
             send_key = send_result["send_key"]
 
             if send_result.get("skipped"):
+                log_info(
+                    logger,
+                    "email.send.deduplicated",
+                    job_id=job_id,
+                    email=email,
+                    send_key=send_key,
+                )
                 return jsonify(
                     {
                         "success": True,
@@ -69,6 +84,13 @@ def register_send_email_route(app: Flask, database_path: str) -> None:
                     }
                 )
 
+            log_info(
+                logger,
+                "email.send.completed",
+                job_id=job_id,
+                email=email,
+                send_key=send_key,
+            )
             return jsonify(
                 {
                     "success": True,
@@ -79,5 +101,11 @@ def register_send_email_route(app: Flask, database_path: str) -> None:
             )
 
         except Exception as e:
-            logging.error(f"Email sending failed: {e}")
+            log_exception(
+                logger,
+                "email.send.failed",
+                e,
+                job_id=locals().get("job_id"),
+                email=locals().get("email"),
+            )
             return jsonify({"error": f"이메일 발송 실패: {str(e)}"}), 500

--- a/web/schedule_runner.py
+++ b/web/schedule_runner.py
@@ -49,9 +49,21 @@ try:
 except ImportError:
     from time_utils import to_iso_utc  # Development
 
+try:
+    from ops_logging import log_debug, log_error, log_exception, log_info, log_warning
+except ImportError:
+    from web.ops_logging import (  # pragma: no cover
+        log_debug,
+        log_error,
+        log_exception,
+        log_info,
+        log_warning,
+    )
+
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    level=os.getenv("LOG_LEVEL", "INFO").upper(),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
 
@@ -74,7 +86,7 @@ class ScheduleRunner:
             self.redis_conn = redis.from_url(self.redis_url)
             self.queue = Queue("default", connection=self.redis_conn)
         except Exception as e:
-            logger.error(f"Redis connection failed: {e}")
+            log_exception(logger, "schedule.redis.connection_failed", e)
             self.redis_conn = None
             self.queue = None
 
@@ -91,14 +103,17 @@ class ScheduleRunner:
     def get_pending_schedules(self) -> List[Dict]:
         """실행 대기 중인 스케줄 목록을 가져옵니다."""
         try:
-            logger.info(f"[DEBUG] Using database path: {self.db_path}")
-            logger.info(f"[DEBUG] Database file exists: {os.path.exists(self.db_path)}")
-
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
 
             now = datetime.now(timezone.utc)
-            logger.info(f"[DEBUG] Current time (UTC): {now}")
+            log_debug(
+                logger,
+                "schedule.scan.started",
+                db_path=self.db_path,
+                db_exists=os.path.exists(self.db_path),
+                now=now,
+            )
 
             # Import time utilities and convert current time
             try:
@@ -114,14 +129,20 @@ class ScheduleRunner:
             )
             expired_count = cursor.rowcount
             if expired_count > 0:
-                logger.info(f"[DEBUG] Disabled {expired_count} expired test schedules")
+                log_info(
+                    logger,
+                    "schedule.expired_tests.disabled",
+                    count=expired_count,
+                )
 
             # 모든 활성 스케줄 조회
             cursor.execute(
                 "SELECT id, params, rrule, next_run, created_at, is_test FROM schedules WHERE enabled = 1"
             )
             all_schedules = cursor.fetchall()
-            logger.info(f"[DEBUG] Found {len(all_schedules)} total active schedules")
+            log_debug(
+                logger, "schedule.scan.loaded_active", active_count=len(all_schedules)
+            )
 
             # 스케줄 실행 대기열과 만료된 스케줄 분리 처리
             ready_for_execution = []
@@ -149,21 +170,36 @@ class ScheduleRunner:
                     # 실행 창 설정 (테스트 vs 정규)
                     execution_window = test_window if is_test else regular_window
 
-                    logger.info(
-                        f"[DEBUG] Schedule {schedule_id}: next_run={next_run_str}, time_diff={time_diff.total_seconds():.1f}s, window={execution_window.total_seconds()}s"
+                    log_debug(
+                        logger,
+                        "schedule.scan.evaluating",
+                        schedule_id=schedule_id,
+                        next_run=next_run_str,
+                        time_diff_seconds=round(time_diff.total_seconds(), 1),
+                        window_seconds=execution_window.total_seconds(),
                     )
 
                     # 실행 창 내에 있는 스케줄 (즉시 실행 대상)
                     if timedelta(0) <= time_diff <= execution_window:
-                        logger.info(
-                            f"[DEBUG] Schedule {schedule_id} is READY for execution (within {execution_window.total_seconds()/60:.1f}min window)"
+                        log_debug(
+                            logger,
+                            "schedule.scan.ready",
+                            schedule_id=schedule_id,
+                            window_minutes=round(
+                                execution_window.total_seconds() / 60, 1
+                            ),
                         )
                         ready_for_execution.append(schedule)
 
                     # 실행 창을 넘어선 과거 스케줄 (다음 주기로 업데이트)
                     elif time_diff > execution_window:
-                        logger.info(
-                            f"[DEBUG] Schedule {schedule_id} is EXPIRED (missed {time_diff.total_seconds()/60:.1f}min window), calculating next occurrence"
+                        log_info(
+                            logger,
+                            "schedule.scan.expired",
+                            schedule_id=schedule_id,
+                            missed_window_minutes=round(
+                                time_diff.total_seconds() / 60, 1
+                            ),
                         )
 
                         # 다음 실행 시간 계산
@@ -175,40 +211,58 @@ class ScheduleRunner:
                                 (to_iso_utc(next_run_calculated), schedule_id),
                             )
                             updated_count += 1
-                            logger.info(
-                                f"[DEBUG] Updated EXPIRED schedule {schedule_id} from {next_run_str} to {to_iso_utc(next_run_calculated)}"
+                            log_info(
+                                logger,
+                                "schedule.scan.expired_rescheduled",
+                                schedule_id=schedule_id,
+                                previous_next_run=next_run_str,
+                                next_run=to_iso_utc(next_run_calculated),
                             )
                         else:
                             cursor.execute(
                                 "UPDATE schedules SET enabled = 0 WHERE id = ?",
                                 (schedule_id,),
                             )
-                            logger.info(
-                                f"[DEBUG] Disabled schedule {schedule_id} - no more occurrences"
+                            log_info(
+                                logger,
+                                "schedule.scan.disabled_no_more_occurrences",
+                                schedule_id=schedule_id,
                             )
 
                     # 미래 스케줄 (아직 실행 시간이 아님)
                     else:
-                        logger.info(
-                            f"[DEBUG] Schedule {schedule_id} is FUTURE (will run in {abs(time_diff.total_seconds())/60:.1f}min)"
+                        log_debug(
+                            logger,
+                            "schedule.scan.future",
+                            schedule_id=schedule_id,
+                            run_in_minutes=round(
+                                abs(time_diff.total_seconds()) / 60, 1
+                            ),
                         )
 
                 except Exception as parse_error:
-                    logger.error(
-                        f"[DEBUG] Failed to parse schedule {schedule_id}: {parse_error}"
+                    log_exception(
+                        logger,
+                        "schedule.scan.parse_failed",
+                        parse_error,
+                        schedule_id=schedule_id,
                     )
                     continue
 
             if expired_count > 0 or updated_count > 0:
                 conn.commit()
             if updated_count > 0:
-                logger.info(
-                    f"[DEBUG] Updated {updated_count} expired schedules to next occurrence"
+                log_info(
+                    logger,
+                    "schedule.scan.expired_updates_committed",
+                    updated_count=updated_count,
                 )
 
             # 실행 준비 완료된 스케줄들을 반환 형식으로 변환
-            logger.info(
-                f"[DEBUG] Found {len(ready_for_execution)} schedules ready for immediate execution"
+            log_debug(
+                logger,
+                "schedule.scan.ready_summary",
+                ready_count=len(ready_for_execution),
             )
 
             # Ensure deterministic execution order (oldest next_run first).
@@ -228,8 +282,12 @@ class ScheduleRunner:
                 ) = schedule_data
                 is_test_bool = bool(is_test)
 
-                logger.info(
-                    f"[DEBUG] Adding {'TEST' if is_test_bool else 'REGULAR'} schedule {schedule_id} to execution queue (next_run={next_run_str})"
+                log_debug(
+                    logger,
+                    "schedule.queue.ready_entry",
+                    schedule_id=schedule_id,
+                    schedule_type="test" if is_test_bool else "regular",
+                    next_run=next_run_str,
                 )
 
                 schedules.append(
@@ -247,7 +305,7 @@ class ScheduleRunner:
             return schedules
 
         except Exception as e:
-            logger.error(f"Failed to get pending schedules: {e}")
+            log_exception(logger, "schedule.scan.failed", e, db_path=self.db_path)
             return []
 
     def calculate_next_run(
@@ -280,7 +338,12 @@ class ScheduleRunner:
                 return None
 
         except Exception as e:
-            logger.error(f"Failed to calculate next run for RRULE '{rrule_str}': {e}")
+            log_exception(
+                logger,
+                "schedule.next_run.calculate_failed",
+                e,
+                rrule=rrule_str,
+            )
             return None
 
     def update_schedule_next_run(self, schedule_id: str, next_run: datetime) -> bool:
@@ -301,11 +364,18 @@ class ScheduleRunner:
             conn.commit()
             conn.close()
 
-            logger.info(f"Updated schedule {schedule_id} next run to {next_run}")
+            log_info(
+                logger,
+                "schedule.next_run.updated",
+                schedule_id=schedule_id,
+                next_run=next_run,
+            )
             return True
 
         except Exception as e:
-            logger.error(f"Failed to update schedule {schedule_id}: {e}")
+            log_exception(
+                logger, "schedule.next_run.update_failed", e, schedule_id=schedule_id
+            )
             return False
 
     def disable_schedule(self, schedule_id: str) -> bool:
@@ -326,11 +396,11 @@ class ScheduleRunner:
             conn.commit()
             conn.close()
 
-            logger.info(f"Disabled schedule {schedule_id}")
+            log_info(logger, "schedule.disabled", schedule_id=schedule_id)
             return True
 
         except Exception as e:
-            logger.error(f"Failed to disable schedule {schedule_id}: {e}")
+            log_exception(logger, "schedule.disable_failed", e, schedule_id=schedule_id)
             return False
 
     def execute_schedule(self, schedule: Dict) -> bool:
@@ -348,30 +418,44 @@ class ScheduleRunner:
                 if next_run:
                     # 다음 실행 시간을 먼저 업데이트하여 중복 실행 방지
                     if self.update_schedule_next_run(schedule_id, next_run):
-                        logger.info(
-                            f"[EXECUTE] Pre-updated next run for schedule {schedule_id} to {next_run} (preventing duplicates)"
+                        log_info(
+                            logger,
+                            "schedule.execute.preupdated_next_run",
+                            schedule_id=schedule_id,
+                            next_run=next_run,
                         )
                     else:
-                        logger.error(
-                            f"[EXECUTE] Failed to pre-update next run for schedule {schedule_id}"
+                        log_error(
+                            logger,
+                            "schedule.execute.preupdate_failed",
+                            schedule_id=schedule_id,
                         )
                         return False
                 else:
                     # 더 이상 실행할 일정이 없으면 비활성화
-                    logger.info(
-                        f"[EXECUTE] No more occurrences for schedule {schedule_id}, disabling"
+                    log_info(
+                        logger,
+                        "schedule.execute.no_more_occurrences",
+                        schedule_id=schedule_id,
                     )
                     self.disable_schedule(schedule_id)
                     return True
             except Exception as update_error:
-                logger.error(
-                    f"[EXECUTE] Failed to calculate next run for schedule {schedule_id}: {update_error}"
+                log_exception(
+                    logger,
+                    "schedule.execute.next_run_failed",
+                    update_error,
+                    schedule_id=schedule_id,
                 )
                 # 업데이트 실패시 실행하지 않음 (중복 방지)
                 return False
 
-            logger.info(
-                f"[EXECUTE] Starting execution for schedule {schedule_id} - {params.get('keywords', 'No keywords')}"
+            log_info(
+                logger,
+                "schedule.execute.started",
+                schedule_id=schedule_id,
+                keywords=params.get("keywords"),
+                email=params.get("email"),
             )
 
             intended_run_at = schedule.get("next_run", datetime.now(timezone.utc))
@@ -412,22 +496,32 @@ class ScheduleRunner:
                         job_timeout="10m",
                         result_ttl=86400,  # 24시간 동안 결과 보관
                     )
-                    logger.info(
-                        f"Enqueued newsletter generation job {job.id} for schedule {schedule_id}"
+                    log_info(
+                        logger,
+                        "schedule.execute.enqueued",
+                        schedule_id=schedule_id,
+                        job_id=job.id,
                     )
                     redis_success = True
                 except Exception as redis_error:
                     # Redis 연결 실패 시 fallback으로 동기 실행
-                    logger.warning(
-                        f"Redis connection failed for schedule {schedule_id}: {redis_error}"
+                    log_exception(
+                        logger,
+                        "schedule.execute.redis_failed",
+                        redis_error,
+                        schedule_id=schedule_id,
                     )
-                    logger.info(
-                        f"Falling back to synchronous execution for schedule {schedule_id}"
+                    log_info(
+                        logger,
+                        "schedule.execute.fallback_sync",
+                        schedule_id=schedule_id,
                     )
 
             if not redis_success:
                 # Redis가 없거나 연결에 실패한 경우 동기 실행 (fallback)
-                logger.info(f"Executing schedule {schedule_id} synchronously")
+                log_info(
+                    logger, "schedule.execute.sync_started", schedule_id=schedule_id
+                )
                 result = generate_newsletter_task(
                     params,
                     schedule_job_id,
@@ -435,8 +529,11 @@ class ScheduleRunner:
                     idempotency_key,
                     self.db_path,
                 )
-                logger.info(
-                    f"Synchronous execution completed for schedule {schedule_id}: {result.get('status', 'unknown') if result else 'no result'}"
+                log_info(
+                    logger,
+                    "schedule.execute.sync_completed",
+                    schedule_id=schedule_id,
+                    status=result.get("status", "unknown") if result else "no_result",
                 )
 
             # 다음 실행 시간은 이미 실행 전에 업데이트됨 (중복 실행 방지)
@@ -444,45 +541,63 @@ class ScheduleRunner:
             return True
 
         except Exception as e:
-            logger.error(f"Failed to execute schedule {schedule['id']}: {e}")
-            # 스택트레이스 포함한 상세 에러 로깅
-            import traceback
-
-            logger.error(
-                f"Full traceback for schedule {schedule['id']}: {traceback.format_exc()}"
+            log_exception(
+                logger,
+                "schedule.execute.failed",
+                e,
+                schedule_id=schedule["id"],
             )
             return False
 
     def run_once(self) -> int:
         """한 번의 스케줄 체크 및 실행을 수행합니다."""
-        logger.info("Running schedule check...")
+        log_info(logger, "schedule.run_once.started")
 
         schedules = self.get_pending_schedules()
         executed_count = 0
 
-        logger.info(f"[DEBUG] Found {len(schedules)} pending schedules to execute")
+        log_debug(logger, "schedule.run_once.loaded", count=len(schedules))
 
         for i, schedule in enumerate(schedules):
             schedule_id = schedule.get("id", "unknown")
-            logger.info(
-                f"[DEBUG] Processing schedule {i+1}/{len(schedules)}: {schedule_id}"
+            log_debug(
+                logger,
+                "schedule.run_once.processing",
+                schedule_id=schedule_id,
+                index=i + 1,
+                total=len(schedules),
             )
             try:
                 if self.execute_schedule(schedule):
                     executed_count += 1
-                    logger.info(f"[DEBUG] Schedule {schedule_id} executed successfully")
+                    log_info(
+                        logger,
+                        "schedule.run_once.executed",
+                        schedule_id=schedule_id,
+                    )
                 else:
-                    logger.warning(f"[DEBUG] Schedule {schedule_id} execution failed")
+                    log_warning(
+                        logger,
+                        "schedule.run_once.execution_failed",
+                        schedule_id=schedule_id,
+                    )
             except Exception as e:
-                logger.error(f"[DEBUG] Exception executing schedule {schedule_id}: {e}")
+                log_exception(
+                    logger,
+                    "schedule.run_once.execution_exception",
+                    e,
+                    schedule_id=schedule_id,
+                )
 
-        logger.info(f"Executed {executed_count} schedules")
+        log_info(logger, "schedule.run_once.completed", executed_count=executed_count)
         return executed_count
 
     def run_continuous(self, check_interval: int = 60) -> None:
         """연속적으로 스케줄을 체크하고 실행합니다."""
-        logger.info(
-            f"Starting continuous schedule runner (check interval: {check_interval}s)"
+        log_info(
+            logger,
+            "schedule.runner.started",
+            check_interval_seconds=check_interval,
         )
 
         import time
@@ -493,10 +608,10 @@ class ScheduleRunner:
                 time.sleep(check_interval)
 
             except KeyboardInterrupt:
-                logger.info("Schedule runner stopped by user")
+                log_info(logger, "schedule.runner.stopped")
                 break
             except Exception as e:
-                logger.error(f"Error in schedule runner: {e}")
+                log_exception(logger, "schedule.runner.loop_failed", e)
                 time.sleep(check_interval)
 
 
@@ -518,7 +633,7 @@ def main() -> None:
 
     if args.once:
         count = runner.run_once()
-        logger.info(f"Executed {count} schedules")
+        log_info(logger, "schedule.runner.once_completed", executed_count=count)
     else:
         runner.run_continuous(args.interval)
 

--- a/web/tasks.py
+++ b/web/tasks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sqlite3
 import traceback
@@ -25,7 +26,13 @@ try:
 except ImportError:
     from .mail import get_newsletter_subject, send_email_with_outbox  # pragma: no cover
 
+try:
+    from ops_logging import log_exception, log_info, log_warning
+except ImportError:
+    from web.ops_logging import log_exception, log_info, log_warning  # pragma: no cover
+
 DATABASE_PATH = os.path.join(os.path.dirname(__file__), "storage.db")
+logger = logging.getLogger("web.tasks")
 
 
 def _resolve_database_path(database_path: str | None) -> str:
@@ -52,7 +59,14 @@ def generate_newsletter_task(
 ) -> Dict[str, Any]:
     """Generate newsletter in worker context with stable response schema."""
     db_path = _resolve_database_path(database_path)
-    print(f"🔄 Worker: starting newsletter generation for job {job_id}")
+    log_info(
+        logger,
+        "worker.job.started",
+        job_id=job_id,
+        send_email=send_email,
+        idempotency_key=idempotency_key,
+        db_path=db_path,
+    )
     update_history_status(
         db_path=db_path,
         job_id=job_id,
@@ -95,6 +109,14 @@ def generate_newsletter_task(
             except Exception as exc:
                 response["email_sent"] = False
                 response["email_error"] = str(exc)
+                log_warning(
+                    logger,
+                    "worker.email.send_failed",
+                    job_id=job_id,
+                    email=email,
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
 
         update_history_status(
             db_path=db_path,
@@ -103,6 +125,14 @@ def generate_newsletter_task(
             result=response,
             params=data,
             idempotency_key=idempotency_key,
+        )
+        log_info(
+            logger,
+            "worker.job.completed",
+            job_id=job_id,
+            status=response["status"],
+            email_sent=response["email_sent"],
+            email_deduplicated=response.get("email_deduplicated"),
         )
         return response
 
@@ -125,6 +155,7 @@ def generate_newsletter_task(
             params=data,
             idempotency_key=idempotency_key,
         )
+        log_exception(logger, "worker.job.generation_error", exc, job_id=job_id)
         raise
     except Exception as exc:
         error_response = {
@@ -146,6 +177,7 @@ def generate_newsletter_task(
             params=data,
             idempotency_key=idempotency_key,
         )
+        log_exception(logger, "worker.job.failed", exc, job_id=job_id)
         raise
 
 
@@ -172,4 +204,8 @@ def create_schedule_entry(params: Dict[str, Any], job_id: str) -> str:
 
 if __name__ == "__main__":
     test_params = {"keywords": "AI, machine learning", "email": "test@example.com"}
-    print(generate_newsletter_task(test_params, "test-job-id"))
+    log_info(
+        logger,
+        "worker.job.sample_result",
+        result=generate_newsletter_task(test_params, "test-job-id"),
+    )


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- replace noisy `print(...)` and ad-hoc `[DEBUG]` style output in the canonical Flask runtime with a shared event logging helper
- normalize runtime logs across app startup, generation, scheduler execution, worker tasks, and email send paths without changing request or scheduling behavior
- add a small unit test that locks the helper message format so follow-up logging changes stay stable

## Scope
### In Scope
- add `web/ops_logging.py`
- route canonical runtime logging through the helper in `web/app.py`, `web/routes_generation.py`, `web/routes_send_email.py`, `web/tasks.py`, and `web/schedule_runner.py`
- add regression coverage in `tests/unit_tests/test_web_ops_logging.py`

### Out of Scope
- non-canonical runtimes under `apps/experimental/`
- behavior, schema, idempotency, dedupe, or scheduling policy changes

## Delivery Unit
- RR: #181
- Delivery Unit ID: DU-20260308-ops-logging-structure
- Merge Boundary: canonical Flask runtime logging normalization only
- Rollback Boundary: revert `698b1ac`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): ops-safety pytest suite

### Commands and Results
```bash
MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/test_web_api.py -q
# 16 passed, 1 skipped

MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/unit_tests/test_schedule_time_sync.py tests/contract/test_web_email_routes_contract.py tests/unit_tests/test_config_import_side_effects.py tests/unit_tests/test_web_ops_logging.py -q
# 19 passed

RUN_INTEGRATION_TESTS=1 MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/integration/test_schedule_execution.py -q
# 7 passed, 1 skipped

EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr13 make check
# pass

EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr13 make check-full
# pass
```

## Risk & Rollback
- Risk: log consumers that parse legacy message strings may need to match the new event names instead of raw print output
- Rollback: revert `698b1ac`

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: unchanged; request/job keys are still produced and applied in the existing generation and schedule paths
- Outbox/send_key 중복 방지 결과: unchanged; verified by `tests/contract/test_web_email_routes_contract.py` and `tests/test_web_api.py`
- import-time side effect 제거 여부: no new import-time side effects introduced; helper is pure and logger setup remains runtime-local

## Not Run (with reason)
- GitHub Actions checks: pending after PR creation

Closes #181