### PR TITLE
feat(web): add analytics dashboard for runtime metrics

### DIFF
--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -15,6 +15,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from web.app import DATABASE_PATH, app  # noqa: E402
+from web.db_state import record_analytics_event  # noqa: E402
 
 pytestmark = [pytest.mark.api, pytest.mark.email]
 
@@ -31,6 +32,14 @@ def _delete_source_policy(policy_id: str) -> None:
     conn = sqlite3.connect(DATABASE_PATH)
     cursor = conn.cursor()
     cursor.execute("DELETE FROM source_policies WHERE id = ?", (policy_id,))
+    conn.commit()
+    conn.close()
+
+
+def _delete_analytics_event(event_id: str) -> None:
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM analytics_events WHERE id = ?", (event_id,))
     conn.commit()
     conn.close()
 
@@ -250,6 +259,30 @@ class TestWebAPI:
 
         result = json.loads(response.data)
         assert isinstance(result, list)
+
+    def test_analytics_endpoint(self, client):
+        """Test analytics dashboard endpoint"""
+        event_id = record_analytics_event(
+            DATABASE_PATH,
+            "generation.completed",
+            job_id=f"analytics-job-{uuid.uuid4()}",
+            status="success",
+            duration_seconds=2.5,
+            cost_usd=0.42,
+            payload={"source": "test_web_api"},
+        )
+
+        try:
+            response = client.get("/api/analytics")
+            assert response.status_code == 200
+
+            result = json.loads(response.data)
+            assert result["window_days"] == 7
+            assert "summary" in result
+            assert "recent_events" in result
+            assert result["summary"]["generation"]["completed"] >= 1
+        finally:
+            _delete_analytics_event(event_id)
 
     def test_schedules_endpoint(self, client):
         """Test schedules endpoint"""

--- a/tests/unit_tests/test_web_access_control.py
+++ b/tests/unit_tests/test_web_access_control.py
@@ -34,6 +34,7 @@ def _build_app(*, testing: bool, monkeypatch: pytest.MonkeyPatch) -> Flask:
 
 def test_protected_route_matcher_covers_sensitive_paths() -> None:
     assert is_protected_route("/api/approvals")
+    assert is_protected_route("/api/analytics")
     assert is_protected_route("/api/schedule")
     assert is_protected_route("/api/schedule/demo/run")
     assert is_protected_route("/api/presets")

--- a/tests/unit_tests/test_web_analytics_routes.py
+++ b/tests/unit_tests/test_web_analytics_routes.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+from db_state import ensure_database_schema, record_analytics_event  # noqa: E402
+from routes_analytics import register_analytics_routes  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def _build_app(database_path: str) -> Flask:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    register_analytics_routes(app, database_path)
+    return app
+
+
+def test_analytics_route_returns_summary_and_recent_events(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+    record_analytics_event(
+        str(db_path),
+        "generation.completed",
+        job_id="job-1",
+        status="success",
+        duration_seconds=3.25,
+        cost_usd=0.75,
+        payload={"source": "unit-test"},
+    )
+    record_analytics_event(
+        str(db_path),
+        "email.sent",
+        job_id="job-1",
+        status="sent",
+        payload={"recipient": "ops@example.com"},
+    )
+    record_analytics_event(
+        str(db_path),
+        "schedule.execute.completed",
+        schedule_id="schedule-1",
+        job_id="job-1",
+        status="success",
+        payload={"source": "schedule_runner"},
+    )
+
+    app = _build_app(str(db_path))
+    with app.test_client() as client:
+        response = client.get("/api/analytics?window_days=14&recent_limit=10")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+    assert payload["window_days"] == 14
+    assert payload["summary"]["generation"]["completed"] == 1
+    assert payload["summary"]["email"]["sent"] == 1
+    assert payload["summary"]["schedule"]["completed"] == 1
+    assert len(payload["recent_events"]) == 3
+
+
+def test_analytics_route_clamps_invalid_window_and_limit(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    app = _build_app(str(db_path))
+    with app.test_client() as client:
+        response = client.get("/api/analytics?window_days=0&recent_limit=999")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+    assert payload["window_days"] == 1
+    assert payload["recent_events"] == []

--- a/web/access_control.py
+++ b/web/access_control.py
@@ -17,6 +17,7 @@ ADMIN_TOKEN_HEADER = "X-Admin-Token"  # nosec B105
 
 _PROTECTED_PREFIXES: tuple[str, ...] = (
     "/api/history",
+    "/api/analytics",
     "/api/presets",
     "/api/approvals",
     "/api/source-policies",

--- a/web/app.py
+++ b/web/app.py
@@ -271,6 +271,14 @@ register_source_policy_routes(app, DATABASE_PATH)
 
 
 try:
+    from routes_analytics import register_analytics_routes
+except ImportError:
+    from web.routes_analytics import register_analytics_routes  # pragma: no cover
+
+register_analytics_routes(app, DATABASE_PATH)
+
+
+try:
     from routes_newsletter_html import register_newsletter_html_route
 except ImportError:
     from web.routes_newsletter_html import (

--- a/web/db_state.py
+++ b/web/db_state.py
@@ -7,7 +7,7 @@ import json
 import os
 import sqlite3
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional, Tuple
 
 APPROVAL_STATUS_NOT_REQUESTED = "not_requested"
@@ -973,12 +973,34 @@ def list_analytics_events(
     *,
     limit: int = 100,
     event_type_prefix: str | None = None,
+    created_since: str | None = None,
 ) -> list[Dict[str, Any]]:
     """Return recent analytics events for tests and dashboard routes."""
     conn = _connect(db_path)
     try:
         cursor = conn.cursor()
-        if event_type_prefix:
+        if event_type_prefix and created_since:
+            cursor.execute(
+                """
+                SELECT
+                    id,
+                    event_type,
+                    job_id,
+                    schedule_id,
+                    status,
+                    deduplicated,
+                    duration_seconds,
+                    cost_usd,
+                    payload,
+                    created_at
+                FROM analytics_events
+                WHERE event_type LIKE ? AND created_at >= ?
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?
+                """,
+                (f"{event_type_prefix}%", created_since, limit),
+            )
+        elif event_type_prefix:
             cursor.execute(
                 """
                 SELECT
@@ -998,6 +1020,27 @@ def list_analytics_events(
                 LIMIT ?
                 """,
                 (f"{event_type_prefix}%", limit),
+            )
+        elif created_since:
+            cursor.execute(
+                """
+                SELECT
+                    id,
+                    event_type,
+                    job_id,
+                    schedule_id,
+                    status,
+                    deduplicated,
+                    duration_seconds,
+                    cost_usd,
+                    payload,
+                    created_at
+                FROM analytics_events
+                WHERE created_at >= ?
+                ORDER BY created_at DESC, id DESC
+                LIMIT ?
+                """,
+                (created_since, limit),
             )
         else:
             cursor.execute(
@@ -1037,3 +1080,105 @@ def list_analytics_events(
         ]
     finally:
         conn.close()
+
+
+def get_analytics_dashboard_data(
+    db_path: str,
+    *,
+    window_days: int = 7,
+    recent_limit: int = 25,
+) -> Dict[str, Any]:
+    """Return aggregated analytics metrics and recent events for the dashboard."""
+    since = (
+        (datetime.now(timezone.utc) - timedelta(days=max(1, int(window_days))))
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT
+                SUM(CASE WHEN event_type = 'generation.started' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN event_type = 'generation.completed' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN event_type = 'generation.failed' THEN 1 ELSE 0 END),
+                AVG(CASE WHEN event_type = 'generation.completed' THEN duration_seconds END),
+                SUM(CASE WHEN event_type = 'generation.completed' THEN COALESCE(cost_usd, 0) ELSE 0 END)
+            FROM analytics_events
+            WHERE created_at >= ?
+            """,
+            (since,),
+        )
+        generation_row = cursor.fetchone() or (0, 0, 0, None, 0.0)
+
+        cursor.execute(
+            """
+            SELECT
+                SUM(CASE WHEN event_type = 'email.sent' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN event_type = 'email.deduplicated' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN event_type = 'email.failed' THEN 1 ELSE 0 END)
+            FROM analytics_events
+            WHERE created_at >= ?
+            """,
+            (since,),
+        )
+        email_row = cursor.fetchone() or (0, 0, 0)
+
+        cursor.execute(
+            """
+            SELECT
+                SUM(CASE WHEN event_type = 'schedule.created' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN event_type IN ('schedule.execute.enqueued', 'schedule.run_now.queued') THEN 1 ELSE 0 END),
+                SUM(CASE WHEN event_type IN ('schedule.execute.completed', 'schedule.run_now.completed') THEN 1 ELSE 0 END),
+                SUM(CASE WHEN event_type IN ('schedule.execute.failed', 'schedule.run_now.failed') THEN 1 ELSE 0 END)
+            FROM analytics_events
+            WHERE created_at >= ?
+            """,
+            (since,),
+        )
+        schedule_row = cursor.fetchone() or (0, 0, 0, 0)
+    finally:
+        conn.close()
+
+    generation_started = int(generation_row[0] or 0)
+    generation_completed = int(generation_row[1] or 0)
+    generation_failed = int(generation_row[2] or 0)
+    success_base = generation_completed + generation_failed
+    success_rate = (
+        round((generation_completed / success_base) * 100, 1) if success_base else None
+    )
+
+    return {
+        "window_days": max(1, int(window_days)),
+        "summary": {
+            "generation": {
+                "started": generation_started,
+                "completed": generation_completed,
+                "failed": generation_failed,
+                "success_rate": success_rate,
+                "average_duration_seconds": (
+                    round(float(generation_row[3]), 2)
+                    if generation_row[3] is not None
+                    else None
+                ),
+                "total_cost_usd": round(float(generation_row[4] or 0.0), 4),
+            },
+            "email": {
+                "sent": int(email_row[0] or 0),
+                "deduplicated": int(email_row[1] or 0),
+                "failed": int(email_row[2] or 0),
+            },
+            "schedule": {
+                "created": int(schedule_row[0] or 0),
+                "queued": int(schedule_row[1] or 0),
+                "completed": int(schedule_row[2] or 0),
+                "failed": int(schedule_row[3] or 0),
+            },
+        },
+        "recent_events": list_analytics_events(
+            db_path,
+            limit=max(1, int(recent_limit)),
+            created_since=since,
+        ),
+    }

--- a/web/routes_analytics.py
+++ b/web/routes_analytics.py
@@ -1,0 +1,49 @@
+"""Protected analytics dashboard routes for the canonical web runtime."""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Flask, jsonify, request
+from flask.typing import ResponseReturnValue
+
+try:
+    from db_state import get_analytics_dashboard_data
+except ImportError:
+    from web.db_state import get_analytics_dashboard_data  # pragma: no cover
+
+try:
+    from ops_logging import log_exception, log_info
+except ImportError:
+    from web.ops_logging import log_exception, log_info  # pragma: no cover
+
+
+logger = logging.getLogger("web.routes_analytics")
+
+
+def register_analytics_routes(app: Flask, database_path: str) -> None:
+    """Register analytics API routes on the given Flask app."""
+
+    @app.route("/api/analytics", methods=["GET"])  # type: ignore[untyped-decorator]
+    def analytics_dashboard() -> ResponseReturnValue:
+        """Return aggregated metrics and recent analytics events."""
+        try:
+            raw_window_days = request.args.get("window_days", type=int)
+            raw_recent_limit = request.args.get("recent_limit", type=int)
+            window_days = 7 if raw_window_days is None else raw_window_days
+            recent_limit = 25 if raw_recent_limit is None else raw_recent_limit
+            payload = get_analytics_dashboard_data(
+                database_path,
+                window_days=max(1, min(window_days, 90)),
+                recent_limit=max(1, min(recent_limit, 100)),
+            )
+            log_info(
+                logger,
+                "analytics.loaded",
+                window_days=payload["window_days"],
+                recent_count=len(payload["recent_events"]),
+            )
+            return jsonify(payload)
+        except Exception as exc:
+            log_exception(logger, "analytics.load_failed", exc)
+            return jsonify({"error": f"Analytics load failed: {exc}"}), 500

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -10,6 +10,7 @@ class NewsletterApp {
         this.adminTokenStorageKey = 'newsletter-admin-api-token';
         this.savedPresets = [];
         this.selectedPresetId = '';
+        this.analyticsData = null;
         this.sourcePolicies = [];
         this.editingSourcePolicyId = '';
         this.init();
@@ -55,6 +56,7 @@ class NewsletterApp {
         document.getElementById('adminToken').addEventListener('input', (e) => {
             this.persistAdminToken(e.target.value);
             this.loadPresets(this.selectedPresetId);
+            this.loadAnalytics();
             this.loadSourcePolicies();
         });
         document.getElementById('presetSelect').addEventListener('change', (e) => this.handlePresetSelection(e.target.value));
@@ -63,12 +65,14 @@ class NewsletterApp {
         document.getElementById('updatePresetBtn').addEventListener('click', () => this.updateSelectedPreset());
         document.getElementById('deletePresetBtn').addEventListener('click', () => this.deleteSelectedPreset());
         document.getElementById('refreshPresetsBtn').addEventListener('click', () => this.loadPresets(this.selectedPresetId));
+        document.getElementById('refreshAnalyticsBtn').addEventListener('click', () => this.loadAnalytics());
         document.getElementById('refreshSourcePoliciesBtn').addEventListener('click', () => this.loadSourcePolicies());
         document.getElementById('saveSourcePolicyBtn').addEventListener('click', () => this.saveSourcePolicy());
         document.getElementById('cancelSourcePolicyEditBtn').addEventListener('click', () => this.resetSourcePolicyForm());
 
         // Navigation buttons
         document.getElementById('historyBtn').addEventListener('click', () => this.switchTab('historyTab'));
+        document.getElementById('analyticsBtn').addEventListener('click', () => this.switchTab('analyticsTab'));
         document.getElementById('approvalBtn').addEventListener('click', () => this.switchTab('approvalTab'));
         document.getElementById('sourcesBtn').addEventListener('click', () => this.switchTab('sourcePolicyTab'));
         document.getElementById('scheduleBtn').addEventListener('click', () => this.switchTab('scheduleManageTab'));
@@ -288,6 +292,7 @@ class NewsletterApp {
         const panelMap = {
             'generateTab': 'generatePanel',
             'historyTab': 'historyPanel',
+            'analyticsTab': 'analyticsPanel',
             'approvalTab': 'approvalPanel',
             'sourcePolicyTab': 'sourcePolicyPanel',
             'scheduleManageTab': 'scheduleManagePanel'
@@ -300,6 +305,8 @@ class NewsletterApp {
             // Load data for specific tabs
             if (tabId === 'historyTab') {
                 this.loadHistory();
+            } else if (tabId === 'analyticsTab') {
+                this.loadAnalytics();
             } else if (tabId === 'approvalTab') {
                 this.loadApprovals();
             } else if (tabId === 'sourcePolicyTab') {
@@ -1191,6 +1198,143 @@ class NewsletterApp {
             `).join('');
         } catch (error) {
             approvalsList.innerHTML = `<p class="text-red-600">승인 대기함 조회 실패: ${error.message}</p>`;
+        }
+    }
+
+    setAnalyticsStatus(message, tone = 'gray') {
+        const status = document.getElementById('analyticsStatus');
+        const toneClassMap = {
+            gray: 'border-gray-200 bg-gray-50 text-gray-600',
+            green: 'border-green-200 bg-green-50 text-green-700',
+            yellow: 'border-amber-200 bg-amber-50 text-amber-700',
+            red: 'border-red-200 bg-red-50 text-red-700'
+        };
+
+        status.className = `mt-4 rounded-lg border px-4 py-3 text-sm ${toneClassMap[tone] || toneClassMap.gray}`;
+        status.textContent = message;
+    }
+
+    renderAnalyticsCards(summary = {}) {
+        const container = document.getElementById('analyticsSummaryCards');
+        const generation = summary.generation || {};
+        const email = summary.email || {};
+        const schedule = summary.schedule || {};
+        const cards = [
+            {
+                label: 'Generation',
+                accent: 'text-blue-700',
+                body: `
+                    <div class="text-3xl font-bold ${generation.failed ? 'text-amber-700' : 'text-blue-700'}">${generation.completed ?? 0}</div>
+                    <p class="mt-1 text-sm text-gray-500">completed / ${generation.failed ?? 0} failed</p>
+                    <p class="mt-2 text-xs text-gray-500">success rate ${generation.success_rate ?? '-'}%</p>
+                `
+            },
+            {
+                label: 'Email Delivery',
+                accent: 'text-emerald-700',
+                body: `
+                    <div class="text-3xl font-bold text-emerald-700">${email.sent ?? 0}</div>
+                    <p class="mt-1 text-sm text-gray-500">sent / ${email.failed ?? 0} failed</p>
+                    <p class="mt-2 text-xs text-gray-500">deduplicated ${email.deduplicated ?? 0}</p>
+                `
+            },
+            {
+                label: 'Schedules',
+                accent: 'text-indigo-700',
+                body: `
+                    <div class="text-3xl font-bold text-indigo-700">${schedule.completed ?? 0}</div>
+                    <p class="mt-1 text-sm text-gray-500">completed / ${schedule.failed ?? 0} failed</p>
+                    <p class="mt-2 text-xs text-gray-500">created ${schedule.created ?? 0} / queued ${schedule.queued ?? 0}</p>
+                `
+            },
+            {
+                label: 'Duration & Cost',
+                accent: 'text-purple-700',
+                body: `
+                    <div class="text-3xl font-bold text-purple-700">${summary.generation?.average_duration_seconds ?? '-'}</div>
+                    <p class="mt-1 text-sm text-gray-500">avg seconds per completed run</p>
+                    <p class="mt-2 text-xs text-gray-500">total cost $${(summary.generation?.total_cost_usd ?? 0).toFixed(4)}</p>
+                `
+            }
+        ];
+
+        container.innerHTML = cards.map((card) => `
+            <div class="rounded-lg border border-gray-200 bg-white px-4 py-5 shadow-sm">
+                <div class="text-sm font-medium text-gray-500">${card.label}</div>
+                <div class="mt-3">${card.body}</div>
+            </div>
+        `).join('');
+    }
+
+    renderAnalyticsEvents(events = []) {
+        const eventsList = document.getElementById('analyticsEventsList');
+
+        if (!Array.isArray(events) || events.length === 0) {
+            eventsList.innerHTML = `
+                <div class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
+                    아직 analytics 이벤트가 없습니다.
+                </div>
+            `;
+            return;
+        }
+
+        eventsList.innerHTML = events.map((event) => {
+            const createdAt = event.created_at ? new Date(event.created_at).toLocaleString() : '-';
+            const payloadPairs = Object.entries(event.payload || {}).slice(0, 4);
+            return `
+                <div class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+                    <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                        <div>
+                            <div class="flex flex-wrap items-center gap-2">
+                                <span class="inline-flex rounded-full bg-blue-100 px-2.5 py-1 text-xs font-semibold text-blue-800">${event.event_type}</span>
+                                ${event.status ? `<span class="inline-flex rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700">${event.status}</span>` : ''}
+                                ${event.deduplicated ? '<span class="inline-flex rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-800">deduplicated</span>' : ''}
+                            </div>
+                            <p class="mt-2 text-sm text-gray-500">${createdAt}</p>
+                            <p class="mt-1 text-sm text-gray-500">job: ${event.job_id || '-'}</p>
+                            <p class="text-sm text-gray-500">schedule: ${event.schedule_id || '-'}</p>
+                        </div>
+                        <div class="min-w-0 flex-1 rounded-md bg-gray-50 px-3 py-2 text-xs text-gray-600 md:max-w-xl">
+                            ${payloadPairs.length > 0
+                                ? payloadPairs.map(([key, value]) => `<div><span class="font-medium text-gray-700">${key}</span>: ${String(value)}</div>`).join('')
+                                : 'payload 없음'}
+                        </div>
+                    </div>
+                </div>
+            `;
+        }).join('');
+    }
+
+    async loadAnalytics() {
+        const analyticsWindow = document.getElementById('analyticsWindow');
+        const windowDays = parseInt(analyticsWindow.value, 10) || 7;
+
+        try {
+            const response = await fetch(`/api/analytics?window_days=${windowDays}&recent_limit=25`, {
+                headers: this.buildHeaders({ includeAdminToken: true })
+            });
+            const result = await response.json();
+
+            if (!response.ok) {
+                this.analyticsData = null;
+                const message = response.status === 401 || response.status === 503
+                    ? this.getProtectedRouteMessage(result.error || 'Analytics를 불러올 수 없습니다.')
+                    : (result.error || 'Analytics를 불러올 수 없습니다.');
+                this.setAnalyticsStatus(message, 'yellow');
+                this.renderAnalyticsCards({});
+                this.renderAnalyticsEvents([]);
+                return;
+            }
+
+            this.analyticsData = result;
+            this.setAnalyticsStatus(`최근 ${result.window_days}일 기준 analytics 요약과 최근 ${result.recent_events.length}건 이벤트를 표시합니다.`, 'green');
+            this.renderAnalyticsCards(result.summary || {});
+            this.renderAnalyticsEvents(result.recent_events || []);
+        } catch (error) {
+            this.analyticsData = null;
+            this.setAnalyticsStatus(`Analytics 조회 실패: ${error.message}`, 'red');
+            this.renderAnalyticsCards({});
+            this.renderAnalyticsEvents([]);
         }
     }
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -33,6 +33,9 @@
                     <button id="historyBtn" class="text-gray-600 hover:text-gray-900">
                         <i class="fas fa-history mr-1"></i> History
                     </button>
+                    <button id="analyticsBtn" class="text-gray-600 hover:text-gray-900">
+                        <i class="fas fa-chart-line mr-1"></i> Analytics
+                    </button>
                     <button id="approvalBtn" class="text-gray-600 hover:text-gray-900">
                         <i class="fas fa-user-check mr-1"></i> Approvals
                     </button>
@@ -56,6 +59,9 @@
                 </button>
                 <button id="historyTab" class="tab-button text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
                     History
+                </button>
+                <button id="analyticsTab" class="tab-button text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
+                    Analytics
                 </button>
                 <button id="approvalTab" class="tab-button text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
                     Approval Inbox
@@ -322,6 +328,62 @@
                     <h3 class="text-lg leading-6 font-medium text-gray-900 mb-4">생성 히스토리</h3>
                     <div id="historyList">
                         <!-- History items will be loaded here -->
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div id="analyticsPanel" class="tab-panel hidden">
+            <div class="space-y-6">
+                <div class="bg-white shadow rounded-lg">
+                    <div class="px-4 py-5 sm:p-6">
+                        <div class="flex flex-col gap-3 border-b border-gray-200 pb-4 md:flex-row md:items-end md:justify-between">
+                            <div>
+                                <h3 class="text-lg leading-6 font-medium text-gray-900">운영 분석 대시보드</h3>
+                                <p class="mt-1 text-sm text-gray-500">
+                                    generation, email, schedule 실행 흐름의 최근 상태와 비용 지표를 확인합니다.
+                                </p>
+                            </div>
+                            <div class="flex items-center gap-3">
+                                <label for="analyticsWindow" class="text-sm font-medium text-gray-700">조회 기간</label>
+                                <select id="analyticsWindow"
+                                        class="rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm">
+                                    <option value="1">최근 1일</option>
+                                    <option value="7" selected>최근 7일</option>
+                                    <option value="14">최근 14일</option>
+                                    <option value="30">최근 30일</option>
+                                </select>
+                                <button id="refreshAnalyticsBtn"
+                                        class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100">
+                                    새로고침
+                                </button>
+                            </div>
+                        </div>
+
+                        <div id="analyticsStatus"
+                             class="mt-4 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600">
+                            운영 토큰이 있으면 최근 analytics 이벤트와 요약 지표를 확인할 수 있습니다.
+                        </div>
+
+                        <div id="analyticsSummaryCards" class="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                            <div class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
+                                Analytics 데이터를 불러오는 중입니다.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="bg-white shadow rounded-lg">
+                    <div class="px-4 py-5 sm:p-6">
+                        <div class="flex items-center justify-between border-b border-gray-200 pb-4">
+                            <h4 class="text-base font-medium text-gray-900">최근 이벤트</h4>
+                            <span class="text-sm text-gray-500">최대 25건</span>
+                        </div>
+                        <div id="analyticsEventsList" class="mt-4 space-y-3">
+                            <div class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-5 text-sm text-gray-500">
+                                아직 analytics 이벤트가 없습니다.
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary (what / why)
- add a protected `/api/analytics` endpoint so runtime metrics can be queried without opening raw database access
- add an analytics dashboard tab to the Flask UI so operators can inspect generation, delivery, and schedule activity in one place
- add regression tests for the new route, protected-path registration, and dashboard data contract

## Scope
- `web/db_state.py`
- `web/routes_analytics.py`
- `web/access_control.py`
- `web/app.py`
- `web/templates/index.html`
- `web/static/js/app.js`
- `tests/test_web_api.py`
- `tests/unit_tests/test_web_access_control.py`
- `tests/unit_tests/test_web_analytics_routes.py`

## Delivery Unit
- RR: #199
- Delivery Unit ID: DU-20260308-RR21
- Merge Boundary: Analytics dashboard API/UI for canonical Flask runtime only.
- Rollback Boundary: Revert PR #200 or commit `ab6a9f6` to remove the dashboard route and UI wiring.

## Test & Evidence
- `python3 -m py_compile web/routes_analytics.py web/db_state.py web/app.py`
- `node --check web/static/js/app.js`
- `MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/unit_tests/test_web_analytics_routes.py tests/unit_tests/test_web_access_control.py -q`
- `MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/test_web_api.py -q`
- `RUN_INTEGRATION_TESTS=1 MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/integration/test_schedule_execution.py -q`
- `MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/unit_tests/test_schedule_time_sync.py tests/contract/test_web_email_routes_contract.py tests/unit_tests/test_config_import_side_effects.py -q`
- `EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr21 make -C /Users/hojungjung/development/newsletter-generator-rr21 check`
- `EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr21 make -C /Users/hojungjung/development/newsletter-generator-rr21 check-full`

## Risk & Rollback
- Risk is limited to read-only analytics aggregation plus dashboard rendering on the canonical Flask app.
- No destructive schema change is included; the route reads additive analytics data already written by RR-20.
- Rollback is a single revert of `ab6a9f6` or PR #200.

## Ops-Safety Addendum (if touching protected paths)
- Touched protected paths: `web/app.py`.
- Additional ops-safety verification run:
  - `tests/test_web_api.py -q`
  - `tests/integration/test_schedule_execution.py -q`
  - `tests/unit_tests/test_schedule_time_sync.py -q`
  - `tests/contract/test_web_email_routes_contract.py -q`
  - `tests/unit_tests/test_config_import_side_effects.py -q`

## Not Run (with reason)
- GitHub-hosted CI checks were not run locally because they require the remote Actions environment.
- No browser E2E suite was run because the dashboard rendering change is covered with API/unit regression tests and static JS syntax validation in this RR.
