### PR TITLE
feat(web): add archive search API for prior newsletters

### DIFF
--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -44,6 +44,15 @@ def _delete_analytics_event(event_id: str) -> None:
     conn.close()
 
 
+def _delete_history_row(job_id: str) -> None:
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM archive_entries WHERE job_id = ?", (job_id,))
+    cursor.execute("DELETE FROM history WHERE id = ?", (job_id,))
+    conn.commit()
+    conn.close()
+
+
 def _insert_schedule_row(
     *,
     schedule_id: str,
@@ -60,6 +69,27 @@ def _insert_schedule_row(
         VALUES (?, ?, ?, ?, ?, 1)
         """,
         (schedule_id, json.dumps(params), rrule, next_run, created_at),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_history_row(
+    *,
+    job_id: str,
+    params: dict,
+    result: dict,
+    created_at: str,
+    status: str = "completed",
+) -> None:
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT OR REPLACE INTO history (id, params, result, created_at, status)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (job_id, json.dumps(params), json.dumps(result), created_at, status),
     )
     conn.commit()
     conn.close()
@@ -283,6 +313,39 @@ class TestWebAPI:
             assert result["summary"]["generation"]["completed"] >= 1
         finally:
             _delete_analytics_event(event_id)
+
+    def test_archive_search_endpoint(self, client):
+        """Test archive search and detail endpoints."""
+        job_id = f"archive-job-{uuid.uuid4()}"
+        _insert_history_row(
+            job_id=job_id,
+            params={
+                "keywords": ["battery", "materials"],
+                "template_style": "compact",
+                "period": 7,
+            },
+            result={
+                "title": "Battery Materials Weekly",
+                "html_content": "<html><body><p>Battery recycling and cathode materials update.</p></body></html>",
+            },
+            created_at="2026-03-08T08:00:00Z",
+        )
+
+        try:
+            response = client.get("/api/archive/search?q=battery")
+            assert response.status_code == 200
+
+            payload = json.loads(response.data)
+            assert payload["count"] >= 1
+            assert any(item["job_id"] == job_id for item in payload["results"])
+
+            detail_response = client.get(f"/api/archive/{job_id}")
+            assert detail_response.status_code == 200
+            detail_payload = json.loads(detail_response.data)
+            assert detail_payload["job_id"] == job_id
+            assert detail_payload["result"]["title"] == "Battery Materials Weekly"
+        finally:
+            _delete_history_row(job_id)
 
     def test_schedules_endpoint(self, client):
         """Test schedules endpoint"""

--- a/tests/unit_tests/test_web_access_control.py
+++ b/tests/unit_tests/test_web_access_control.py
@@ -35,6 +35,8 @@ def _build_app(*, testing: bool, monkeypatch: pytest.MonkeyPatch) -> Flask:
 def test_protected_route_matcher_covers_sensitive_paths() -> None:
     assert is_protected_route("/api/approvals")
     assert is_protected_route("/api/analytics")
+    assert is_protected_route("/api/archive")
+    assert is_protected_route("/api/archive/search")
     assert is_protected_route("/api/schedule")
     assert is_protected_route("/api/schedule/demo/run")
     assert is_protected_route("/api/presets")

--- a/tests/unit_tests/test_web_archive_routes.py
+++ b/tests/unit_tests/test_web_archive_routes.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+import routes_archive  # noqa: E402
+from db_state import ensure_database_schema  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def _build_archive_app(database_path: str) -> Flask:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    routes_archive.register_archive_routes(app, database_path)
+    return app
+
+
+def _insert_history_row(
+    database_path: str,
+    *,
+    job_id: str,
+    params: dict,
+    result: dict,
+    created_at: str,
+    status: str = "completed",
+) -> None:
+    ensure_database_schema(database_path)
+    conn = sqlite3.connect(database_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT OR REPLACE INTO history (id, params, result, created_at, status)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (job_id, json.dumps(params), json.dumps(result), created_at, status),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_archive_search_route_returns_recent_results(tmp_path: Path) -> None:
+    database_path = str(tmp_path / "storage.db")
+    app = _build_archive_app(database_path)
+    _insert_history_row(
+        database_path,
+        job_id="archive-job-1",
+        params={"keywords": ["battery", "materials"], "template_style": "compact"},
+        result={
+            "title": "Battery Materials Weekly",
+            "html_content": "<html><body><h1>Battery Materials Weekly</h1><p>Solid-state battery supply chain update.</p></body></html>",
+        },
+        created_at="2026-03-08T08:00:00Z",
+    )
+
+    with app.test_client() as client:
+        response = client.get("/api/archive/search")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+    assert payload["count"] == 1
+    assert payload["results"][0]["job_id"] == "archive-job-1"
+    assert payload["results"][0]["keywords"] == ["battery", "materials"]
+
+
+def test_archive_search_route_filters_by_query_and_clamps_limit(tmp_path: Path) -> None:
+    database_path = str(tmp_path / "storage.db")
+    app = _build_archive_app(database_path)
+    _insert_history_row(
+        database_path,
+        job_id="archive-job-battery",
+        params={"keywords": "battery, materials", "template_style": "compact"},
+        result={
+            "title": "Battery Materials Weekly",
+            "html_content": "<html><body><p>Battery recycling and cathode materials.</p></body></html>",
+        },
+        created_at="2026-03-08T08:00:00Z",
+    )
+    _insert_history_row(
+        database_path,
+        job_id="archive-job-ai",
+        params={"keywords": ["ai", "chip"], "template_style": "detailed"},
+        result={
+            "title": "AI Chip Radar",
+            "html_content": "<html><body><p>Inference accelerator roadmap.</p></body></html>",
+        },
+        created_at="2026-03-08T09:00:00Z",
+    )
+
+    with app.test_client() as client:
+        response = client.get("/api/archive/search?q=battery&limit=999")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+    assert payload["query"] == "battery"
+    assert payload["count"] == 1
+    assert payload["results"][0]["job_id"] == "archive-job-battery"
+
+
+def test_archive_detail_route_returns_archived_payload(tmp_path: Path) -> None:
+    database_path = str(tmp_path / "storage.db")
+    app = _build_archive_app(database_path)
+    _insert_history_row(
+        database_path,
+        job_id="archive-job-detail",
+        params={"domain": "semiconductor", "period": 7},
+        result={
+            "title": "Semiconductor Weekly",
+            "html_content": "<html><body><p>Packaging capacity and foundry updates.</p></body></html>",
+        },
+        created_at="2026-03-08T10:00:00Z",
+    )
+
+    with app.test_client() as client:
+        response = client.get("/api/archive/archive-job-detail")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+    assert payload["job_id"] == "archive-job-detail"
+    assert payload["params"]["domain"] == "semiconductor"
+    assert payload["result"]["title"] == "Semiconductor Weekly"

--- a/web/access_control.py
+++ b/web/access_control.py
@@ -21,6 +21,7 @@ _PROTECTED_PREFIXES: tuple[str, ...] = (
     "/api/presets",
     "/api/approvals",
     "/api/source-policies",
+    "/api/archive",
     "/api/schedule",
     "/api/schedules",
     "/api/send-email",

--- a/web/app.py
+++ b/web/app.py
@@ -279,6 +279,14 @@ register_analytics_routes(app, DATABASE_PATH)
 
 
 try:
+    from routes_archive import register_archive_routes
+except ImportError:
+    from web.routes_archive import register_archive_routes  # pragma: no cover
+
+register_archive_routes(app, DATABASE_PATH)
+
+
+try:
     from routes_newsletter_html import register_newsletter_html_route
 except ImportError:
     from web.routes_newsletter_html import (

--- a/web/archive.py
+++ b/web/archive.py
@@ -1,0 +1,96 @@
+"""Helpers for deriving searchable archive entries from completed history rows."""
+
+from __future__ import annotations
+
+import html
+import re
+from typing import Any, Dict, List
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+_SNIPPET_LENGTH = 280
+
+
+def normalize_keywords(raw: Any) -> List[str]:
+    """Normalize stored keywords into a clean list of strings."""
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [item.strip() for item in raw.split(",") if item.strip()]
+    if isinstance(raw, list):
+        return [str(item).strip() for item in raw if str(item).strip()]
+    return [str(raw).strip()] if str(raw).strip() else []
+
+
+def strip_html_text(html_content: str) -> str:
+    """Collapse HTML into plain text suitable for indexing and snippets."""
+    if not html_content:
+        return ""
+    without_tags = _HTML_TAG_RE.sub(" ", html_content)
+    unescaped = html.unescape(without_tags)
+    return _WHITESPACE_RE.sub(" ", unescaped).strip()
+
+
+def build_archive_entry(
+    *,
+    job_id: str,
+    created_at: str,
+    params: Dict[str, Any] | None,
+    result: Dict[str, Any] | None,
+) -> Dict[str, Any] | None:
+    """Return a normalized archive entry or None when history is not archivable."""
+    parsed_params = params or {}
+    parsed_result = result or {}
+    html_content = str(parsed_result.get("html_content") or "").strip()
+    if not html_content:
+        return None
+
+    keywords = normalize_keywords(parsed_params.get("keywords"))
+    domain = str(parsed_params.get("domain") or "").strip()
+    title = str(parsed_result.get("title") or "").strip()
+    if not title:
+        title = (
+            f"Newsletter: {domain}"
+            if domain
+            else f"Newsletter: {', '.join(keywords[:3]) or job_id}"
+        )
+
+    plain_text = strip_html_text(html_content)
+    snippet = plain_text[:_SNIPPET_LENGTH].rstrip()
+    if len(plain_text) > _SNIPPET_LENGTH:
+        snippet = f"{snippet}..."
+
+    source_kind = "domain" if domain else "keywords"
+    source_value = domain or ", ".join(keywords)
+    metadata = {
+        "domain": domain or None,
+        "keywords": keywords,
+        "template_style": parsed_params.get("template_style"),
+        "period": parsed_params.get("period"),
+        "email_compatible": bool(parsed_params.get("email_compatible", False)),
+        "approval_status": parsed_result.get("approval_status"),
+        "delivery_status": parsed_result.get("delivery_status"),
+    }
+    search_text = "\n".join(
+        segment
+        for segment in (
+            title,
+            source_value,
+            plain_text,
+            str(parsed_params.get("template_style") or "").strip(),
+        )
+        if segment
+    )
+
+    return {
+        "job_id": job_id,
+        "title": title,
+        "snippet": snippet or title,
+        "source_kind": source_kind,
+        "source_value": source_value,
+        "keywords": keywords,
+        "metadata": metadata,
+        "search_text": search_text,
+        "created_at": created_at,
+        "updated_at": created_at,
+    }

--- a/web/db_state.py
+++ b/web/db_state.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import sqlite3
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional, Tuple
+
+try:
+    from archive import build_archive_entry
+except ImportError:
+    from web.archive import build_archive_entry  # pragma: no cover
 
 APPROVAL_STATUS_NOT_REQUESTED = "not_requested"
 APPROVAL_STATUS_PENDING = "pending"
@@ -211,6 +217,23 @@ def _ensure_database_schema(conn: sqlite3.Connection) -> None:
     )
 
     cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS archive_entries (
+            job_id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            snippet TEXT NOT NULL,
+            source_kind TEXT NOT NULL,
+            source_value TEXT,
+            keywords JSON NOT NULL,
+            metadata JSON,
+            search_text TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+
+    cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_history_created_at ON history(created_at)"
     )
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_history_status ON history(status)")
@@ -246,6 +269,12 @@ def _ensure_database_schema(conn: sqlite3.Connection) -> None:
     )
     cursor.execute(
         "CREATE INDEX IF NOT EXISTS idx_analytics_events_created_at ON analytics_events(created_at DESC)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_archive_entries_created_at ON archive_entries(created_at DESC)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_archive_entries_source_kind ON archive_entries(source_kind, created_at DESC)"
     )
 
     conn.commit()
@@ -901,6 +930,17 @@ def get_active_source_policies(db_path: str) -> Dict[str, list[str]]:
         conn.close()
 
 
+def _parse_history_json(raw_value: str | None) -> Dict[str, Any]:
+    """Best-effort JSON decoding for stored history payloads."""
+    if not raw_value:
+        return {}
+    try:
+        parsed = json.loads(raw_value)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
 def _serialize_event_timestamp(value: str | datetime | None) -> str:
     """Serialize analytics timestamps in UTC ISO format."""
     if value is None:
@@ -913,6 +953,215 @@ def _serialize_event_timestamp(value: str | datetime | None) -> str:
         timestamp = value.astimezone(timezone.utc)
 
     return timestamp.isoformat().replace("+00:00", "Z")
+
+
+def sync_archive_entry_from_history(
+    db_path: str, job_id: str
+) -> Optional[Dict[str, Any]]:
+    """Create or refresh a normalized archive entry from a completed history row."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, params, result, created_at, status
+            FROM history
+            WHERE id = ?
+            """,
+            (job_id,),
+        )
+        row = cursor.fetchone()
+        if not row or row[4] != "completed":
+            return None
+
+        entry = build_archive_entry(
+            job_id=row[0],
+            created_at=row[3],
+            params=_parse_history_json(row[1]),
+            result=_parse_history_json(row[2]),
+        )
+        if entry is None:
+            return None
+
+        cursor.execute(
+            """
+            INSERT INTO archive_entries (
+                job_id,
+                title,
+                snippet,
+                source_kind,
+                source_value,
+                keywords,
+                metadata,
+                search_text,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(job_id) DO UPDATE SET
+                title = excluded.title,
+                snippet = excluded.snippet,
+                source_kind = excluded.source_kind,
+                source_value = excluded.source_value,
+                keywords = excluded.keywords,
+                metadata = excluded.metadata,
+                search_text = excluded.search_text,
+                created_at = excluded.created_at,
+                updated_at = excluded.updated_at
+            """,
+            (
+                entry["job_id"],
+                entry["title"],
+                entry["snippet"],
+                entry["source_kind"],
+                entry["source_value"],
+                canonical_json({"items": entry["keywords"]}),
+                canonical_json(entry["metadata"]),
+                entry["search_text"],
+                entry["created_at"],
+                _serialize_event_timestamp(datetime.now(timezone.utc)),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return get_archive_entry(db_path, job_id)
+
+
+def sync_archive_entries_from_history(db_path: str, *, limit: int = 100) -> int:
+    """Backfill recent completed history rows into archive storage."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id
+            FROM history
+            WHERE status = 'completed'
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            (max(1, int(limit)),),
+        )
+        job_ids = [str(row[0]) for row in cursor.fetchall()]
+    finally:
+        conn.close()
+
+    synced = 0
+    for job_id in job_ids:
+        if sync_archive_entry_from_history(db_path, job_id):
+            synced += 1
+    return synced
+
+
+def _decode_archive_row(row: tuple[Any, ...]) -> Dict[str, Any]:
+    keywords_payload = _parse_history_json(row[5])
+    metadata = _parse_history_json(row[6])
+    return {
+        "job_id": row[0],
+        "title": row[1],
+        "snippet": row[2],
+        "source_kind": row[3],
+        "source_value": row[4],
+        "keywords": keywords_payload.get("items", []),
+        "metadata": metadata,
+        "created_at": row[8],
+        "updated_at": row[9],
+    }
+
+
+def get_archive_entry(db_path: str, job_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch a normalized archive entry with archived history payloads."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT
+                a.job_id,
+                a.title,
+                a.snippet,
+                a.source_kind,
+                a.source_value,
+                a.keywords,
+                a.metadata,
+                a.search_text,
+                a.created_at,
+                a.updated_at,
+                h.params,
+                h.result,
+                h.status
+            FROM archive_entries AS a
+            LEFT JOIN history AS h ON h.id = a.job_id
+            WHERE a.job_id = ?
+            """,
+            (job_id,),
+        )
+        row = cursor.fetchone()
+    finally:
+        conn.close()
+
+    if row is None:
+        synced = sync_archive_entry_from_history(db_path, job_id)
+        if synced is None:
+            return None
+        return get_archive_entry(db_path, job_id)
+
+    archive_entry = _decode_archive_row(row[:10])
+    archive_entry["params"] = _parse_history_json(row[10])
+    archive_entry["result"] = _parse_history_json(row[11])
+    archive_entry["status"] = row[12]
+    return archive_entry
+
+
+def search_archive_entries(
+    db_path: str,
+    *,
+    query: str | None = None,
+    limit: int = 20,
+) -> list[Dict[str, Any]]:
+    """Search archive entries by source, title, and archived newsletter content."""
+    normalized_limit = max(1, int(limit))
+    sync_archive_entries_from_history(db_path, limit=max(50, normalized_limit * 5))
+
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT
+                job_id,
+                title,
+                snippet,
+                source_kind,
+                source_value,
+                keywords,
+                metadata,
+                search_text,
+                created_at,
+                updated_at
+            FROM archive_entries
+            ORDER BY created_at DESC, job_id DESC
+            LIMIT ?
+            """,
+            (max(50, normalized_limit * 5),),
+        )
+        rows = cursor.fetchall()
+        entries = [_decode_archive_row(row) for row in rows]
+        normalized_query = (query or "").strip().lower()
+        if not normalized_query:
+            return entries[:normalized_limit]
+
+        terms = [term for term in re.split(r"\s+", normalized_query) if term]
+        filtered_entries = [
+            entry
+            for entry, row in zip(entries, rows)
+            if all(term in str(row[7]).lower() for term in terms)
+        ]
+        return filtered_entries[:normalized_limit]
+    finally:
+        conn.close()
 
 
 def record_analytics_event(

--- a/web/routes_archive.py
+++ b/web/routes_archive.py
@@ -1,0 +1,72 @@
+"""Archive search and detail routes for prior newsletter editions."""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Flask, jsonify, request
+from flask.typing import ResponseReturnValue
+
+try:
+    from db_state import get_archive_entry, search_archive_entries
+except ImportError:
+    from web.db_state import (  # pragma: no cover
+        get_archive_entry,
+        search_archive_entries,
+    )
+
+try:
+    from ops_logging import log_exception, log_info
+except ImportError:
+    from web.ops_logging import log_exception, log_info  # pragma: no cover
+
+
+logger = logging.getLogger("web.routes_archive")
+
+
+def register_archive_routes(app: Flask, database_path: str) -> None:
+    """Register read-only archive search and detail endpoints."""
+
+    @app.route("/api/archive/search")  # type: ignore[untyped-decorator]
+    def search_archive() -> ResponseReturnValue:
+        raw_limit = request.args.get("limit", type=int)
+        limit = 10 if raw_limit is None else raw_limit
+        normalized_limit = max(1, min(limit, 50))
+        query = (request.args.get("q") or "").strip()
+
+        try:
+            results = search_archive_entries(
+                database_path,
+                query=query or None,
+                limit=normalized_limit,
+            )
+            log_info(
+                logger,
+                "archive.search.completed",
+                query=query,
+                limit=normalized_limit,
+                count=len(results),
+            )
+            return jsonify(
+                {
+                    "query": query,
+                    "count": len(results),
+                    "results": results,
+                }
+            )
+        except Exception as exc:  # pragma: no cover - defensive route wrapper
+            log_exception(logger, "archive.search.failed", exc, query=query)
+            return jsonify({"error": f"Archive search failed: {str(exc)}"}), 500
+
+    @app.route("/api/archive/<job_id>")  # type: ignore[untyped-decorator]
+    def get_archive(job_id: str) -> ResponseReturnValue:
+        try:
+            entry = get_archive_entry(database_path, job_id)
+            if entry is None:
+                return jsonify({"error": "Archive entry not found"}), 404
+
+            log_info(logger, "archive.detail.loaded", job_id=job_id)
+            return jsonify(entry)
+        except Exception as exc:  # pragma: no cover - defensive route wrapper
+            log_exception(logger, "archive.detail.failed", exc, job_id=job_id)
+            return jsonify({"error": f"Archive lookup failed: {str(exc)}"}), 500


### PR DESCRIPTION
## Summary (what / why)
- add a normalized archive index derived from completed history rows so prior newsletters can be searched without reading raw history JSON
- add protected `/api/archive/search` and `/api/archive/<job_id>` routes for recent and query-based archive lookup
- add API and unit regression tests for archive indexing, protected route coverage, and archive detail retrieval

## Scope
- `web/archive.py`
- `web/routes_archive.py`
- `web/db_state.py`
- `web/access_control.py`
- `web/app.py`
- `tests/test_web_api.py`
- `tests/unit_tests/test_web_access_control.py`
- `tests/unit_tests/test_web_archive_routes.py`

## Delivery Unit
- RR: #201
- Delivery Unit ID: DU-20260308-RR22
- Merge Boundary: Archive indexing and read-only search/detail APIs for canonical Flask history data only.
- Rollback Boundary: Revert PR #203 or commit `1fa1093` to remove archive storage and routes.

## Test & Evidence
- `python3 -m py_compile web/archive.py web/routes_archive.py web/db_state.py web/app.py`
- `MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/unit_tests/test_web_archive_routes.py tests/unit_tests/test_web_access_control.py -q`
- `MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/test_web_api.py -q`
- `RUN_INTEGRATION_TESTS=1 MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com ./.venv/bin/python -m pytest tests/integration/test_schedule_execution.py tests/unit_tests/test_schedule_time_sync.py tests/contract/test_web_email_routes_contract.py tests/unit_tests/test_config_import_side_effects.py -q`
- `EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr22 make -C /Users/hojungjung/development/newsletter-generator-rr22 check`
- `EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr22 make -C /Users/hojungjung/development/newsletter-generator-rr22 check-full`

## Risk & Rollback
- Schema change is additive only: `archive_entries` table and indexes.
- Runtime risk is limited to read-only archive syncing and search route registration.
- Rollback is a single revert of PR #203 or commit `1fa1093`.

## Ops-Safety Addendum (if touching protected paths)
- Touched protected paths: `web/app.py`.
- Additional ops-safety verification run:
  - `tests/test_web_api.py -q`
  - `tests/integration/test_schedule_execution.py -q`
  - `tests/unit_tests/test_schedule_time_sync.py -q`
  - `tests/contract/test_web_email_routes_contract.py -q`
  - `tests/unit_tests/test_config_import_side_effects.py -q`

## Not Run (with reason)
- GitHub-hosted CI checks were not run locally because they require the remote Actions environment.
- No browser UI checks were run because RR-22 ships API-only archive access; UI integration is planned for RR-23.
