### PR TITLE
feat(web): capture analytics events for runtime operations

### DIFF
--- a/tests/unit_tests/test_web_analytics_capture.py
+++ b/tests/unit_tests/test_web_analytics_capture.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+import routes_send_email  # noqa: E402
+from db_state import ensure_database_schema, list_analytics_events  # noqa: E402
+from schedule_runner import ScheduleRunner  # noqa: E402
+from tasks import generate_newsletter_task  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def _build_send_email_app(database_path: str) -> Flask:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    routes_send_email.register_send_email_route(app, database_path)
+    return app
+
+
+def test_generate_newsletter_task_records_generation_and_email_events(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    with patch("tasks.generate_newsletter") as generate_mock:
+        generate_mock.return_value = {
+            "status": "success",
+            "html_content": "<html><head><title>Analytics</title></head><body>ok</body></html>",
+            "title": "Analytics",
+            "generation_stats": {
+                "total_time": 4.5,
+                "cost_summary": {"total_cost_usd": 1.75},
+            },
+            "input_params": {"keywords": ["AI"]},
+            "error": None,
+        }
+        with patch("tasks.send_email_with_outbox") as send_mock:
+            send_mock.return_value = {"send_key": "send-1", "skipped": False}
+
+            result = generate_newsletter_task(
+                {"keywords": ["AI"], "email": "ops@example.com"},
+                "job-analytics",
+                send_email=True,
+                database_path=str(db_path),
+            )
+
+    assert result["status"] == "success"
+    events = list_analytics_events(str(db_path), limit=10)
+    event_types = {event["event_type"] for event in events}
+    assert "generation.started" in event_types
+    assert "generation.completed" in event_types
+    assert "email.sent" in event_types
+
+    completed = next(
+        event for event in events if event["event_type"] == "generation.completed"
+    )
+    assert completed["duration_seconds"] == pytest.approx(4.5)
+    assert completed["cost_usd"] == pytest.approx(1.75)
+
+
+def test_send_email_route_records_deduplicated_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO history (id, params, result, status, approval_status, delivery_status)
+        VALUES (?, ?, ?, 'completed', 'approved', 'approved')
+        """,
+        (
+            "job-send-route",
+            json.dumps({"email": "ops@example.com"}),
+            json.dumps({"html_content": "<html>ok</html>", "title": "Route Analytics"}),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(
+        routes_send_email,
+        "send_email_with_outbox",
+        lambda **_: {"send_key": "send-dup", "skipped": True},
+    )
+
+    app = _build_send_email_app(str(db_path))
+    with app.test_client() as client:
+        response = client.post(
+            "/api/send-email",
+            data=json.dumps({"job_id": "job-send-route", "email": "ops@example.com"}),
+            content_type="application/json",
+        )
+
+    assert response.status_code == 200
+    events = list_analytics_events(str(db_path), limit=10)
+    deduplicated = next(
+        event for event in events if event["event_type"] == "email.deduplicated"
+    )
+    assert deduplicated["job_id"] == "job-send-route"
+    assert deduplicated["deduplicated"] is True
+
+
+def test_schedule_runner_records_execution_events(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    schedule_id = "schedule-analytics"
+    next_run = datetime.now(timezone.utc).replace(microsecond=0)
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO schedules (id, params, rrule, next_run, enabled)
+        VALUES (?, ?, ?, ?, 1)
+        """,
+        (
+            schedule_id,
+            json.dumps({"keywords": ["AI"], "send_email": False}),
+            "FREQ=WEEKLY;BYDAY=MO;BYHOUR=9;BYMINUTE=0",
+            next_run.isoformat().replace("+00:00", "Z"),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    runner = ScheduleRunner(db_path=str(db_path), redis_url="redis://localhost:6379/0")
+    runner.redis_conn = None
+    runner.queue = None
+
+    with patch("schedule_runner.generate_newsletter_task") as generate_mock:
+        generate_mock.return_value = {
+            "status": "success",
+            "html_content": "<html><body>ok</body></html>",
+            "title": "Scheduled Analytics",
+            "generation_stats": {},
+            "input_params": {},
+            "error": None,
+            "sent": False,
+            "email_sent": False,
+        }
+        success = runner.execute_schedule(
+            {
+                "id": schedule_id,
+                "params": {"keywords": ["AI"], "send_email": False},
+                "rrule": "FREQ=WEEKLY;BYDAY=MO;BYHOUR=9;BYMINUTE=0",
+                "next_run": next_run,
+                "created_at": next_run,
+                "is_test": False,
+            }
+        )
+
+    assert success is True
+    events = list_analytics_events(
+        str(db_path),
+        limit=10,
+        event_type_prefix="schedule.execute",
+    )
+    event_types = {event["event_type"] for event in events}
+    assert "schedule.execute.started" in event_types
+    assert "schedule.execute.completed" in event_types

--- a/web/analytics.py
+++ b/web/analytics.py
@@ -1,0 +1,175 @@
+"""Analytics capture helpers for the canonical web runtime."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+try:
+    from db_state import record_analytics_event
+except ImportError:
+    from web.db_state import record_analytics_event  # pragma: no cover
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_generation_stats(result: Dict[str, Any] | None) -> Dict[str, Any]:
+    if not isinstance(result, dict):
+        return {}
+    stats = result.get("generation_stats")
+    return stats if isinstance(stats, dict) else {}
+
+
+def _extract_total_time(result: Dict[str, Any] | None) -> float | None:
+    return _coerce_float(_extract_generation_stats(result).get("total_time"))
+
+
+def _extract_total_cost_usd(result: Dict[str, Any] | None) -> float | None:
+    stats = _extract_generation_stats(result)
+    cost_summary = stats.get("cost_summary")
+    if not isinstance(cost_summary, dict):
+        return None
+    return _coerce_float(cost_summary.get("total_cost_usd"))
+
+
+def record_generation_started(
+    db_path: str,
+    *,
+    job_id: str,
+    params: Dict[str, Any],
+    send_email: bool,
+    source: str,
+    idempotency_key: str | None = None,
+    schedule_id: str | None = None,
+) -> None:
+    """Record the start of a generation attempt."""
+    record_analytics_event(
+        db_path,
+        "generation.started",
+        job_id=job_id,
+        schedule_id=schedule_id,
+        status="processing",
+        payload={
+            "source": source,
+            "send_email": send_email,
+            "has_email": bool(str(params.get("email", "") or "").strip()),
+            "preview_only": bool(params.get("preview_only")),
+            "template_style": params.get("template_style"),
+            "period": params.get("period"),
+            "idempotency_key": idempotency_key,
+        },
+    )
+
+
+def record_generation_completed(
+    db_path: str,
+    *,
+    job_id: str,
+    result: Dict[str, Any],
+    source: str,
+    schedule_id: str | None = None,
+) -> None:
+    """Record the successful end of a generation attempt."""
+    record_analytics_event(
+        db_path,
+        "generation.completed",
+        job_id=job_id,
+        schedule_id=schedule_id,
+        status=result.get("status"),
+        duration_seconds=_extract_total_time(result),
+        cost_usd=_extract_total_cost_usd(result),
+        payload={
+            "source": source,
+            "email_sent": bool(result.get("email_sent")),
+            "email_deduplicated": bool(result.get("email_deduplicated")),
+            "approval_status": result.get("approval_status"),
+            "delivery_status": result.get("delivery_status"),
+        },
+    )
+
+
+def record_generation_failed(
+    db_path: str,
+    *,
+    job_id: str,
+    error: Exception,
+    source: str,
+    schedule_id: str | None = None,
+) -> None:
+    """Record a failed generation attempt."""
+    record_analytics_event(
+        db_path,
+        "generation.failed",
+        job_id=job_id,
+        schedule_id=schedule_id,
+        status="error",
+        payload={
+            "source": source,
+            "error": str(error),
+            "error_type": type(error).__name__,
+        },
+    )
+
+
+def record_email_event(
+    db_path: str,
+    *,
+    event_type: str,
+    job_id: str,
+    recipient: str,
+    source: str,
+    send_key: str | None = None,
+    schedule_id: str | None = None,
+    status: str | None = None,
+    deduplicated: bool = False,
+    error: str | None = None,
+) -> None:
+    """Record an email delivery event."""
+    payload = {
+        "source": source,
+        "recipient": recipient,
+        "send_key": send_key,
+    }
+    if error:
+        payload["error"] = error
+
+    record_analytics_event(
+        db_path,
+        event_type,
+        job_id=job_id,
+        schedule_id=schedule_id,
+        status=status,
+        deduplicated=deduplicated,
+        payload=payload,
+    )
+
+
+def record_schedule_event(
+    db_path: str,
+    *,
+    event_type: str,
+    schedule_id: str,
+    source: str,
+    job_id: str | None = None,
+    status: str | None = None,
+    payload: Dict[str, Any] | None = None,
+) -> None:
+    """Record a schedule lifecycle event."""
+    event_payload = {"source": source}
+    if payload:
+        event_payload.update(payload)
+
+    record_analytics_event(
+        db_path,
+        event_type,
+        job_id=job_id,
+        schedule_id=schedule_id,
+        status=status,
+        payload=event_payload,
+    )

--- a/web/db_state.py
+++ b/web/db_state.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import sqlite3
+import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple
 
@@ -193,6 +194,23 @@ def _ensure_database_schema(conn: sqlite3.Connection) -> None:
     )
 
     cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS analytics_events (
+            id TEXT PRIMARY KEY,
+            event_type TEXT NOT NULL,
+            job_id TEXT,
+            schedule_id TEXT,
+            status TEXT,
+            deduplicated INTEGER NOT NULL DEFAULT 0,
+            duration_seconds REAL,
+            cost_usd REAL,
+            payload JSON,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_history_created_at ON history(created_at)"
     )
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_history_status ON history(status)")
@@ -216,6 +234,18 @@ def _ensure_database_schema(conn: sqlite3.Connection) -> None:
     )
     cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_source_policies_type_active ON source_policies(policy_type, is_active)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_analytics_events_type_created ON analytics_events(event_type, created_at DESC)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_analytics_events_job_id ON analytics_events(job_id)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_analytics_events_schedule_id ON analytics_events(schedule_id)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_analytics_events_created_at ON analytics_events(created_at DESC)"
     )
 
     conn.commit()
@@ -867,5 +897,143 @@ def get_active_source_policies(db_path: str) -> Dict[str, list[str]]:
             elif policy_type == SOURCE_POLICY_BLOCK:
                 blocklist.append(str(pattern))
         return {"allowlist": allowlist, "blocklist": blocklist}
+    finally:
+        conn.close()
+
+
+def _serialize_event_timestamp(value: str | datetime | None) -> str:
+    """Serialize analytics timestamps in UTC ISO format."""
+    if value is None:
+        timestamp = datetime.now(timezone.utc)
+    elif isinstance(value, str):
+        return value
+    elif value.tzinfo is None:
+        timestamp = value.replace(tzinfo=timezone.utc)
+    else:
+        timestamp = value.astimezone(timezone.utc)
+
+    return timestamp.isoformat().replace("+00:00", "Z")
+
+
+def record_analytics_event(
+    db_path: str,
+    event_type: str,
+    *,
+    job_id: str | None = None,
+    schedule_id: str | None = None,
+    status: str | None = None,
+    deduplicated: bool = False,
+    duration_seconds: float | None = None,
+    cost_usd: float | None = None,
+    payload: Dict[str, Any] | None = None,
+    occurred_at: str | datetime | None = None,
+) -> str:
+    """Persist a structured analytics event for later aggregation."""
+    event_id = f"evt_{uuid.uuid4().hex}"
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO analytics_events (
+                id,
+                event_type,
+                job_id,
+                schedule_id,
+                status,
+                deduplicated,
+                duration_seconds,
+                cost_usd,
+                payload,
+                created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_id,
+                event_type,
+                job_id,
+                schedule_id,
+                status,
+                int(deduplicated),
+                duration_seconds,
+                cost_usd,
+                None if payload is None else canonical_json(payload),
+                _serialize_event_timestamp(occurred_at),
+            ),
+        )
+        conn.commit()
+        return event_id
+    finally:
+        conn.close()
+
+
+def list_analytics_events(
+    db_path: str,
+    *,
+    limit: int = 100,
+    event_type_prefix: str | None = None,
+) -> list[Dict[str, Any]]:
+    """Return recent analytics events for tests and dashboard routes."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        if event_type_prefix:
+            cursor.execute(
+                """
+                SELECT
+                    id,
+                    event_type,
+                    job_id,
+                    schedule_id,
+                    status,
+                    deduplicated,
+                    duration_seconds,
+                    cost_usd,
+                    payload,
+                    created_at
+                FROM analytics_events
+                WHERE event_type LIKE ?
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?
+                """,
+                (f"{event_type_prefix}%", limit),
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT
+                    id,
+                    event_type,
+                    job_id,
+                    schedule_id,
+                    status,
+                    deduplicated,
+                    duration_seconds,
+                    cost_usd,
+                    payload,
+                    created_at
+                FROM analytics_events
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?
+                """,
+                (limit,),
+            )
+        rows = cursor.fetchall()
+        return [
+            {
+                "id": row[0],
+                "event_type": row[1],
+                "job_id": row[2],
+                "schedule_id": row[3],
+                "status": row[4],
+                "deduplicated": bool(row[5]),
+                "duration_seconds": row[6],
+                "cost_usd": row[7],
+                "payload": json.loads(row[8]) if row[8] else None,
+                "created_at": row[9],
+            }
+            for row in rows
+        ]
     finally:
         conn.close()

--- a/web/routes_generation.py
+++ b/web/routes_generation.py
@@ -55,6 +55,11 @@ try:
 except ImportError:
     from web.ops_logging import log_debug, log_exception, log_info  # pragma: no cover
 
+try:
+    from analytics import record_schedule_event
+except ImportError:
+    from web.analytics import record_schedule_event  # pragma: no cover
+
 
 logger = logging.getLogger("web.routes_generation")
 
@@ -768,6 +773,20 @@ def register_generation_routes(
         )
         conn.commit()
         conn.close()
+        record_schedule_event(
+            DATABASE_PATH,
+            event_type="schedule.created",
+            schedule_id=schedule_id,
+            source="api.schedule",
+            status="scheduled",
+            payload={
+                "rrule": rrule_str,
+                "email": data["email"],
+                "is_test": is_test,
+                "require_approval": bool(data.get("require_approval", False)),
+                "expires_at": expires_at,
+            },
+        )
 
         return (
             jsonify(
@@ -826,6 +845,7 @@ def register_generation_routes(
     def run_schedule_now(schedule_id):
         """Immediately execute a scheduled newsletter"""
         try:
+            immediate_job_id = None
             # 스케줄 정보 조회
             conn = sqlite3.connect(DATABASE_PATH)
             cursor = conn.cursor()
@@ -857,6 +877,15 @@ def register_generation_routes(
                 )
             job_suffix = derive_job_id(idempotency_key, prefix="sched").split("_", 1)[1]
             immediate_job_id = f"schedule_{schedule_id}_{job_suffix}"
+            record_schedule_event(
+                DATABASE_PATH,
+                event_type="schedule.run_now.requested",
+                schedule_id=schedule_id,
+                job_id=immediate_job_id,
+                source="api.schedule_run_now",
+                status="requested",
+                payload={"idempotency_key": idempotency_key},
+            )
 
             # 즉시 뉴스레터 생성 작업 큐에 추가
             if redis_conn and task_queue:
@@ -869,6 +898,15 @@ def register_generation_routes(
                     DATABASE_PATH,
                     job_id=immediate_job_id,
                     job_timeout="10m",
+                )
+                record_schedule_event(
+                    DATABASE_PATH,
+                    event_type="schedule.run_now.queued",
+                    schedule_id=schedule_id,
+                    job_id=immediate_job_id,
+                    source="api.schedule_run_now",
+                    status="queued",
+                    payload={"queue_job_id": job.id},
                 )
 
                 return jsonify(
@@ -888,6 +926,14 @@ def register_generation_routes(
                     idempotency_key if idempotency_enabled else None,
                     DATABASE_PATH,
                 )
+                record_schedule_event(
+                    DATABASE_PATH,
+                    event_type="schedule.run_now.completed",
+                    schedule_id=schedule_id,
+                    job_id=immediate_job_id,
+                    source="api.schedule_run_now",
+                    status=result.get("status"),
+                )
                 return jsonify(
                     {
                         "status": "completed",
@@ -898,5 +944,15 @@ def register_generation_routes(
                 )
 
         except Exception as e:
+            if locals().get("immediate_job_id"):
+                record_schedule_event(
+                    DATABASE_PATH,
+                    event_type="schedule.run_now.failed",
+                    schedule_id=schedule_id,
+                    job_id=locals()["immediate_job_id"],
+                    source="api.schedule_run_now",
+                    status="failed",
+                    payload={"error": str(e)},
+                )
             log_exception(logger, "schedule.run_now.failed", e, schedule_id=schedule_id)
             return jsonify({"error": f"Failed to execute schedule: {str(e)}"}), 500

--- a/web/routes_send_email.py
+++ b/web/routes_send_email.py
@@ -32,6 +32,11 @@ try:
 except ImportError:
     from web.ops_logging import log_exception, log_info  # pragma: no cover
 
+try:
+    from analytics import record_email_event
+except ImportError:
+    from web.analytics import record_email_event  # pragma: no cover
+
 
 logger = logging.getLogger("web.routes_send_email")
 
@@ -100,6 +105,16 @@ def register_send_email_route(app: Flask, database_path: str) -> None:
                     job_id=job_id,
                     delivery_status=DELIVERY_STATUS_SENT,
                 )
+                record_email_event(
+                    database_path,
+                    event_type="email.deduplicated",
+                    job_id=job_id,
+                    recipient=email,
+                    send_key=send_key,
+                    source="api.send_email",
+                    status="sent",
+                    deduplicated=True,
+                )
                 log_info(
                     logger,
                     "email.send.deduplicated",
@@ -121,6 +136,15 @@ def register_send_email_route(app: Flask, database_path: str) -> None:
                 job_id=job_id,
                 delivery_status=DELIVERY_STATUS_SENT,
             )
+            record_email_event(
+                database_path,
+                event_type="email.sent",
+                job_id=job_id,
+                recipient=email,
+                send_key=send_key,
+                source="api.send_email",
+                status="sent",
+            )
             log_info(
                 logger,
                 "email.send.completed",
@@ -138,6 +162,17 @@ def register_send_email_route(app: Flask, database_path: str) -> None:
             )
 
         except Exception as e:
+            if locals().get("job_id") and locals().get("email"):
+                record_email_event(
+                    database_path,
+                    event_type="email.failed",
+                    job_id=locals()["job_id"],
+                    recipient=locals()["email"],
+                    send_key=locals().get("send_key"),
+                    source="api.send_email",
+                    status="failed",
+                    error=str(e),
+                )
             log_exception(
                 logger,
                 "email.send.failed",

--- a/web/schedule_runner.py
+++ b/web/schedule_runner.py
@@ -60,6 +60,11 @@ except ImportError:
         log_warning,
     )
 
+try:
+    from analytics import record_schedule_event
+except ImportError:
+    from web.analytics import record_schedule_event  # pragma: no cover
+
 # Configure logging
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO").upper(),
@@ -430,9 +435,25 @@ class ScheduleRunner:
                             "schedule.execute.preupdate_failed",
                             schedule_id=schedule_id,
                         )
+                        record_schedule_event(
+                            self.db_path,
+                            event_type="schedule.execute.failed",
+                            schedule_id=schedule_id,
+                            source="schedule_runner",
+                            status="failed",
+                            payload={"reason": "next_run_update_failed"},
+                        )
                         return False
                 else:
                     # 더 이상 실행할 일정이 없으면 비활성화
+                    record_schedule_event(
+                        self.db_path,
+                        event_type="schedule.execute.disabled",
+                        schedule_id=schedule_id,
+                        source="schedule_runner",
+                        status="disabled",
+                        payload={"reason": "no_more_occurrences"},
+                    )
                     log_info(
                         logger,
                         "schedule.execute.no_more_occurrences",
@@ -479,6 +500,15 @@ class ScheduleRunner:
                 status="pending",
                 idempotency_key=idempotency_key,
             )
+            record_schedule_event(
+                self.db_path,
+                event_type="schedule.execute.started",
+                schedule_id=schedule_id,
+                job_id=schedule_job_id,
+                source="schedule_runner",
+                status="processing",
+                payload={"idempotency_key": idempotency_key},
+            )
 
             # 뉴스레터 생성 작업을 큐에 추가
             redis_success = False
@@ -502,6 +532,15 @@ class ScheduleRunner:
                         schedule_id=schedule_id,
                         job_id=job.id,
                     )
+                    record_schedule_event(
+                        self.db_path,
+                        event_type="schedule.execute.enqueued",
+                        schedule_id=schedule_id,
+                        job_id=schedule_job_id,
+                        source="schedule_runner",
+                        status="queued",
+                        payload={"queue_job_id": job.id},
+                    )
                     redis_success = True
                 except Exception as redis_error:
                     # Redis 연결 실패 시 fallback으로 동기 실행
@@ -515,6 +554,15 @@ class ScheduleRunner:
                         logger,
                         "schedule.execute.fallback_sync",
                         schedule_id=schedule_id,
+                    )
+                    record_schedule_event(
+                        self.db_path,
+                        event_type="schedule.execute.redis_failed",
+                        schedule_id=schedule_id,
+                        job_id=schedule_job_id,
+                        source="schedule_runner",
+                        status="fallback_sync",
+                        payload={"error": str(redis_error)},
                     )
 
             if not redis_success:
@@ -535,12 +583,29 @@ class ScheduleRunner:
                     schedule_id=schedule_id,
                     status=result.get("status", "unknown") if result else "no_result",
                 )
+                record_schedule_event(
+                    self.db_path,
+                    event_type="schedule.execute.completed",
+                    schedule_id=schedule_id,
+                    job_id=schedule_job_id,
+                    source="schedule_runner",
+                    status=result.get("status", "unknown") if result else "unknown",
+                )
 
             # 다음 실행 시간은 이미 실행 전에 업데이트됨 (중복 실행 방지)
 
             return True
 
         except Exception as e:
+            record_schedule_event(
+                self.db_path,
+                event_type="schedule.execute.failed",
+                schedule_id=schedule["id"],
+                job_id=locals().get("schedule_job_id"),
+                source="schedule_runner",
+                status="failed",
+                payload={"error": str(e)},
+            )
             log_exception(
                 logger,
                 "schedule.execute.failed",

--- a/web/tasks.py
+++ b/web/tasks.py
@@ -51,6 +51,21 @@ try:
 except ImportError:
     from web.ops_logging import log_exception, log_info, log_warning  # pragma: no cover
 
+try:
+    from analytics import (
+        record_email_event,
+        record_generation_completed,
+        record_generation_failed,
+        record_generation_started,
+    )
+except ImportError:
+    from web.analytics import (  # pragma: no cover
+        record_email_event,
+        record_generation_completed,
+        record_generation_failed,
+        record_generation_started,
+    )
+
 DATABASE_PATH = os.path.join(os.path.dirname(__file__), "storage.db")
 logger = logging.getLogger("web.tasks")
 
@@ -99,6 +114,14 @@ def generate_newsletter_task(
         params=data,
         idempotency_key=idempotency_key,
     )
+    record_generation_started(
+        db_path,
+        job_id=job_id,
+        params=data,
+        send_email=send_email,
+        source="worker",
+        idempotency_key=idempotency_key,
+    )
 
     email = data.get("email", "")
     approval_required = bool(data.get("require_approval")) and bool(email)
@@ -144,10 +167,33 @@ def generate_newsletter_task(
                 response["email_to"] = email
                 response["email_deduplicated"] = bool(send_result.get("skipped", False))
                 response["send_key"] = send_result.get("send_key")
+                record_email_event(
+                    db_path,
+                    event_type=(
+                        "email.deduplicated"
+                        if response["email_deduplicated"]
+                        else "email.sent"
+                    ),
+                    job_id=job_id,
+                    recipient=email,
+                    send_key=response["send_key"],
+                    source="worker",
+                    status="sent",
+                    deduplicated=response["email_deduplicated"],
+                )
             except Exception as exc:
                 response["email_sent"] = False
                 response["email_error"] = str(exc)
                 response["delivery_status"] = DELIVERY_STATUS_SEND_FAILED
+                record_email_event(
+                    db_path,
+                    event_type="email.failed",
+                    job_id=job_id,
+                    recipient=email,
+                    source="worker",
+                    status="failed",
+                    error=str(exc),
+                )
                 log_warning(
                     logger,
                     "worker.email.send_failed",
@@ -175,6 +221,12 @@ def generate_newsletter_task(
             job_id=job_id,
             approval_status=response["approval_status"],
             delivery_status=response["delivery_status"],
+        )
+        record_generation_completed(
+            db_path,
+            job_id=job_id,
+            result=response,
+            source="worker",
         )
         log_info(
             logger,
@@ -205,6 +257,12 @@ def generate_newsletter_task(
             params=data,
             idempotency_key=idempotency_key,
         )
+        record_generation_failed(
+            db_path,
+            job_id=job_id,
+            error=exc,
+            source="worker",
+        )
         log_exception(logger, "worker.job.generation_error", exc, job_id=job_id)
         raise
     except Exception as exc:
@@ -226,6 +284,12 @@ def generate_newsletter_task(
             result=error_response,
             params=data,
             idempotency_key=idempotency_key,
+        )
+        record_generation_failed(
+            db_path,
+            job_id=job_id,
+            error=exc,
+            source="worker",
         )
         log_exception(logger, "worker.job.failed", exc, job_id=job_id)
         raise


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- add a durable analytics event store for canonical Flask runtime operations
- capture generation, email delivery, and schedule execution events so RR-21 can build an ops dashboard without re-instrumenting runtime paths

## Scope
### In Scope
- additive `analytics_events` schema and persistence helpers
- worker/send/schedule runtime instrumentation
- regression tests for analytics capture on core ops paths

### Out of Scope
- analytics read APIs and dashboard UI
- changes to scheduling semantics or email delivery behavior beyond event capture

## Delivery Unit
- RR: #197
- Delivery Unit ID: DU-20260308-analytics-capture
- Merge Boundary: analytics event storage plus runtime instrumentation only
- Rollback Boundary: revert commit `2422aa0`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): analytics capture regression tests

### Commands and Results
```bash
MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com /Users/hojungjung/development/newsletter-generator-rr20/.venv/bin/python -m pytest /Users/hojungjung/development/newsletter-generator-rr20/tests/unit_tests/test_web_analytics_capture.py -q
# 3 passed

MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com /Users/hojungjung/development/newsletter-generator-rr20/.venv/bin/python -m pytest /Users/hojungjung/development/newsletter-generator-rr20/tests/test_web_api.py -q
# 17 passed, 1 skipped

RUN_INTEGRATION_TESTS=1 MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com /Users/hojungjung/development/newsletter-generator-rr20/.venv/bin/python -m pytest /Users/hojungjung/development/newsletter-generator-rr20/tests/integration/test_schedule_execution.py -q
# 7 passed, 1 skipped

MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com /Users/hojungjung/development/newsletter-generator-rr20/.venv/bin/python -m pytest /Users/hojungjung/development/newsletter-generator-rr20/tests/unit_tests/test_schedule_time_sync.py /Users/hojungjung/development/newsletter-generator-rr20/tests/contract/test_web_email_routes_contract.py /Users/hojungjung/development/newsletter-generator-rr20/tests/unit_tests/test_config_import_side_effects.py -q
# 18 passed

EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr20 make -C /Users/hojungjung/development/newsletter-generator-rr20 check
# pass

EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr20 make -C /Users/hojungjung/development/newsletter-generator-rr20 check-full
# pass
```

## Risk & Rollback
- Risk: extra SQLite writes on worker, send-email, and schedule execution paths
- Rollback: revert commit `2422aa0` to drop instrumentation and stop writing `analytics_events`; additive schema can remain safely unused if needed

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 기존 `generate` / `schedule` idempotency key 경로는 그대로 두고, analytics payload에 참조만 추가했습니다.
- Outbox/send_key 중복 방지 결과: 기존 dedupe 동작은 유지했고 `email.deduplicated` / `email.sent` / `email.failed` 이벤트만 추가 적재했습니다.
- import-time side effect 제거 여부: 새 import-time side effect는 추가하지 않았습니다.

## Not Run (with reason)
- 실제 메일 발송 통합 검증: 로컬 dummy token 환경이어서 skip
- CI의 manual real-time schedule scenario: 기존 테스트 자체가 manual verification으로 skip
