### PR TITLE
feat(web): persist saved generation presets

### DIFF
--- a/tests/unit_tests/test_web_access_control.py
+++ b/tests/unit_tests/test_web_access_control.py
@@ -35,6 +35,7 @@ def _build_app(*, testing: bool, monkeypatch: pytest.MonkeyPatch) -> Flask:
 def test_protected_route_matcher_covers_sensitive_paths() -> None:
     assert is_protected_route("/api/schedule")
     assert is_protected_route("/api/schedule/demo/run")
+    assert is_protected_route("/api/presets")
     assert is_protected_route("/api/send-email")
     assert not is_protected_route("/api/generate")
     assert not is_protected_route("/health")

--- a/tests/unit_tests/test_web_preset_routes.py
+++ b/tests/unit_tests/test_web_preset_routes.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+import routes_presets  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def _build_preset_app(database_path: str) -> Flask:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    routes_presets.register_preset_routes(app, database_path)
+    return app
+
+
+def test_preset_routes_create_and_list(tmp_path: Path) -> None:
+    app = _build_preset_app(str(tmp_path / "storage.db"))
+
+    payload = {
+        "name": "Weekly AI Digest",
+        "description": "Compact weekly summary",
+        "is_default": True,
+        "params": {
+            "keywords": ["AI", "robotics"],
+            "template_style": "compact",
+            "email_compatible": True,
+            "period": 7,
+            "email": "test@example.com",
+            "rrule": "FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=9;BYMINUTE=0",
+        },
+    }
+
+    with app.test_client() as client:
+        create_response = client.post(
+            "/api/presets",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        assert create_response.status_code == 201
+        created = create_response.get_json()
+        assert created is not None
+        assert created["name"] == "Weekly AI Digest"
+        assert created["is_default"] is True
+        assert created["params"]["keywords"] == ["AI", "robotics"]
+        assert created["params"]["rrule"].startswith("FREQ=WEEKLY")
+
+        list_response = client.get("/api/presets")
+        assert list_response.status_code == 200
+        presets = list_response.get_json()
+
+    assert isinstance(presets, list)
+    assert presets[0]["id"] == created["id"]
+    assert presets[0]["is_default"] is True
+
+
+def test_update_route_promotes_single_default_preset(tmp_path: Path) -> None:
+    app = _build_preset_app(str(tmp_path / "storage.db"))
+
+    first_payload = {
+        "name": "Daily AI",
+        "is_default": True,
+        "params": {
+            "keywords": ["AI"],
+            "template_style": "compact",
+            "email_compatible": False,
+            "period": 1,
+        },
+    }
+    second_payload = {
+        "name": "Domain Watch",
+        "is_default": False,
+        "params": {
+            "domain": "semiconductor",
+            "template_style": "detailed",
+            "email_compatible": True,
+            "period": 14,
+        },
+    }
+
+    with app.test_client() as client:
+        first_response = client.post(
+            "/api/presets",
+            data=json.dumps(first_payload),
+            content_type="application/json",
+        )
+        second_response = client.post(
+            "/api/presets",
+            data=json.dumps(second_payload),
+            content_type="application/json",
+        )
+
+        first = first_response.get_json()
+        second = second_response.get_json()
+        assert first_response.status_code == 201
+        assert second_response.status_code == 201
+
+        update_response = client.put(
+            f"/api/presets/{second['id']}",
+            data=json.dumps(
+                {
+                    "name": "Domain Watch",
+                    "description": "Promoted preset",
+                    "is_default": True,
+                    "params": {
+                        "domain": "semiconductor",
+                        "template_style": "modern",
+                        "email_compatible": True,
+                        "period": 30,
+                    },
+                }
+            ),
+            content_type="application/json",
+        )
+        assert update_response.status_code == 200
+
+        list_response = client.get("/api/presets")
+        presets = list_response.get_json()
+
+    assert isinstance(presets, list)
+    preset_by_id = {preset["id"]: preset for preset in presets}
+    assert preset_by_id[first["id"]]["is_default"] is False
+    assert preset_by_id[second["id"]]["is_default"] is True
+    assert preset_by_id[second["id"]]["params"]["template_style"] == "modern"
+    assert preset_by_id[second["id"]]["params"]["period"] == 30
+
+
+def test_delete_route_removes_preset(tmp_path: Path) -> None:
+    app = _build_preset_app(str(tmp_path / "storage.db"))
+
+    with app.test_client() as client:
+        create_response = client.post(
+            "/api/presets",
+            data=json.dumps(
+                {
+                    "name": "Delete Me",
+                    "params": {
+                        "keywords": ["ai"],
+                        "template_style": "compact",
+                        "email_compatible": False,
+                        "period": 7,
+                    },
+                }
+            ),
+            content_type="application/json",
+        )
+        preset = create_response.get_json()
+        assert create_response.status_code == 201
+
+        delete_response = client.delete(f"/api/presets/{preset['id']}")
+        assert delete_response.status_code == 200
+        assert delete_response.get_json() == {
+            "success": True,
+            "deleted_id": preset["id"],
+        }
+
+        list_response = client.get("/api/presets")
+        assert list_response.status_code == 200
+        assert list_response.get_json() == []

--- a/web/access_control.py
+++ b/web/access_control.py
@@ -17,6 +17,7 @@ ADMIN_TOKEN_HEADER = "X-Admin-Token"  # nosec B105
 
 _PROTECTED_PREFIXES: tuple[str, ...] = (
     "/api/history",
+    "/api/presets",
     "/api/schedule",
     "/api/schedules",
     "/api/send-email",

--- a/web/app.py
+++ b/web/app.py
@@ -245,6 +245,14 @@ register_email_api_routes(app)
 
 
 try:
+    from routes_presets import register_preset_routes
+except ImportError:
+    from web.routes_presets import register_preset_routes  # pragma: no cover
+
+register_preset_routes(app, DATABASE_PATH)
+
+
+try:
     from routes_newsletter_html import register_newsletter_html_route
 except ImportError:
     from web.routes_newsletter_html import (

--- a/web/db_state.py
+++ b/web/db_state.py
@@ -120,6 +120,20 @@ def _ensure_database_schema(conn: sqlite3.Connection) -> None:
     )
 
     cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS generation_presets (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE,
+            description TEXT,
+            params JSON NOT NULL,
+            is_default INTEGER NOT NULL DEFAULT 0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_history_created_at ON history(created_at)"
     )
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_history_status ON history(status)")
@@ -134,6 +148,12 @@ def _ensure_database_schema(conn: sqlite3.Connection) -> None:
     )
     cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_email_outbox_status ON email_outbox(status)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_generation_presets_default ON generation_presets(is_default)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_generation_presets_updated_at ON generation_presets(updated_at)"
     )
 
     conn.commit()
@@ -369,5 +389,162 @@ def mark_outbox_failed(db_path: str, send_key: str, error_message: str) -> None:
             (error_message, send_key),
         )
         conn.commit()
+    finally:
+        conn.close()
+
+
+def list_generation_presets(db_path: str) -> list[Dict[str, Any]]:
+    """Return generation presets ordered with defaults first."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, name, description, params, is_default, created_at, updated_at
+            FROM generation_presets
+            ORDER BY is_default DESC, updated_at DESC, created_at DESC
+            """
+        )
+        rows = cursor.fetchall()
+        return [
+            {
+                "id": row[0],
+                "name": row[1],
+                "description": row[2],
+                "params": json.loads(row[3]) if row[3] else {},
+                "is_default": bool(row[4]),
+                "created_at": row[5],
+                "updated_at": row[6],
+            }
+            for row in rows
+        ]
+    finally:
+        conn.close()
+
+
+def get_generation_preset(db_path: str, preset_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch a single generation preset."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, name, description, params, is_default, created_at, updated_at
+            FROM generation_presets
+            WHERE id = ?
+            """,
+            (preset_id,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return {
+            "id": row[0],
+            "name": row[1],
+            "description": row[2],
+            "params": json.loads(row[3]) if row[3] else {},
+            "is_default": bool(row[4]),
+            "created_at": row[5],
+            "updated_at": row[6],
+        }
+    finally:
+        conn.close()
+
+
+def create_generation_preset(
+    db_path: str,
+    preset_id: str,
+    name: str,
+    description: str | None,
+    params: Dict[str, Any],
+    *,
+    is_default: bool = False,
+) -> Dict[str, Any]:
+    """Create a generation preset and return the stored row."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        if is_default:
+            cursor.execute("UPDATE generation_presets SET is_default = 0")
+
+        cursor.execute(
+            """
+            INSERT INTO generation_presets (id, name, description, params, is_default)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                preset_id,
+                name,
+                description,
+                canonical_json(params),
+                int(is_default),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return get_generation_preset(db_path, preset_id) or {}
+
+
+def update_generation_preset(
+    db_path: str,
+    preset_id: str,
+    name: str,
+    description: str | None,
+    params: Dict[str, Any],
+    *,
+    is_default: bool = False,
+) -> Optional[Dict[str, Any]]:
+    """Update a generation preset and return the stored row."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT id FROM generation_presets WHERE id = ?",
+            (preset_id,),
+        )
+        if not cursor.fetchone():
+            return None
+
+        if is_default:
+            cursor.execute(
+                "UPDATE generation_presets SET is_default = 0 WHERE id != ?",
+                (preset_id,),
+            )
+
+        cursor.execute(
+            """
+            UPDATE generation_presets
+            SET name = ?,
+                description = ?,
+                params = ?,
+                is_default = ?,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (
+                name,
+                description,
+                canonical_json(params),
+                int(is_default),
+                preset_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return get_generation_preset(db_path, preset_id)
+
+
+def delete_generation_preset(db_path: str, preset_id: str) -> bool:
+    """Delete a generation preset."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM generation_presets WHERE id = ?", (preset_id,))
+        conn.commit()
+        return cursor.rowcount > 0
     finally:
         conn.close()

--- a/web/routes_presets.py
+++ b/web/routes_presets.py
@@ -1,0 +1,199 @@
+"""Route registration for saved generation preset management."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import uuid
+from typing import Any
+
+from flask import Flask, jsonify, request
+from flask.typing import ResponseReturnValue
+
+try:
+    from db_state import (
+        create_generation_preset,
+        delete_generation_preset,
+        get_generation_preset,
+        list_generation_presets,
+        update_generation_preset,
+    )
+except ImportError:
+    from web.db_state import (  # pragma: no cover
+        create_generation_preset,
+        delete_generation_preset,
+        get_generation_preset,
+        list_generation_presets,
+        update_generation_preset,
+    )
+
+try:
+    from ops_logging import log_exception, log_info
+except ImportError:
+    from web.ops_logging import log_exception, log_info  # pragma: no cover
+
+try:
+    from web.types import EMAIL_PATTERN
+except ImportError:
+    from .types import EMAIL_PATTERN  # pragma: no cover
+
+logger = logging.getLogger("web.routes_presets")
+
+VALID_TEMPLATE_STYLES = {"compact", "detailed", "modern"}
+VALID_PERIODS = {1, 7, 14, 30}
+
+
+def _normalize_keywords(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw_keywords = value.split(",")
+    elif isinstance(value, list):
+        raw_keywords = value
+    else:
+        raise ValueError("keywords must be a string or list")
+
+    keywords = [
+        str(keyword).strip() for keyword in raw_keywords if str(keyword).strip()
+    ]
+    return keywords
+
+
+def _normalize_preset_payload(raw_payload: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(raw_payload, dict):
+        raise ValueError("params must be an object")
+
+    keywords = _normalize_keywords(raw_payload.get("keywords"))
+    domain = str(raw_payload.get("domain", "") or "").strip()
+    if bool(keywords) == bool(domain):
+        raise ValueError("Provide either keywords or domain")
+
+    template_style = str(raw_payload.get("template_style", "compact") or "").strip()
+    if template_style not in VALID_TEMPLATE_STYLES:
+        raise ValueError("template_style must be one of: compact, detailed, modern")
+
+    try:
+        period = int(raw_payload.get("period", 14))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("period must be an integer") from exc
+    if period not in VALID_PERIODS:
+        raise ValueError("period must be one of: 1, 7, 14, 30")
+
+    email = str(raw_payload.get("email", "") or "").strip()
+    if email and not EMAIL_PATTERN.match(email):
+        raise ValueError("Invalid email format")
+
+    rrule = str(raw_payload.get("rrule", "") or "").strip()
+    if rrule:
+        if not email:
+            raise ValueError("Scheduled presets require an email address")
+        if not rrule.startswith("FREQ="):
+            raise ValueError("Invalid rrule format")
+
+    normalized = {
+        "template_style": template_style,
+        "email_compatible": bool(raw_payload.get("email_compatible", False)),
+        "period": period,
+    }
+    if keywords:
+        normalized["keywords"] = keywords
+    if domain:
+        normalized["domain"] = domain
+    if email:
+        normalized["email"] = email
+    if rrule:
+        normalized["rrule"] = rrule
+    return normalized
+
+
+def _normalize_preset_metadata(payload: dict[str, Any]) -> tuple[str, str | None, bool]:
+    name = str(payload.get("name", "") or "").strip()
+    if not name:
+        raise ValueError("name is required")
+    if len(name) > 80:
+        raise ValueError("name must be 80 characters or fewer")
+
+    description = str(payload.get("description", "") or "").strip() or None
+    if description and len(description) > 240:
+        raise ValueError("description must be 240 characters or fewer")
+
+    return name, description, bool(payload.get("is_default", False))
+
+
+def register_preset_routes(app: Flask, database_path: str) -> None:
+    """Register saved generation preset routes."""
+
+    @app.route("/api/presets")  # type: ignore[untyped-decorator]
+    def list_presets() -> ResponseReturnValue:
+        try:
+            return jsonify(list_generation_presets(database_path))
+        except Exception as exc:
+            log_exception(logger, "preset.list.failed", exc)
+            return jsonify({"error": "프리셋 목록을 불러오지 못했습니다"}), 500
+
+    @app.route("/api/presets", methods=["POST"])  # type: ignore[untyped-decorator]
+    def create_preset() -> ResponseReturnValue:
+        try:
+            payload = request.get_json() or {}
+            name, description, is_default = _normalize_preset_metadata(payload)
+            params = _normalize_preset_payload(payload.get("params") or {})
+            preset = create_generation_preset(
+                db_path=database_path,
+                preset_id=f"preset_{uuid.uuid4().hex[:12]}",
+                name=name,
+                description=description,
+                params=params,
+                is_default=is_default,
+            )
+            log_info(logger, "preset.create.completed", preset_id=preset["id"])
+            return jsonify(preset), 201
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        except sqlite3.IntegrityError:
+            return jsonify({"error": "같은 이름의 프리셋이 이미 존재합니다"}), 409
+        except Exception as exc:
+            log_exception(logger, "preset.create.failed", exc)
+            return jsonify({"error": "프리셋 저장에 실패했습니다"}), 500
+
+    @app.route("/api/presets/<preset_id>", methods=["PUT"])  # type: ignore[untyped-decorator]
+    def update_preset(preset_id: str) -> ResponseReturnValue:
+        try:
+            payload = request.get_json() or {}
+            name, description, is_default = _normalize_preset_metadata(payload)
+            params = _normalize_preset_payload(payload.get("params") or {})
+            preset = update_generation_preset(
+                db_path=database_path,
+                preset_id=preset_id,
+                name=name,
+                description=description,
+                params=params,
+                is_default=is_default,
+            )
+            if not preset:
+                return jsonify({"error": "프리셋을 찾을 수 없습니다"}), 404
+            log_info(logger, "preset.update.completed", preset_id=preset_id)
+            return jsonify(preset)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        except sqlite3.IntegrityError:
+            return jsonify({"error": "같은 이름의 프리셋이 이미 존재합니다"}), 409
+        except Exception as exc:
+            log_exception(logger, "preset.update.failed", exc, preset_id=preset_id)
+            return jsonify({"error": "프리셋 수정에 실패했습니다"}), 500
+
+    @app.route("/api/presets/<preset_id>", methods=["DELETE"])  # type: ignore[untyped-decorator]
+    def delete_preset(preset_id: str) -> ResponseReturnValue:
+        try:
+            preset = get_generation_preset(database_path, preset_id)
+            if not preset:
+                return jsonify({"error": "프리셋을 찾을 수 없습니다"}), 404
+
+            deleted = delete_generation_preset(database_path, preset_id)
+            if not deleted:
+                return jsonify({"error": "프리셋을 찾을 수 없습니다"}), 404
+
+            log_info(logger, "preset.delete.completed", preset_id=preset_id)
+            return jsonify({"success": True, "deleted_id": preset_id})
+        except Exception as exc:
+            log_exception(logger, "preset.delete.failed", exc, preset_id=preset_id)
+            return jsonify({"error": "프리셋 삭제에 실패했습니다"}), 500


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- add persistent saved generation presets to the canonical Flask runtime
- expose protected CRUD routes so preset UX can be layered in a follow-up PR without changing the storage contract

## Scope
### In Scope
- add `generation_presets` schema and DB helpers
- register `/api/presets` CRUD routes in the canonical web app
- protect preset routes with the existing admin token policy
- add preset route and access-control regression tests

### Out of Scope
- preset selection and save/load UI in the web form
- approval workflow changes

## Delivery Unit
- RR: #185
- Delivery Unit ID: DU-20260308-preset-storage
- Merge Boundary: preset persistence and API only
- Rollback Boundary: fe0237d09f3a7c440eeb1b483165f4f7192edc92

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): preset route unit tests plus canonical web/runtime suites

### Commands and Results
```bash
MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/unit_tests/test_web_preset_routes.py tests/unit_tests/test_web_access_control.py tests/test_web_api.py tests/contract/test_web_email_routes_contract.py tests/unit_tests/test_schedule_time_sync.py tests/unit_tests/test_config_import_side_effects.py tests/contract/test_web_runtime_contract.py -q
# 46 passed, 1 skipped

RUN_INTEGRATION_TESTS=1 MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/integration/test_schedule_execution.py -q
# 7 passed, 1 skipped

EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr16 make check
# pass

EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr16 make check-full
# pass
```

## Risk & Rollback
- Risk: additive schema and new protected preset routes may affect canonical app startup or admin-token route coverage.
- Rollback: revert `fe0237d09f3a7c440eeb1b483165f4f7192edc92`.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: unchanged; presets do not participate in job or schedule idempotency.
- Outbox/send_key 중복 방지 결과: unchanged; preset CRUD does not send email.
- import-time side effect 제거 여부: no new import-time side effects introduced.

## Not Run (with reason)
- None.
