### PR TITLE
feat(web): add draft approval gate for deliveries

### DIFF
--- a/tests/unit_tests/test_web_approval_gate.py
+++ b/tests/unit_tests/test_web_approval_gate.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+WEB_DIR = ROOT_DIR / "web"
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+import routes_send_email  # noqa: E402
+import tasks  # noqa: E402
+from db_state import ensure_database_schema, get_history_row  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def _build_send_email_app(database_path: str) -> Flask:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    routes_send_email.register_send_email_route(app, database_path)
+    return app
+
+
+def _insert_history_row(
+    db_path: str,
+    *,
+    job_id: str,
+    params: dict,
+    result: dict,
+    status: str = "completed",
+    approval_status: str = "not_requested",
+    delivery_status: str = "draft",
+) -> None:
+    ensure_database_schema(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT OR REPLACE INTO history (
+                id,
+                params,
+                result,
+                status,
+                approval_status,
+                delivery_status
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                job_id,
+                json.dumps(params),
+                json.dumps(result),
+                status,
+                approval_status,
+                delivery_status,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_generate_task_marks_email_job_pending_approval(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database_path = str(tmp_path / "storage.db")
+    ensure_database_schema(database_path)
+
+    monkeypatch.setattr(
+        tasks,
+        "generate_newsletter",
+        lambda request: {
+            "status": "success",
+            "html_content": "<html><body>approval</body></html>",
+            "title": "Approval Newsletter",
+            "generation_stats": {},
+            "input_params": {"keywords": request.keywords},
+        },
+    )
+
+    send_calls: list[dict[str, str]] = []
+
+    def _fake_send_email_with_outbox(**kwargs: str) -> dict[str, str]:
+        send_calls.append(kwargs)
+        return {"send_key": "unexpected-send", "skipped": False}
+
+    monkeypatch.setattr(tasks, "send_email_with_outbox", _fake_send_email_with_outbox)
+
+    result = tasks.generate_newsletter_task(
+        {
+            "keywords": ["AI", "robotics"],
+            "email": "approval@example.com",
+            "require_approval": True,
+        },
+        job_id="approval-job",
+        send_email=True,
+        idempotency_key="generate:approval-job",
+        database_path=database_path,
+    )
+
+    assert send_calls == []
+    assert result["approval_required"] is True
+    assert result["approval_status"] == "pending"
+    assert result["delivery_status"] == "pending_approval"
+    assert result["email_sent"] is False
+
+    history_row = get_history_row(database_path, "approval-job")
+    assert history_row is not None
+    assert history_row["status"] == "completed"
+    assert history_row["approval_status"] == "pending"
+    assert history_row["delivery_status"] == "pending_approval"
+
+
+def test_send_email_route_rejects_pending_approval_job(tmp_path: Path) -> None:
+    database_path = str(tmp_path / "storage.db")
+    app = _build_send_email_app(database_path)
+    job_id = "pending-approval-job"
+    _insert_history_row(
+        database_path,
+        job_id=job_id,
+        params={"keywords": ["AI"], "email": "approval@example.com"},
+        result={"html_content": "<html><body>approval</body></html>"},
+        approval_status="pending",
+        delivery_status="pending_approval",
+    )
+
+    with app.test_client() as client:
+        response = client.post(
+            "/api/send-email",
+            json={"job_id": job_id, "email": "approval@example.com"},
+        )
+
+    assert response.status_code == 409
+    assert response.get_json() == {"error": "승인 대기 중인 작업입니다"}
+
+
+def test_send_email_route_marks_approved_job_as_sent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database_path = str(tmp_path / "storage.db")
+    app = _build_send_email_app(database_path)
+    job_id = "approved-job"
+
+    _insert_history_row(
+        database_path,
+        job_id=job_id,
+        params={"keywords": ["AI"], "email": "approved@example.com"},
+        result={
+            "html_content": "<html><body>approved</body></html>",
+            "title": "Approved",
+        },
+        approval_status="approved",
+        delivery_status="approved",
+    )
+
+    monkeypatch.setattr(
+        routes_send_email,
+        "send_email_with_outbox",
+        lambda **kwargs: {"send_key": "approved-send-key", "skipped": False},
+    )
+    monkeypatch.setattr(
+        routes_send_email,
+        "get_newsletter_subject",
+        lambda result, params: "Approved Subject",
+    )
+
+    with app.test_client() as client:
+        response = client.post(
+            "/api/send-email",
+            json={"job_id": job_id, "email": "approved@example.com"},
+        )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["deduplicated"] is False
+
+    history_row = get_history_row(database_path, job_id)
+    assert history_row is not None
+    assert history_row["delivery_status"] == "sent"

--- a/web/db_state.py
+++ b/web/db_state.py
@@ -9,6 +9,19 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple
 
+APPROVAL_STATUS_NOT_REQUESTED = "not_requested"
+APPROVAL_STATUS_PENDING = "pending"
+APPROVAL_STATUS_APPROVED = "approved"
+APPROVAL_STATUS_REJECTED = "rejected"
+
+DELIVERY_STATUS_DRAFT = "draft"
+DELIVERY_STATUS_PENDING_APPROVAL = "pending_approval"
+DELIVERY_STATUS_APPROVED = "approved"
+DELIVERY_STATUS_SENT = "sent"
+DELIVERY_STATUS_SEND_FAILED = "send_failed"
+
+_UNSET = object()
+
 
 def is_feature_enabled(env_var: str, default: bool = True) -> bool:
     """Read a boolean feature flag from environment variables."""
@@ -55,6 +68,20 @@ def derive_job_id(idempotency_key: str, prefix: str = "job") -> str:
     return f"{prefix}_{digest}"
 
 
+def derive_history_review_state(
+    params: Dict[str, Any] | None,
+) -> tuple[str, str]:
+    """Derive initial approval and delivery state from request params."""
+    payload = params or {}
+    has_email = bool(str(payload.get("email", "") or "").strip())
+    requires_approval = bool(payload.get("require_approval")) and has_email
+
+    if requires_approval:
+        return APPROVAL_STATUS_PENDING, DELIVERY_STATUS_PENDING_APPROVAL
+
+    return APPROVAL_STATUS_NOT_REQUESTED, DELIVERY_STATUS_DRAFT
+
+
 def _ensure_column(
     cursor: sqlite3.Cursor, table_name: str, column_name: str, column_def: str
 ) -> None:
@@ -86,6 +113,21 @@ def _ensure_database_schema(conn: sqlite3.Connection) -> None:
         cursor, "history", "created_at", "TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
     )
     _ensure_column(cursor, "history", "idempotency_key", "TEXT")
+    _ensure_column(
+        cursor,
+        "history",
+        "approval_status",
+        f"TEXT DEFAULT '{APPROVAL_STATUS_NOT_REQUESTED}'",
+    )
+    _ensure_column(
+        cursor,
+        "history",
+        "delivery_status",
+        f"TEXT DEFAULT '{DELIVERY_STATUS_DRAFT}'",
+    )
+    _ensure_column(cursor, "history", "approved_at", "TEXT")
+    _ensure_column(cursor, "history", "rejected_at", "TEXT")
+    _ensure_column(cursor, "history", "approval_note", "TEXT")
 
     cursor.execute(
         """
@@ -185,6 +227,7 @@ def create_or_get_history_job(
     conn = _connect(db_path)
     try:
         cursor = conn.cursor()
+        approval_status, delivery_status = derive_history_review_state(params)
         if idempotency_key:
             cursor.execute(
                 "SELECT id, status FROM history WHERE idempotency_key = ?",
@@ -196,10 +239,24 @@ def create_or_get_history_job(
 
         cursor.execute(
             """
-            INSERT OR IGNORE INTO history (id, params, status, idempotency_key)
-            VALUES (?, ?, ?, ?)
+            INSERT OR IGNORE INTO history (
+                id,
+                params,
+                status,
+                idempotency_key,
+                approval_status,
+                delivery_status
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
             """,
-            (job_id, canonical_json(params), status, idempotency_key),
+            (
+                job_id,
+                canonical_json(params),
+                status,
+                idempotency_key,
+                approval_status,
+                delivery_status,
+            ),
         )
         conn.commit()
         return job_id, False, status
@@ -218,12 +275,27 @@ def ensure_history_row(
     conn = _connect(db_path)
     try:
         cursor = conn.cursor()
+        approval_status, delivery_status = derive_history_review_state(params)
         cursor.execute(
             """
-            INSERT OR IGNORE INTO history (id, params, status, idempotency_key)
-            VALUES (?, ?, ?, ?)
+            INSERT OR IGNORE INTO history (
+                id,
+                params,
+                status,
+                idempotency_key,
+                approval_status,
+                delivery_status
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
             """,
-            (job_id, canonical_json(params), status, idempotency_key),
+            (
+                job_id,
+                canonical_json(params),
+                status,
+                idempotency_key,
+                approval_status,
+                delivery_status,
+            ),
         )
         conn.commit()
     finally:
@@ -273,7 +345,11 @@ def get_history_row_by_idempotency_key(
     try:
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT id, status, result, params FROM history WHERE idempotency_key = ?",
+            """
+            SELECT id, status, result, params, approval_status, delivery_status
+            FROM history
+            WHERE idempotency_key = ?
+            """,
             (idempotency_key,),
         )
         row = cursor.fetchone()
@@ -284,6 +360,8 @@ def get_history_row_by_idempotency_key(
             "status": row[1],
             "result": row[2],
             "params": row[3],
+            "approval_status": row[4],
+            "delivery_status": row[5],
         }
     finally:
         conn.close()
@@ -295,7 +373,21 @@ def get_history_row(db_path: str, job_id: str) -> Optional[Dict[str, Any]]:
     try:
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT id, status, result, params, idempotency_key FROM history WHERE id = ?",
+            """
+            SELECT
+                id,
+                status,
+                result,
+                params,
+                idempotency_key,
+                approval_status,
+                delivery_status,
+                approved_at,
+                rejected_at,
+                approval_note
+            FROM history
+            WHERE id = ?
+            """,
             (job_id,),
         )
         row = cursor.fetchone()
@@ -307,7 +399,63 @@ def get_history_row(db_path: str, job_id: str) -> Optional[Dict[str, Any]]:
             "result": row[2],
             "params": row[3],
             "idempotency_key": row[4],
+            "approval_status": row[5],
+            "delivery_status": row[6],
+            "approved_at": row[7],
+            "rejected_at": row[8],
+            "approval_note": row[9],
         }
+    finally:
+        conn.close()
+
+
+def update_history_review_state(
+    db_path: str,
+    job_id: str,
+    *,
+    approval_status: str | None = None,
+    delivery_status: str | None = None,
+    approved_at: str | None | object = _UNSET,
+    rejected_at: str | None | object = _UNSET,
+    approval_note: str | None | object = _UNSET,
+) -> None:
+    """Update approval and delivery metadata for a history row."""
+    if (
+        approval_status is None
+        and delivery_status is None
+        and approved_at is _UNSET
+        and rejected_at is _UNSET
+        and approval_note is _UNSET
+    ):
+        return
+
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            UPDATE history
+            SET
+                approval_status = COALESCE(?, approval_status),
+                delivery_status = COALESCE(?, delivery_status),
+                approved_at = CASE WHEN ? THEN ? ELSE approved_at END,
+                rejected_at = CASE WHEN ? THEN ? ELSE rejected_at END,
+                approval_note = CASE WHEN ? THEN ? ELSE approval_note END
+            WHERE id = ?
+            """,
+            (
+                approval_status,
+                delivery_status,
+                approved_at is not _UNSET,
+                None if approved_at is _UNSET else approved_at,
+                rejected_at is not _UNSET,
+                None if rejected_at is _UNSET else rejected_at,
+                approval_note is not _UNSET,
+                None if approval_note is _UNSET else approval_note,
+                job_id,
+            ),
+        )
+        conn.commit()
     finally:
         conn.close()
 

--- a/web/routes_generation.py
+++ b/web/routes_generation.py
@@ -560,6 +560,8 @@ def register_generation_routes(
                 # Extract sent status from result if available
                 if isinstance(task["result"], dict):
                     response["sent"] = task["result"].get("sent", False)
+                    response["approval_status"] = task["result"].get("approval_status")
+                    response["delivery_status"] = task["result"].get("delivery_status")
             if "error" in task:
                 response["error"] = task["error"]
 
@@ -569,7 +571,20 @@ def register_generation_routes(
         conn = sqlite3.connect(DATABASE_PATH)
         cursor = conn.cursor()
         cursor.execute(
-            "SELECT params, result, status, idempotency_key FROM history WHERE id = ?",
+            """
+            SELECT
+                params,
+                result,
+                status,
+                idempotency_key,
+                approval_status,
+                delivery_status,
+                approved_at,
+                rejected_at,
+                approval_note
+            FROM history
+            WHERE id = ?
+            """,
             (job_id,),
         )
         row = cursor.fetchone()
@@ -578,13 +593,28 @@ def register_generation_routes(
         if not row:
             return jsonify({"error": "Job not found"}), 404
 
-        params, result, status, idempotency_key = row
+        (
+            params,
+            result,
+            status,
+            idempotency_key,
+            approval_status,
+            delivery_status,
+            approved_at,
+            rejected_at,
+            approval_note,
+        ) = row
         response = {
             "job_id": job_id,
             "status": status,
             "params": json.loads(params) if params else None,
             "sent": False,
             "idempotency_key": idempotency_key,
+            "approval_status": approval_status,
+            "delivery_status": delivery_status,
+            "approved_at": approved_at,
+            "rejected_at": rejected_at,
+            "approval_note": approval_note,
         }
 
         if result:
@@ -593,6 +623,12 @@ def register_generation_routes(
             # Extract sent status from result
             if isinstance(result_data, dict):
                 response["sent"] = result_data.get("sent", False)
+                response["approval_status"] = result_data.get(
+                    "approval_status", response["approval_status"]
+                )
+                response["delivery_status"] = result_data.get(
+                    "delivery_status", response["delivery_status"]
+                )
 
         return jsonify(response)
 
@@ -607,8 +643,10 @@ def register_generation_routes(
             cursor.execute(
                 """
                 SELECT id, params, result, created_at, status, idempotency_key
+                     , approval_status, delivery_status, approved_at, rejected_at, approval_note
                 FROM history
                 ORDER BY
+                    CASE WHEN approval_status = 'pending' THEN 0 ELSE 1 END,
                     CASE WHEN status = 'completed' THEN 0 ELSE 1 END,
                     created_at DESC
                 LIMIT 20
@@ -624,7 +662,19 @@ def register_generation_routes(
 
         history = []
         for row in rows:
-            job_id, params, result, created_at, status, idempotency_key = row
+            (
+                job_id,
+                params,
+                result,
+                created_at,
+                status,
+                idempotency_key,
+                approval_status,
+                delivery_status,
+                approved_at,
+                rejected_at,
+                approval_note,
+            ) = row
 
             try:
                 parsed_params = json.loads(params) if params else None
@@ -646,6 +696,11 @@ def register_generation_routes(
                     "created_at": created_at,
                     "status": status,
                     "idempotency_key": idempotency_key,
+                    "approval_status": approval_status,
+                    "delivery_status": delivery_status,
+                    "approved_at": approved_at,
+                    "rejected_at": rejected_at,
+                    "approval_note": approval_note,
                 }
             )
 
@@ -692,6 +747,7 @@ def register_generation_routes(
             "email_compatible": data.get("email_compatible", True),
             "period": data.get("period", 14),
             "send_email": True,
+            "require_approval": bool(data.get("require_approval", False)),
         }
         is_test = bool(data.get("is_test", False))
         expires_at = data.get("expires_at")

--- a/web/routes_send_email.py
+++ b/web/routes_send_email.py
@@ -13,6 +13,21 @@ except ImportError:
     from .mail import get_newsletter_subject, send_email_with_outbox  # pragma: no cover
 
 try:
+    from db_state import (
+        APPROVAL_STATUS_APPROVED,
+        APPROVAL_STATUS_NOT_REQUESTED,
+        DELIVERY_STATUS_SENT,
+        update_history_review_state,
+    )
+except ImportError:
+    from web.db_state import (  # pragma: no cover
+        APPROVAL_STATUS_APPROVED,
+        APPROVAL_STATUS_NOT_REQUESTED,
+        DELIVERY_STATUS_SENT,
+        update_history_review_state,
+    )
+
+try:
     from ops_logging import log_exception, log_info
 except ImportError:
     from web.ops_logging import log_exception, log_info  # pragma: no cover
@@ -38,7 +53,12 @@ def register_send_email_route(app: Flask, database_path: str) -> None:
             conn = sqlite3.connect(database_path)
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT status, result, params FROM history WHERE id = ?", (job_id,)
+                """
+                SELECT status, result, params, approval_status
+                FROM history
+                WHERE id = ?
+                """,
+                (job_id,),
             )
             row = cursor.fetchone()
             conn.close()
@@ -46,9 +66,16 @@ def register_send_email_route(app: Flask, database_path: str) -> None:
             if not row:
                 return jsonify({"error": "작업을 찾을 수 없습니다"}), 404
 
-            status, result_json, params_json = row
+            status, result_json, params_json, approval_status = row
             if status != "completed":
                 return jsonify({"error": "완료되지 않은 작업입니다"}), 400
+
+            if approval_status not in (
+                None,
+                APPROVAL_STATUS_NOT_REQUESTED,
+                APPROVAL_STATUS_APPROVED,
+            ):
+                return jsonify({"error": "승인 대기 중인 작업입니다"}), 409
 
             result = json.loads(result_json) if result_json else {}
             params = json.loads(params_json) if params_json else {}
@@ -68,6 +95,11 @@ def register_send_email_route(app: Flask, database_path: str) -> None:
             send_key = send_result["send_key"]
 
             if send_result.get("skipped"):
+                update_history_review_state(
+                    db_path=database_path,
+                    job_id=job_id,
+                    delivery_status=DELIVERY_STATUS_SENT,
+                )
                 log_info(
                     logger,
                     "email.send.deduplicated",
@@ -84,6 +116,11 @@ def register_send_email_route(app: Flask, database_path: str) -> None:
                     }
                 )
 
+            update_history_review_state(
+                db_path=database_path,
+                job_id=job_id,
+                delivery_status=DELIVERY_STATUS_SENT,
+            )
             log_info(
                 logger,
                 "email.send.completed",

--- a/web/tasks.py
+++ b/web/tasks.py
@@ -17,9 +17,27 @@ from newsletter_core.public.generation import (
 )
 
 try:
-    from db_state import update_history_status
+    from db_state import (
+        APPROVAL_STATUS_NOT_REQUESTED,
+        APPROVAL_STATUS_PENDING,
+        DELIVERY_STATUS_DRAFT,
+        DELIVERY_STATUS_PENDING_APPROVAL,
+        DELIVERY_STATUS_SEND_FAILED,
+        DELIVERY_STATUS_SENT,
+        update_history_review_state,
+        update_history_status,
+    )
 except ImportError:
-    from web.db_state import update_history_status  # pragma: no cover
+    from web.db_state import (  # pragma: no cover
+        APPROVAL_STATUS_NOT_REQUESTED,
+        APPROVAL_STATUS_PENDING,
+        DELIVERY_STATUS_DRAFT,
+        DELIVERY_STATUS_PENDING_APPROVAL,
+        DELIVERY_STATUS_SEND_FAILED,
+        DELIVERY_STATUS_SENT,
+        update_history_review_state,
+        update_history_status,
+    )
 
 try:
     from mail import get_newsletter_subject, send_email_with_outbox
@@ -76,6 +94,7 @@ def generate_newsletter_task(
     )
 
     email = data.get("email", "")
+    approval_required = bool(data.get("require_approval")) and bool(email)
 
     try:
         request = _build_request(data)
@@ -90,9 +109,20 @@ def generate_newsletter_task(
             "error": None,
             "sent": False,
             "email_sent": False,
+            "approval_required": approval_required,
+            "approval_status": (
+                APPROVAL_STATUS_PENDING
+                if approval_required
+                else APPROVAL_STATUS_NOT_REQUESTED
+            ),
+            "delivery_status": (
+                DELIVERY_STATUS_PENDING_APPROVAL
+                if approval_required
+                else DELIVERY_STATUS_DRAFT
+            ),
         }
 
-        if send_email and email:
+        if send_email and email and not approval_required:
             try:
                 send_result = send_email_with_outbox(
                     db_path=db_path,
@@ -109,6 +139,7 @@ def generate_newsletter_task(
             except Exception as exc:
                 response["email_sent"] = False
                 response["email_error"] = str(exc)
+                response["delivery_status"] = DELIVERY_STATUS_SEND_FAILED
                 log_warning(
                     logger,
                     "worker.email.send_failed",
@@ -117,6 +148,11 @@ def generate_newsletter_task(
                     error=str(exc),
                     error_type=type(exc).__name__,
                 )
+        elif response["delivery_status"] == DELIVERY_STATUS_DRAFT and approval_required:
+            response["delivery_status"] = DELIVERY_STATUS_PENDING_APPROVAL
+
+        if response["email_sent"]:
+            response["delivery_status"] = DELIVERY_STATUS_SENT
 
         update_history_status(
             db_path=db_path,
@@ -125,6 +161,12 @@ def generate_newsletter_task(
             result=response,
             params=data,
             idempotency_key=idempotency_key,
+        )
+        update_history_review_state(
+            db_path=db_path,
+            job_id=job_id,
+            approval_status=response["approval_status"],
+            delivery_status=response["delivery_status"],
         )
         log_info(
             logger,

--- a/web/types.py
+++ b/web/types.py
@@ -27,6 +27,7 @@ class GenerateNewsletterRequest(BaseModel):
     email_compatible: bool = False
     period: int = Field(default=14)
     email: Optional[str] = None  # 즉시 발송용 이메일 주소
+    require_approval: bool = False
 
     @field_validator("keywords")  # type: ignore[untyped-decorator]
     @classmethod


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- add additive approval and delivery metadata to `history` rows so generated newsletters can remain draft or pending approval before any send happens
- block the canonical send-email route when a job is still pending approval, while keeping already-approved and legacy rows sendable
- expose approval metadata on history/status responses and lock the state transitions with regression tests

## Scope
### In Scope
- `history` schema additions for approval and delivery state
- worker/send-email/runtime response updates for approval-required jobs
- schedule payload propagation for `require_approval`
- regression tests for approval gate behavior

### Out of Scope
- approval inbox UI and approve/reject APIs
- preset storage and preset UI

## Delivery Unit
- RR: #187
- Delivery Unit ID: DU-20260308-approval-draft-gate
- Merge Boundary: backend approval gate and response/schema support only
- Rollback Boundary: revert `c476b67`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): ops-safety suite and approval gate regressions

### Commands and Results
```bash
MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/unit_tests/test_web_approval_gate.py tests/test_web_api.py tests/contract/test_web_email_routes_contract.py tests/unit_tests/test_schedule_time_sync.py tests/unit_tests/test_config_import_side_effects.py -q
# 37 passed, 1 skipped

RUN_INTEGRATION_TESTS=1 MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/integration/test_schedule_execution.py -q
# 7 passed, 1 skipped

EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr14 make check
# pass

EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr14 make check-full
# pass
```

## Risk & Rollback
- Risk: legacy consumers that assumed all completed rows were immediately sendable must now respect `approval_status` / `delivery_status`
- Rollback: revert `c476b67`

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: unchanged. generation/schedule key generation and job reuse paths were not altered.
- Outbox/send_key 중복 방지 결과: unchanged. duplicate-prevention still runs through the existing outbox helper and contract tests remain green.
- import-time side effect 제거 여부: none introduced. schema migration and approval helpers run at DB access time only.

## Not Run (with reason)
- Browser manual flow verification: deferred to RR-15 because the approval UI is added there.

Closes #187