### PR TITLE
feat(web): wire saved presets into the form

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -8,6 +8,8 @@ class NewsletterApp {
         this.currentJobId = null;
         this.pollInterval = null;
         this.adminTokenStorageKey = 'newsletter-admin-api-token';
+        this.savedPresets = [];
+        this.selectedPresetId = '';
         this.init();
     }
 
@@ -17,6 +19,8 @@ class NewsletterApp {
         this.toggleInputMethod();
         this.toggleScheduleSettings(document.getElementById('enableSchedule').checked);
         this.updateScheduleOptions();
+        this.syncPresetActions();
+        this.loadPresets();
     }
 
     bindEvents() {
@@ -46,7 +50,16 @@ class NewsletterApp {
         document.getElementById('downloadBtn').addEventListener('click', () => this.downloadNewsletter());
         document.getElementById('sendEmailBtn').addEventListener('click', () => this.sendEmail());
         document.getElementById('emailConfigBtn').addEventListener('click', () => this.checkEmailConfiguration());
-        document.getElementById('adminToken').addEventListener('input', (e) => this.persistAdminToken(e.target.value));
+        document.getElementById('adminToken').addEventListener('input', (e) => {
+            this.persistAdminToken(e.target.value);
+            this.loadPresets(this.selectedPresetId);
+        });
+        document.getElementById('presetSelect').addEventListener('change', (e) => this.handlePresetSelection(e.target.value));
+        document.getElementById('applyPresetBtn').addEventListener('click', () => this.applySelectedPreset());
+        document.getElementById('savePresetBtn').addEventListener('click', () => this.saveNewPreset());
+        document.getElementById('updatePresetBtn').addEventListener('click', () => this.updateSelectedPreset());
+        document.getElementById('deletePresetBtn').addEventListener('click', () => this.deleteSelectedPreset());
+        document.getElementById('refreshPresetsBtn').addEventListener('click', () => this.loadPresets(this.selectedPresetId));
 
         // Navigation buttons
         document.getElementById('historyBtn').addEventListener('click', () => this.switchTab('historyTab'));
@@ -96,6 +109,104 @@ class NewsletterApp {
 
     getProtectedRouteMessage(defaultMessage = '운영 토큰이 필요합니다.') {
         return `${defaultMessage} 상단의 운영 토큰을 입력한 뒤 다시 시도해주세요.`;
+    }
+
+    setPresetStatus(message, tone = 'gray') {
+        const presetStatus = document.getElementById('presetStatus');
+        presetStatus.className = `mt-2 text-sm text-${tone}-600`;
+        presetStatus.textContent = message;
+    }
+
+    syncPresetActions() {
+        const hasSelection = Boolean(this.selectedPresetId);
+        ['applyPresetBtn', 'updatePresetBtn', 'deletePresetBtn'].forEach((buttonId) => {
+            const button = document.getElementById(buttonId);
+            button.disabled = !hasSelection;
+            button.classList.toggle('opacity-50', !hasSelection);
+            button.classList.toggle('cursor-not-allowed', !hasSelection);
+        });
+    }
+
+    renderPresetOptions(preferredPresetId = '') {
+        const presetSelect = document.getElementById('presetSelect');
+        const nextSelectedId = preferredPresetId || this.selectedPresetId;
+        presetSelect.innerHTML = '';
+
+        const placeholderOption = document.createElement('option');
+        placeholderOption.value = '';
+        placeholderOption.textContent = '프리셋을 선택하세요';
+        presetSelect.appendChild(placeholderOption);
+
+        this.savedPresets.forEach((preset) => {
+            const option = document.createElement('option');
+            option.value = preset.id;
+            option.textContent = `${preset.name}${preset.is_default ? ' (기본)' : ''}`;
+            option.selected = preset.id === nextSelectedId;
+            presetSelect.appendChild(option);
+        });
+
+        this.selectedPresetId = presetSelect.value;
+        this.syncPresetActions();
+    }
+
+    getSelectedPreset() {
+        return this.savedPresets.find((preset) => preset.id === this.selectedPresetId) || null;
+    }
+
+    handlePresetSelection(presetId) {
+        this.selectedPresetId = presetId || '';
+        this.syncPresetActions();
+
+        const preset = this.getSelectedPreset();
+        if (preset) {
+            const summary = preset.description
+                ? `${preset.name}: ${preset.description}`
+                : `${preset.name} 프리셋이 준비되었습니다.`;
+            this.setPresetStatus(summary, 'gray');
+            return;
+        }
+
+        this.setPresetStatus('운영 토큰이 있으면 프리셋을 저장하고 불러올 수 있습니다.');
+    }
+
+    async loadPresets(preferredPresetId = '') {
+        const presetSelect = document.getElementById('presetSelect');
+
+        try {
+            const response = await fetch('/api/presets', {
+                headers: this.buildHeaders({ includeAdminToken: true })
+            });
+            const result = await response.json();
+
+            if (!response.ok) {
+                this.savedPresets = [];
+                presetSelect.innerHTML = '<option value="">프리셋을 선택하세요</option>';
+                this.selectedPresetId = '';
+                this.syncPresetActions();
+                const message = response.status === 401 || response.status === 503
+                    ? this.getProtectedRouteMessage(result.error || '프리셋을 불러올 수 없습니다.')
+                    : (result.error || '프리셋을 불러올 수 없습니다.');
+                this.setPresetStatus(message, 'yellow');
+                return;
+            }
+
+            this.savedPresets = Array.isArray(result) ? result : [];
+            const resolvedPresetId = preferredPresetId || this.selectedPresetId || this.savedPresets.find((preset) => preset.is_default)?.id || '';
+            this.renderPresetOptions(resolvedPresetId);
+
+            if (this.savedPresets.length === 0) {
+                this.setPresetStatus('저장된 프리셋이 없습니다. 현재 입력값으로 새 프리셋을 저장해보세요.');
+            } else if (this.selectedPresetId) {
+                this.handlePresetSelection(this.selectedPresetId);
+            } else {
+                this.setPresetStatus('프리셋을 선택하면 현재 폼에 불러올 수 있습니다.');
+            }
+        } catch (error) {
+            this.savedPresets = [];
+            this.selectedPresetId = '';
+            this.syncPresetActions();
+            this.setPresetStatus(`프리셋 조회 실패: ${error.message}`, 'red');
+        }
     }
 
     switchTab(tabId) {
@@ -172,6 +283,74 @@ class NewsletterApp {
         } else {
             weeklyOptions.classList.add('hidden');
         }
+    }
+
+    applyScheduleFromRRule(rrule) {
+        if (!rrule) {
+            document.getElementById('enableSchedule').checked = false;
+            this.toggleScheduleSettings(false);
+            return;
+        }
+
+        const parts = Object.fromEntries(
+            rrule.split(';').map((part) => {
+                const [key, value] = part.split('=');
+                return [key, value];
+            })
+        );
+
+        document.getElementById('enableSchedule').checked = true;
+        this.toggleScheduleSettings(true);
+        document.getElementById('frequency').value = parts.FREQ || 'WEEKLY';
+        this.updateScheduleOptions();
+
+        if (parts.BYHOUR && parts.BYMINUTE) {
+            const hour = String(parts.BYHOUR).padStart(2, '0');
+            const minute = String(parts.BYMINUTE).padStart(2, '0');
+            document.getElementById('scheduleTime').value = `${hour}:${minute}`;
+        }
+
+        const selectedDays = new Set((parts.BYDAY || '').split(',').filter(Boolean));
+        document.querySelectorAll('.weekday').forEach((checkbox) => {
+            checkbox.checked = selectedDays.has(checkbox.value);
+        });
+    }
+
+    applyParamsToForm(params = {}) {
+        const keywords = params.keywords;
+
+        if (keywords && keywords.length > 0) {
+            document.getElementById('keywordsMethod').checked = true;
+            document.getElementById('keywords').value = Array.isArray(keywords) ? keywords.join(', ') : String(keywords);
+            document.getElementById('domain').value = '';
+        } else if (params.domain) {
+            document.getElementById('domainMethod').checked = true;
+            document.getElementById('domain').value = params.domain;
+            document.getElementById('keywords').value = '';
+        }
+
+        document.getElementById('period').value = String(params.period || 14);
+        document.getElementById('templateStyle').value = params.template_style || 'compact';
+        document.getElementById('emailCompatible').checked = Boolean(params.email_compatible);
+        document.getElementById('email').value = params.email || '';
+        this.applyScheduleFromRRule(params.rrule || '');
+        this.toggleInputMethod();
+    }
+
+    applyPresetToForm(preset) {
+        this.applyParamsToForm(preset?.params || {});
+    }
+
+    applySelectedPreset() {
+        const preset = this.getSelectedPreset();
+        if (!preset) {
+            this.showError('불러올 프리셋을 선택해주세요.');
+            return;
+        }
+
+        this.applyPresetToForm(preset);
+        this.setPresetStatus(`${preset.name} 프리셋을 현재 폼에 적용했습니다.`, 'green');
+        this.showSuccess(`프리셋 적용 완료: ${preset.name}`);
     }
 
     async generateNewsletter() {
@@ -283,6 +462,10 @@ class NewsletterApp {
             data.email = email;
         }
 
+        data.period = parseInt(document.getElementById('period').value, 10);
+        data.template_style = document.getElementById('templateStyle').value;
+        data.email_compatible = document.getElementById('emailCompatible').checked;
+
         // Schedule data
         const enableSchedule = document.getElementById('enableSchedule').checked;
         if (includeSchedule && enableSchedule) {
@@ -314,6 +497,146 @@ class NewsletterApp {
         }
 
         return data;
+    }
+
+    buildPresetRequest(existingPreset = null) {
+        const params = this.collectFormData({ includeSchedule: true, includeEmail: true });
+        if (!params) {
+            return null;
+        }
+
+        const name = window.prompt(
+            '프리셋 이름을 입력하세요.',
+            existingPreset?.name || ''
+        );
+        if (name === null) {
+            return null;
+        }
+
+        const normalizedName = String(name || '').trim();
+        if (!normalizedName) {
+            this.showError('프리셋 이름을 입력해주세요.');
+            return null;
+        }
+
+        const descriptionInput = window.prompt(
+            '프리셋 설명을 입력하세요. (선택)',
+            existingPreset?.description || ''
+        );
+        if (descriptionInput === null) {
+            return null;
+        }
+
+        const shouldSetDefault = window.confirm(
+            existingPreset?.is_default
+                ? '현재 기본 프리셋입니다. 기본 프리셋으로 유지할까요?'
+                : '이 프리셋을 기본 프리셋으로 지정할까요?'
+        );
+
+        return {
+            name: normalizedName,
+            description: (descriptionInput || '').trim(),
+            is_default: shouldSetDefault,
+            params
+        };
+    }
+
+    async saveNewPreset() {
+        const payload = this.buildPresetRequest();
+        if (!payload) {
+            return;
+        }
+
+        try {
+            const response = await fetch('/api/presets', {
+                method: 'POST',
+                headers: this.buildHeaders({ includeJson: true, includeAdminToken: true }),
+                body: JSON.stringify(payload)
+            });
+            const result = await response.json();
+
+            if (!response.ok) {
+                const message = response.status === 401 || response.status === 503
+                    ? this.getProtectedRouteMessage(result.error || '프리셋 저장 권한이 없습니다.')
+                    : (result.error || '프리셋 저장에 실패했습니다.');
+                this.showError(message);
+                return;
+            }
+
+            await this.loadPresets(result.id);
+            this.showSuccess(`프리셋 저장 완료: ${result.name}`);
+        } catch (error) {
+            this.showError('Network error: ' + error.message);
+        }
+    }
+
+    async updateSelectedPreset() {
+        const preset = this.getSelectedPreset();
+        if (!preset) {
+            this.showError('업데이트할 프리셋을 선택해주세요.');
+            return;
+        }
+
+        const payload = this.buildPresetRequest(preset);
+        if (!payload) {
+            return;
+        }
+
+        try {
+            const response = await fetch(`/api/presets/${preset.id}`, {
+                method: 'PUT',
+                headers: this.buildHeaders({ includeJson: true, includeAdminToken: true }),
+                body: JSON.stringify(payload)
+            });
+            const result = await response.json();
+
+            if (!response.ok) {
+                const message = response.status === 401 || response.status === 503
+                    ? this.getProtectedRouteMessage(result.error || '프리셋 수정 권한이 없습니다.')
+                    : (result.error || '프리셋 수정에 실패했습니다.');
+                this.showError(message);
+                return;
+            }
+
+            await this.loadPresets(result.id);
+            this.showSuccess(`프리셋 업데이트 완료: ${result.name}`);
+        } catch (error) {
+            this.showError('Network error: ' + error.message);
+        }
+    }
+
+    async deleteSelectedPreset() {
+        const preset = this.getSelectedPreset();
+        if (!preset) {
+            this.showError('삭제할 프리셋을 선택해주세요.');
+            return;
+        }
+
+        if (!confirm(`프리셋 "${preset.name}"을 삭제하시겠습니까?`)) {
+            return;
+        }
+
+        try {
+            const response = await fetch(`/api/presets/${preset.id}`, {
+                method: 'DELETE',
+                headers: this.buildHeaders({ includeAdminToken: true })
+            });
+            const result = await response.json();
+
+            if (!response.ok) {
+                const message = response.status === 401 || response.status === 503
+                    ? this.getProtectedRouteMessage(result.error || '프리셋 삭제 권한이 없습니다.')
+                    : (result.error || '프리셋 삭제에 실패했습니다.');
+                this.showError(message);
+                return;
+            }
+
+            this.selectedPresetId = '';
+            await this.loadPresets();
+            this.showSuccess(`프리셋 삭제 완료: ${preset.name}`);
+        } catch (error) {
+            this.showError('Network error: ' + error.message);
+        }
     }
 
     showProgress() {
@@ -852,20 +1175,7 @@ class NewsletterApp {
             const result = await response.json();
 
             if (result.params) {
-                // Populate form with historical parameters
-                if (result.params.keywords) {
-                    document.getElementById('keywordsMethod').checked = true;
-                    document.getElementById('keywords').value = Array.isArray(result.params.keywords) ? result.params.keywords.join(', ') : result.params.keywords;
-                } else if (result.params.domain) {
-                    document.getElementById('domainMethod').checked = true;
-                    document.getElementById('domain').value = result.params.domain;
-                }
-
-                if (result.params.email) {
-                    document.getElementById('email').value = result.params.email;
-                }
-
-                this.toggleInputMethod();
+                this.applyParamsToForm(result.params);
                 this.switchTab('generateTab');
             }
         } catch (error) {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -63,6 +63,43 @@
                 <div class="px-4 py-5 sm:p-6">
                     <h3 class="text-lg leading-6 font-medium text-gray-900 mb-4">뉴스레터 생성</h3>
 
+                    <div class="mb-6 rounded-lg border border-gray-200 bg-gray-50 p-4">
+                        <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                            <div class="flex-1">
+                                <label for="presetSelect" class="block text-sm font-medium text-gray-700">저장된 프리셋</label>
+                                <select id="presetSelect"
+                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm">
+                                    <option value="">프리셋을 선택하세요</option>
+                                </select>
+                                <p id="presetStatus" class="mt-2 text-sm text-gray-500">
+                                    운영 토큰이 있으면 프리셋을 저장하고 불러올 수 있습니다.
+                                </p>
+                            </div>
+                            <div class="flex flex-wrap gap-2">
+                                <button id="applyPresetBtn"
+                                        class="rounded-md bg-gray-700 px-3 py-2 text-sm font-medium text-white hover:bg-gray-800">
+                                    불러오기
+                                </button>
+                                <button id="savePresetBtn"
+                                        class="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700">
+                                    새 프리셋 저장
+                                </button>
+                                <button id="updatePresetBtn"
+                                        class="rounded-md bg-yellow-500 px-3 py-2 text-sm font-medium text-white hover:bg-yellow-600">
+                                    선택 프리셋 업데이트
+                                </button>
+                                <button id="deletePresetBtn"
+                                        class="rounded-md bg-red-600 px-3 py-2 text-sm font-medium text-white hover:bg-red-700">
+                                    삭제
+                                </button>
+                                <button id="refreshPresetsBtn"
+                                        class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100">
+                                    새로고침
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Input Method Selection -->
                     <div class="mb-6">
                         <label class="text-base font-medium text-gray-900">입력 방식</label>
@@ -109,6 +146,38 @@
                         </div>
                         <p class="mt-2 text-sm text-gray-500">관심 있는 분야나 도메인을 입력하고 추천받기 버튼을 클릭하세요.</p>
                         <div id="keywords-result" class="mt-3"></div>
+                    </div>
+
+                    <div class="mb-6 rounded-lg border border-gray-200 bg-gray-50 p-4">
+                        <h4 class="text-sm font-medium text-gray-900 mb-3">생성 옵션</h4>
+                        <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+                            <div>
+                                <label for="period" class="block text-sm font-medium text-gray-700">수집 기간</label>
+                                <select id="period"
+                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm">
+                                    <option value="1">최근 1일</option>
+                                    <option value="7">최근 7일</option>
+                                    <option value="14" selected>최근 14일</option>
+                                    <option value="30">최근 30일</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label for="templateStyle" class="block text-sm font-medium text-gray-700">템플릿 스타일</label>
+                                <select id="templateStyle"
+                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm">
+                                    <option value="compact" selected>Compact</option>
+                                    <option value="detailed">Detailed</option>
+                                    <option value="modern">Modern</option>
+                                </select>
+                            </div>
+                            <div class="flex items-end">
+                                <label class="flex items-center rounded-md border border-gray-200 bg-white px-3 py-2 shadow-sm">
+                                    <input type="checkbox" id="emailCompatible"
+                                           class="rounded border-gray-300 text-blue-600 focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50">
+                                    <span class="ml-2 text-sm text-gray-700">이메일 호환 렌더링</span>
+                                </label>
+                            </div>
+                        </div>
                     </div>
 
                     <!-- Email Input -->


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- wire saved presets into the canonical web form so operators can load, save, update, and delete presets without raw API calls
- expose preset-relevant generation fields in the UI so the stored preset contract is actually usable end to end

## Scope
### In Scope
- add preset controls to the generate form
- add period, template style, and email-compatible options to the form and request payloads
- wire preset CRUD actions to `/api/presets`
- repopulate schedule and generation fields when applying presets or reusing history items

### Out of Scope
- preset sharing beyond the existing global storage model
- approval workflow changes

## Delivery Unit
- RR: #188
- Delivery Unit ID: DU-20260308-preset-form-ux
- Merge Boundary: form UX only, stacked on RR-16 preset storage
- Rollback Boundary: 9b38fd6425ae79c582d69fc3c268df6c29b89f16

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): `node --check web/static/js/app.js`

### Commands and Results
```bash
node --check web/static/js/app.js
# pass

EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr17 make check
# pass

EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr17 make check-full
# pass
```

## Risk & Rollback
- Risk: frontend preset UX now depends on RR-16 preset API availability and admin-token protected access in production-like runtimes.
- Rollback: revert `9b38fd6425ae79c582d69fc3c268df6c29b89f16` on top of RR-16.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: unchanged; UI changes do not alter backend idempotency behavior.
- Outbox/send_key 중복 방지 결과: unchanged; preset UX only affects request payload selection.
- import-time side effect 제거 여부: no new import-time side effects introduced.

## Not Run (with reason)
- None.
