### PR TITLE
feat(web): enforce source allow and block policies

### DIFF
--- a/newsletter_core/public/__init__.py
+++ b/newsletter_core/public/__init__.py
@@ -1,3 +1,3 @@
 """Public API surface for newsletter_core."""
 
-__all__ = ["generation", "settings", "lifecycle"]
+__all__ = ["generation", "settings", "lifecycle", "source_policies"]

--- a/newsletter_core/public/generation.py
+++ b/newsletter_core/public/generation.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import re
+from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, TypedDict, Union
+from unittest.mock import patch
+
+from langchain.tools import tool
 
 from newsletter import graph, tools
+from newsletter_core.public.source_policies import filter_articles_by_source_policies
 
 
 class NewsletterGenerationError(Exception):
@@ -36,6 +41,8 @@ class GenerateNewsletterRequest:
     email_compatible: bool = False
     period: int = 14
     suggest_count: int = 10
+    source_allowlist: Optional[List[str]] = None
+    source_blocklist: Optional[List[str]] = None
 
 
 def _normalize_keywords(raw: Optional[Union[str, List[str]]]) -> List[str]:
@@ -73,18 +80,55 @@ def _resolve_keywords(request: GenerateNewsletterRequest) -> List[str]:
     raise NewsletterGenerationError("Either keywords or domain must be provided")
 
 
+def _build_filtered_search_tool(
+    allowlist: List[str] | None,
+    blocklist: List[str] | None,
+):
+    original_search_tool = tools.search_news_articles
+
+    @tool
+    def filtered_search_news_articles(
+        keywords: str, num_results: int = 10
+    ) -> List[Dict[str, Any]]:
+        """Search for articles and enforce configured source allow/block policies."""
+        articles = original_search_tool.invoke(
+            {"keywords": keywords, "num_results": num_results}
+        )
+        return filter_articles_by_source_policies(
+            articles,
+            allowlist=allowlist or [],
+            blocklist=blocklist or [],
+        )
+
+    return filtered_search_news_articles
+
+
 def generate_newsletter(request: GenerateNewsletterRequest) -> NewsletterResult:
     """Generate newsletter HTML and return a stable response schema."""
     keywords = _resolve_keywords(request)
 
-    try:
-        html_or_error, status = graph.generate_newsletter(
-            keywords,
-            news_period_days=request.period,
-            domain=request.domain,
-            template_style=request.template_style,
-            email_compatible=request.email_compatible,
+    search_tool_override = (
+        patch.object(
+            tools,
+            "search_news_articles",
+            _build_filtered_search_tool(
+                request.source_allowlist,
+                request.source_blocklist,
+            ),
         )
+        if request.source_allowlist or request.source_blocklist
+        else nullcontext()
+    )
+
+    try:
+        with search_tool_override:
+            html_or_error, status = graph.generate_newsletter(
+                keywords,
+                news_period_days=request.period,
+                domain=request.domain,
+                template_style=request.template_style,
+                email_compatible=request.email_compatible,
+            )
     except Exception as exc:  # pragma: no cover - defensive wrapper
         raise NewsletterGenerationError(str(exc)) from exc
 
@@ -103,6 +147,8 @@ def generate_newsletter(request: GenerateNewsletterRequest) -> NewsletterResult:
         "email_compatible": request.email_compatible,
         "period": request.period,
         "suggest_count": request.suggest_count,
+        "source_allowlist": request.source_allowlist or [],
+        "source_blocklist": request.source_blocklist or [],
     }
 
     if status != "success":

--- a/newsletter_core/public/source_policies.py
+++ b/newsletter_core/public/source_policies.py
@@ -1,0 +1,87 @@
+"""Stable public helpers for source allow/block policy enforcement."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from urllib.parse import urlparse
+
+
+def normalize_source_pattern(value: str) -> str:
+    """Normalize a domain/source pattern for allow/block list matching."""
+    normalized = str(value or "").strip().lower()
+    normalized = re.sub(r"^https?://", "", normalized)
+    normalized = normalized.split("/", 1)[0]
+    normalized = re.sub(r"^www\.", "", normalized)
+    return normalized
+
+
+def _article_source_candidates(article: dict[str, Any]) -> set[str]:
+    candidates: set[str] = set()
+
+    source = normalize_source_pattern(str(article.get("source", "") or ""))
+    if source:
+        candidates.add(source)
+
+    url = str(article.get("url", "") or "").strip()
+    if url and url != "#":
+        try:
+            domain = normalize_source_pattern(urlparse(url).netloc or url)
+        except ValueError:
+            domain = normalize_source_pattern(url)
+        if domain:
+            candidates.add(domain)
+
+    return candidates
+
+
+def _matches_source_pattern(candidate: str, pattern: str) -> bool:
+    if not candidate or not pattern:
+        return False
+
+    if "." in pattern:
+        return candidate == pattern or candidate.endswith(f".{pattern}")
+
+    return pattern in candidate
+
+
+def filter_articles_by_source_policies(
+    articles: list[dict[str, Any]],
+    allowlist: list[str] | None = None,
+    blocklist: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Filter articles according to normalized source allow/block policies."""
+    normalized_allowlist = [
+        normalize_source_pattern(item) for item in (allowlist or []) if item
+    ]
+    normalized_blocklist = [
+        normalize_source_pattern(item) for item in (blocklist or []) if item
+    ]
+
+    if not normalized_allowlist and not normalized_blocklist:
+        return articles
+
+    filtered_articles: list[dict[str, Any]] = []
+
+    for article in articles:
+        candidates = _article_source_candidates(article)
+        blocked = any(
+            _matches_source_pattern(candidate, pattern)
+            for candidate in candidates
+            for pattern in normalized_blocklist
+        )
+        if blocked:
+            continue
+
+        if normalized_allowlist:
+            allowed = any(
+                _matches_source_pattern(candidate, pattern)
+                for candidate in candidates
+                for pattern in normalized_allowlist
+            )
+            if not allowed:
+                continue
+
+        filtered_articles.append(article)
+
+    return filtered_articles

--- a/tests/contract/test_generation_facade.py
+++ b/tests/contract/test_generation_facade.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
+import newsletter_core.public.generation as generation_module
 from newsletter_core.public.generation import (
     GenerateNewsletterRequest,
     NewsletterGenerationError,
@@ -56,6 +57,42 @@ def test_generation_facade_raises_on_error_status() -> None:
     ):
         with pytest.raises(NewsletterGenerationError):
             generate_newsletter(GenerateNewsletterRequest(keywords="AI"))
+
+
+@pytest.mark.unit
+@pytest.mark.mock_api
+def test_generation_facade_applies_source_policy_override() -> None:
+    html = "<html><head><title>Facade Smoke</title></head><body>ok</body></html>"
+    original_search_tool = generation_module.tools.search_news_articles
+
+    def _fake_generate(*args, **kwargs):
+        assert generation_module.tools.search_news_articles is not original_search_tool
+        assert kwargs == {
+            "news_period_days": 14,
+            "domain": None,
+            "template_style": "compact",
+            "email_compatible": False,
+        }
+        return html, "success"
+
+    with patch(
+        "newsletter_core.public.generation.graph.generate_newsletter",
+        side_effect=_fake_generate,
+    ), patch(
+        "newsletter_core.public.generation.graph.get_last_generation_info",
+        return_value={},
+    ):
+        result = generate_newsletter(
+            GenerateNewsletterRequest(
+                keywords="AI",
+                source_allowlist=["reuters.com"],
+                source_blocklist=["spam.example"],
+            )
+        )
+
+    assert generation_module.tools.search_news_articles is original_search_tool
+    assert result["input_params"]["source_allowlist"] == ["reuters.com"]
+    assert result["input_params"]["source_blocklist"] == ["spam.example"]
 
 
 @pytest.mark.unit

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -27,6 +27,14 @@ def _delete_schedule(schedule_id: str) -> None:
     conn.close()
 
 
+def _delete_source_policy(policy_id: str) -> None:
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM source_policies WHERE id = ?", (policy_id,))
+    conn.commit()
+    conn.close()
+
+
 def _insert_schedule_row(
     *,
     schedule_id: str,
@@ -250,6 +258,53 @@ class TestWebAPI:
 
         result = json.loads(response.data)
         assert isinstance(result, list)
+
+    def test_source_policy_crud_endpoint(self, client):
+        created_policy_id = None
+        response = client.post(
+            "/api/source-policies",
+            data=json.dumps(
+                {"pattern": "https://www.reuters.com", "policy_type": "allow"}
+            ),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 201
+        created = json.loads(response.data)
+        created_policy_id = created["id"]
+        assert created["pattern"] == "reuters.com"
+        assert created["policy_type"] == "allow"
+        assert created["is_active"] is True
+
+        try:
+            list_response = client.get("/api/source-policies")
+            assert list_response.status_code == 200
+            listed = json.loads(list_response.data)
+            assert any(item["id"] == created_policy_id for item in listed)
+
+            update_response = client.put(
+                f"/api/source-policies/{created_policy_id}",
+                data=json.dumps(
+                    {
+                        "pattern": "spam.example",
+                        "policy_type": "block",
+                        "is_active": False,
+                    }
+                ),
+                content_type="application/json",
+            )
+            assert update_response.status_code == 200
+            updated = json.loads(update_response.data)
+            assert updated["pattern"] == "spam.example"
+            assert updated["policy_type"] == "block"
+            assert updated["is_active"] is False
+
+            delete_response = client.delete(f"/api/source-policies/{created_policy_id}")
+            assert delete_response.status_code == 200
+            assert json.loads(delete_response.data)["success"] is True
+        finally:
+            if created_policy_id:
+                _delete_source_policy(created_policy_id)
 
     def test_schedule_creation_returns_utc_next_run(self, client):
         schedule_id = None

--- a/tests/unit_tests/test_source_policy_filtering.py
+++ b/tests/unit_tests/test_source_policy_filtering.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from newsletter_core.public.source_policies import filter_articles_by_source_policies
+
+
+def test_source_policy_filtering_blocks_matching_domains() -> None:
+    articles = [
+        {
+            "title": "Keep me",
+            "url": "https://www.reuters.com/world/test-story",
+            "source": "Reuters",
+        },
+        {
+            "title": "Drop me",
+            "url": "https://spam.example/news/story",
+            "source": "Spam Example",
+        },
+    ]
+
+    filtered = filter_articles_by_source_policies(
+        articles,
+        blocklist=["spam.example"],
+    )
+
+    assert [item["title"] for item in filtered] == ["Keep me"]
+
+
+def test_source_policy_filtering_respects_allowlist() -> None:
+    articles = [
+        {
+            "title": "Allowed",
+            "url": "https://www.ft.com/content/test-story",
+            "source": "Financial Times",
+        },
+        {
+            "title": "Excluded",
+            "url": "https://example.org/post",
+            "source": "Example Org",
+        },
+    ]
+
+    filtered = filter_articles_by_source_policies(
+        articles,
+        allowlist=["ft.com"],
+    )
+
+    assert [item["title"] for item in filtered] == ["Allowed"]

--- a/tests/unit_tests/test_web_access_control.py
+++ b/tests/unit_tests/test_web_access_control.py
@@ -37,6 +37,7 @@ def test_protected_route_matcher_covers_sensitive_paths() -> None:
     assert is_protected_route("/api/schedule")
     assert is_protected_route("/api/schedule/demo/run")
     assert is_protected_route("/api/presets")
+    assert is_protected_route("/api/source-policies")
     assert is_protected_route("/api/send-email")
     assert not is_protected_route("/api/generate")
     assert not is_protected_route("/health")

--- a/tests/unit_tests/test_web_source_policy_task.py
+++ b/tests/unit_tests/test_web_source_policy_task.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+from db_state import create_source_policy, ensure_database_schema  # noqa: E402
+from tasks import generate_newsletter_task  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def test_generate_newsletter_task_loads_active_source_policies(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+    create_source_policy(
+        str(db_path),
+        "policy_allow",
+        "reuters.com",
+        "allow",
+        is_active=True,
+    )
+    create_source_policy(
+        str(db_path),
+        "policy_block",
+        "spam.example",
+        "block",
+        is_active=True,
+    )
+
+    with patch("tasks.generate_newsletter") as generate_mock:
+        generate_mock.return_value = {
+            "status": "success",
+            "html_content": "<html><head><title>Smoke</title></head><body>ok</body></html>",
+            "title": "Smoke",
+            "generation_stats": {},
+            "input_params": {},
+            "error": None,
+        }
+
+        result = generate_newsletter_task(
+            {"keywords": ["AI"]},
+            "job-source-policy",
+            database_path=str(db_path),
+        )
+
+    request = generate_mock.call_args.args[0]
+    assert request.source_allowlist == ["reuters.com"]
+    assert request.source_blocklist == ["spam.example"]
+    assert result["status"] == "success"

--- a/web/access_control.py
+++ b/web/access_control.py
@@ -19,6 +19,7 @@ _PROTECTED_PREFIXES: tuple[str, ...] = (
     "/api/history",
     "/api/presets",
     "/api/approvals",
+    "/api/source-policies",
     "/api/schedule",
     "/api/schedules",
     "/api/send-email",

--- a/web/app.py
+++ b/web/app.py
@@ -261,6 +261,16 @@ register_preset_routes(app, DATABASE_PATH)
 
 
 try:
+    from routes_source_policies import register_source_policy_routes
+except ImportError:
+    from web.routes_source_policies import (  # pragma: no cover
+        register_source_policy_routes,
+    )
+
+register_source_policy_routes(app, DATABASE_PATH)
+
+
+try:
     from routes_newsletter_html import register_newsletter_html_route
 except ImportError:
     from web.routes_newsletter_html import (

--- a/web/db_state.py
+++ b/web/db_state.py
@@ -20,6 +20,9 @@ DELIVERY_STATUS_APPROVED = "approved"
 DELIVERY_STATUS_SENT = "sent"
 DELIVERY_STATUS_SEND_FAILED = "send_failed"
 
+SOURCE_POLICY_ALLOW = "allow"
+SOURCE_POLICY_BLOCK = "block"
+
 _UNSET = object()
 
 
@@ -176,6 +179,20 @@ def _ensure_database_schema(conn: sqlite3.Connection) -> None:
     )
 
     cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS source_policies (
+            id TEXT PRIMARY KEY,
+            pattern TEXT NOT NULL,
+            policy_type TEXT NOT NULL,
+            is_active INTEGER NOT NULL DEFAULT 1,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(pattern, policy_type)
+        )
+        """
+    )
+
+    cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_history_created_at ON history(created_at)"
     )
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_history_status ON history(status)")
@@ -196,6 +213,9 @@ def _ensure_database_schema(conn: sqlite3.Connection) -> None:
     )
     cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_generation_presets_updated_at ON generation_presets(updated_at)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_source_policies_type_active ON source_policies(policy_type, is_active)"
     )
 
     conn.commit()
@@ -694,5 +714,158 @@ def delete_generation_preset(db_path: str, preset_id: str) -> bool:
         cursor.execute("DELETE FROM generation_presets WHERE id = ?", (preset_id,))
         conn.commit()
         return cursor.rowcount > 0
+    finally:
+        conn.close()
+
+
+def list_source_policies(db_path: str) -> list[Dict[str, Any]]:
+    """Return source policy rows ordered by type and recency."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, pattern, policy_type, is_active, created_at, updated_at
+            FROM source_policies
+            ORDER BY policy_type ASC, updated_at DESC, created_at DESC
+            """
+        )
+        rows = cursor.fetchall()
+        return [
+            {
+                "id": row[0],
+                "pattern": row[1],
+                "policy_type": row[2],
+                "is_active": bool(row[3]),
+                "created_at": row[4],
+                "updated_at": row[5],
+            }
+            for row in rows
+        ]
+    finally:
+        conn.close()
+
+
+def get_source_policy(db_path: str, policy_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch a single source policy row."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, pattern, policy_type, is_active, created_at, updated_at
+            FROM source_policies
+            WHERE id = ?
+            """,
+            (policy_id,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return {
+            "id": row[0],
+            "pattern": row[1],
+            "policy_type": row[2],
+            "is_active": bool(row[3]),
+            "created_at": row[4],
+            "updated_at": row[5],
+        }
+    finally:
+        conn.close()
+
+
+def create_source_policy(
+    db_path: str,
+    policy_id: str,
+    pattern: str,
+    policy_type: str,
+    *,
+    is_active: bool = True,
+) -> Dict[str, Any]:
+    """Create a source policy row and return it."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO source_policies (id, pattern, policy_type, is_active)
+            VALUES (?, ?, ?, ?)
+            """,
+            (policy_id, pattern, policy_type, int(is_active)),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return get_source_policy(db_path, policy_id) or {}
+
+
+def update_source_policy(
+    db_path: str,
+    policy_id: str,
+    pattern: str,
+    policy_type: str,
+    *,
+    is_active: bool = True,
+) -> Optional[Dict[str, Any]]:
+    """Update an existing source policy row."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM source_policies WHERE id = ?", (policy_id,))
+        if not cursor.fetchone():
+            return None
+
+        cursor.execute(
+            """
+            UPDATE source_policies
+            SET pattern = ?,
+                policy_type = ?,
+                is_active = ?,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (pattern, policy_type, int(is_active), policy_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return get_source_policy(db_path, policy_id)
+
+
+def delete_source_policy(db_path: str, policy_id: str) -> bool:
+    """Delete a source policy row."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM source_policies WHERE id = ?", (policy_id,))
+        conn.commit()
+        return cursor.rowcount > 0
+    finally:
+        conn.close()
+
+
+def get_active_source_policies(db_path: str) -> Dict[str, list[str]]:
+    """Return active source policy patterns grouped by allow/block type."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT pattern, policy_type
+            FROM source_policies
+            WHERE is_active = 1
+            ORDER BY policy_type ASC, updated_at DESC
+            """
+        )
+        allowlist: list[str] = []
+        blocklist: list[str] = []
+        for pattern, policy_type in cursor.fetchall():
+            if policy_type == SOURCE_POLICY_ALLOW:
+                allowlist.append(str(pattern))
+            elif policy_type == SOURCE_POLICY_BLOCK:
+                blocklist.append(str(pattern))
+        return {"allowlist": allowlist, "blocklist": blocklist}
     finally:
         conn.close()

--- a/web/routes_source_policies.py
+++ b/web/routes_source_policies.py
@@ -1,0 +1,143 @@
+"""Route registration for source allow/block policy management."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import uuid
+
+from flask import Flask, jsonify, request
+from flask.typing import ResponseReturnValue
+
+from newsletter_core.public.source_policies import normalize_source_pattern
+
+try:
+    from db_state import (
+        SOURCE_POLICY_ALLOW,
+        SOURCE_POLICY_BLOCK,
+        create_source_policy,
+        delete_source_policy,
+        get_source_policy,
+        list_source_policies,
+        update_source_policy,
+    )
+except ImportError:
+    from web.db_state import (  # pragma: no cover
+        SOURCE_POLICY_ALLOW,
+        SOURCE_POLICY_BLOCK,
+        create_source_policy,
+        delete_source_policy,
+        get_source_policy,
+        list_source_policies,
+        update_source_policy,
+    )
+
+try:
+    from ops_logging import log_exception, log_info
+except ImportError:
+    from web.ops_logging import log_exception, log_info  # pragma: no cover
+
+logger = logging.getLogger("web.routes_source_policies")
+
+VALID_POLICY_TYPES = {SOURCE_POLICY_ALLOW, SOURCE_POLICY_BLOCK}
+
+
+def _normalize_policy_payload(payload: dict) -> tuple[str, str, bool]:
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be an object")
+
+    pattern = normalize_source_pattern(str(payload.get("pattern", "") or ""))
+    if not pattern:
+        raise ValueError("pattern is required")
+    if len(pattern) > 255:
+        raise ValueError("pattern must be 255 characters or fewer")
+
+    policy_type = str(payload.get("policy_type", "") or "").strip().lower()
+    if policy_type not in VALID_POLICY_TYPES:
+        raise ValueError("policy_type must be one of: allow, block")
+
+    return pattern, policy_type, bool(payload.get("is_active", True))
+
+
+def register_source_policy_routes(app: Flask, database_path: str) -> None:
+    """Register source allow/block policy CRUD routes."""
+
+    @app.route("/api/source-policies")  # type: ignore[untyped-decorator]
+    def list_source_policy_entries() -> ResponseReturnValue:
+        try:
+            return jsonify(list_source_policies(database_path))
+        except Exception as exc:
+            log_exception(logger, "source_policy.list.failed", exc)
+            return jsonify({"error": "소스 정책 목록을 불러오지 못했습니다"}), 500
+
+    @app.route("/api/source-policies", methods=["POST"])  # type: ignore[untyped-decorator]
+    def create_source_policy_entry() -> ResponseReturnValue:
+        try:
+            payload = request.get_json() or {}
+            pattern, policy_type, is_active = _normalize_policy_payload(payload)
+            policy = create_source_policy(
+                db_path=database_path,
+                policy_id=f"policy_{uuid.uuid4().hex[:12]}",
+                pattern=pattern,
+                policy_type=policy_type,
+                is_active=is_active,
+            )
+            log_info(
+                logger,
+                "source_policy.create.completed",
+                policy_id=policy["id"],
+                policy_type=policy_type,
+            )
+            return jsonify(policy), 201
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        except sqlite3.IntegrityError:
+            return jsonify({"error": "같은 정책이 이미 존재합니다"}), 409
+        except Exception as exc:
+            log_exception(logger, "source_policy.create.failed", exc)
+            return jsonify({"error": "소스 정책 저장에 실패했습니다"}), 500
+
+    @app.route("/api/source-policies/<policy_id>", methods=["PUT"])  # type: ignore[untyped-decorator]
+    def update_source_policy_entry(policy_id: str) -> ResponseReturnValue:
+        try:
+            payload = request.get_json() or {}
+            pattern, policy_type, is_active = _normalize_policy_payload(payload)
+            policy = update_source_policy(
+                db_path=database_path,
+                policy_id=policy_id,
+                pattern=pattern,
+                policy_type=policy_type,
+                is_active=is_active,
+            )
+            if not policy:
+                return jsonify({"error": "소스 정책을 찾을 수 없습니다"}), 404
+            log_info(logger, "source_policy.update.completed", policy_id=policy_id)
+            return jsonify(policy)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        except sqlite3.IntegrityError:
+            return jsonify({"error": "같은 정책이 이미 존재합니다"}), 409
+        except Exception as exc:
+            log_exception(
+                logger, "source_policy.update.failed", exc, policy_id=policy_id
+            )
+            return jsonify({"error": "소스 정책 수정에 실패했습니다"}), 500
+
+    @app.route("/api/source-policies/<policy_id>", methods=["DELETE"])  # type: ignore[untyped-decorator]
+    def delete_source_policy_entry(policy_id: str) -> ResponseReturnValue:
+        try:
+            policy = get_source_policy(database_path, policy_id)
+            if not policy:
+                return jsonify({"error": "소스 정책을 찾을 수 없습니다"}), 404
+
+            deleted = delete_source_policy(database_path, policy_id)
+            if not deleted:
+                return jsonify({"error": "소스 정책을 찾을 수 없습니다"}), 404
+
+            log_info(logger, "source_policy.delete.completed", policy_id=policy_id)
+            return jsonify({"success": True, "deleted_id": policy_id})
+        except Exception as exc:
+            log_exception(
+                logger, "source_policy.delete.failed", exc, policy_id=policy_id
+            )
+            return jsonify({"error": "소스 정책 삭제에 실패했습니다"}), 500

--- a/web/tasks.py
+++ b/web/tasks.py
@@ -24,6 +24,7 @@ try:
         DELIVERY_STATUS_PENDING_APPROVAL,
         DELIVERY_STATUS_SEND_FAILED,
         DELIVERY_STATUS_SENT,
+        get_active_source_policies,
         update_history_review_state,
         update_history_status,
     )
@@ -35,6 +36,7 @@ except ImportError:
         DELIVERY_STATUS_PENDING_APPROVAL,
         DELIVERY_STATUS_SEND_FAILED,
         DELIVERY_STATUS_SENT,
+        get_active_source_policies,
         update_history_review_state,
         update_history_status,
     )
@@ -57,7 +59,10 @@ def _resolve_database_path(database_path: str | None) -> str:
     return database_path or DATABASE_PATH
 
 
-def _build_request(data: Dict[str, Any]) -> GenerateNewsletterRequest:
+def _build_request(
+    data: Dict[str, Any], source_policies: Dict[str, list[str]] | None = None
+) -> GenerateNewsletterRequest:
+    policies = source_policies or {"allowlist": [], "blocklist": []}
     return GenerateNewsletterRequest(
         keywords=data.get("keywords"),
         domain=data.get("domain"),
@@ -65,6 +70,8 @@ def _build_request(data: Dict[str, Any]) -> GenerateNewsletterRequest:
         email_compatible=bool(data.get("email_compatible", False)),
         period=int(data.get("period", 14)),
         suggest_count=int(data.get("suggest_count", 10)),
+        source_allowlist=policies.get("allowlist") or [],
+        source_blocklist=policies.get("blocklist") or [],
     )
 
 
@@ -97,7 +104,8 @@ def generate_newsletter_task(
     approval_required = bool(data.get("require_approval")) and bool(email)
 
     try:
-        request = _build_request(data)
+        source_policies = get_active_source_policies(db_path)
+        request = _build_request(data, source_policies=source_policies)
         result = generate_newsletter(request)
 
         response: Dict[str, Any] = {


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Add global source allow/block policy CRUD in the canonical Flask runtime.
- Enforce active source policies during newsletter generation without widening legacy `newsletter` import boundaries.
- Cover the new runtime path with source filtering, task wiring, access control, and API regression tests.

## Scope
### In Scope
- `source_policies` additive DB table and access helpers
- `/api/source-policies` CRUD routes and access-control protection
- Stable public source-policy helpers in `newsletter_core.public`
- Worker request wiring so active policies apply during generation
- Regression/contract tests for filtering, task wiring, access control, and route CRUD

### Out of Scope
- Source policy management UI
- Per-user policy scopes
- Historical backfill of existing generated newsletters

## Delivery Unit
- RR: #193
- Delivery Unit ID: DU-20260308-source-policy-enforcement
- Merge Boundary: source policy enforcement backend only
- Rollback Boundary: revert commit `796e40c`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): ops-safety pytest matrix for protected paths

### Commands and Results
```bash
EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr18 make check
# PASS

MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/test_web_api.py -q
# 17 passed, 1 skipped

RUN_INTEGRATION_TESTS=1 MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/integration/test_schedule_execution.py -q
# 7 passed, 1 skipped

MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/unit_tests/test_schedule_time_sync.py -q
# 4 passed

MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/contract/test_web_email_routes_contract.py -q
# 7 passed

MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/unit_tests/test_config_import_side_effects.py -q
# 7 passed

EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr18 make check-full
# PASS
```

## Risk & Rollback
- Risk: additive SQLite schema change (`source_policies`) and request-time filtering could suppress articles if allow/block rules are configured incorrectly.
- Rollback: revert `796e40c` and restart the Flask/worker processes; the unused additive table can remain in place safely.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: unchanged; schedule/generate idempotency flow is not modified.
- Outbox/send_key 중복 방지 결과: unchanged; email delivery path is not modified.
- import-time side effect 제거 여부: no new import-time side effects added; policy enforcement is applied inside request-time generation wrapper.

## Not Run (with reason)
- UI/end-to-end browser validation was not run because RR-18 is backend-only and RR-19 will cover the management UI.
