### PR TITLE
feat(web): reuse archived newsletters in compose flow

### DIFF
--- a/tests/unit_tests/test_web_archive_reuse_task.py
+++ b/tests/unit_tests/test_web_archive_reuse_task.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+from db_state import ensure_database_schema  # noqa: E402
+from tasks import generate_newsletter_task  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def _insert_history_row(
+    database_path: str,
+    *,
+    job_id: str,
+    params: dict,
+    result: dict,
+    created_at: str,
+    status: str = "completed",
+) -> None:
+    ensure_database_schema(database_path)
+    conn = sqlite3.connect(database_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT OR REPLACE INTO history (id, params, result, created_at, status)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (job_id, json.dumps(params), json.dumps(result), created_at, status),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_generate_newsletter_task_appends_selected_archive_references(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database_path = str(tmp_path / "storage.db")
+    archive_job_id = "archive-source-job"
+    _insert_history_row(
+        database_path,
+        job_id=archive_job_id,
+        params={"keywords": ["battery"], "template_style": "compact"},
+        result={
+            "title": "Battery Materials Weekly",
+            "html_content": "<html><body><p>Legacy battery supply chain summary.</p></body></html>",
+        },
+        created_at="2026-03-08T08:00:00Z",
+    )
+
+    monkeypatch.setattr(
+        "tasks.generate_newsletter",
+        lambda request: {
+            "status": "success",
+            "html_content": "<html><body><h1>Fresh Newsletter</h1><p>New market update.</p></body></html>",
+            "title": "Fresh Newsletter",
+            "generation_stats": {},
+            "input_params": {"keywords": request.keywords},
+            "error": None,
+        },
+    )
+
+    result = generate_newsletter_task(
+        {
+            "keywords": ["battery", "materials"],
+            "archive_reference_ids": [archive_job_id],
+        },
+        "job-with-archive-reference",
+        database_path=database_path,
+    )
+
+    assert result["status"] == "success"
+    assert result["archive_references"] == [
+        {
+            "job_id": archive_job_id,
+            "title": "Battery Materials Weekly",
+            "snippet": "Legacy battery supply chain summary.",
+            "source_value": "battery",
+            "created_at": "2026-03-08T08:00:00Z",
+        }
+    ]
+    assert result["input_params"]["archive_reference_ids"] == [archive_job_id]
+    assert "지난 뉴스레터 참고" in result["html_content"]
+    assert "Battery Materials Weekly" in result["html_content"]

--- a/web/archive.py
+++ b/web/archive.py
@@ -1,4 +1,4 @@
-"""Helpers for deriving searchable archive entries from completed history rows."""
+"""Helpers for deriving searchable archive entries and reuse sections."""
 
 from __future__ import annotations
 
@@ -94,3 +94,49 @@ def build_archive_entry(
         "created_at": created_at,
         "updated_at": created_at,
     }
+
+
+def render_archive_reference_section(references: List[Dict[str, Any]]) -> str:
+    """Render a portable HTML section summarizing selected archive references."""
+    if not references:
+        return ""
+
+    items_html = "".join(
+        f"""
+        <li style="margin-bottom: 14px;">
+            <div style="font-weight: 600; color: #1f2937;">{html.escape(str(reference.get("title") or reference.get("job_id") or "Archive Reference"))}</div>
+            <div style="margin-top: 4px; color: #4b5563; font-size: 14px; line-height: 1.5;">{html.escape(str(reference.get("snippet") or ""))}</div>
+            <div style="margin-top: 4px; color: #6b7280; font-size: 12px;">{html.escape(str(reference.get("source_value") or ""))}</div>
+        </li>
+        """
+        for reference in references
+    )
+
+    return f"""
+    <section style="margin: 28px 0; padding: 20px; border: 1px solid #dbeafe; border-radius: 12px; background: #eff6ff;">
+        <h2 style="margin: 0 0 12px 0; color: #1d4ed8; font-size: 20px;">지난 뉴스레터 참고</h2>
+        <p style="margin: 0 0 14px 0; color: #1f2937; font-size: 14px; line-height: 1.6;">
+            이번 생성에는 아래 과거 뉴스레터를 참고본으로 함께 보관했습니다.
+        </p>
+        <ul style="margin: 0; padding-left: 20px;">
+            {items_html}
+        </ul>
+    </section>
+    """
+
+
+def inject_archive_references(
+    html_content: str,
+    references: List[Dict[str, Any]],
+) -> str:
+    """Inject a reusable archive reference section before the closing body tag."""
+    if not html_content or not references:
+        return html_content
+
+    reference_section = render_archive_reference_section(references)
+    if not reference_section:
+        return html_content
+
+    if "</body>" in html_content:
+        return html_content.replace("</body>", f"{reference_section}\n</body>", 1)
+    return f"{html_content}\n{reference_section}"

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -10,6 +10,8 @@ class NewsletterApp {
         this.adminTokenStorageKey = 'newsletter-admin-api-token';
         this.savedPresets = [];
         this.selectedPresetId = '';
+        this.archiveSearchResults = [];
+        this.selectedArchiveReferences = [];
         this.analyticsData = null;
         this.sourcePolicies = [];
         this.editingSourcePolicyId = '';
@@ -23,6 +25,8 @@ class NewsletterApp {
         this.toggleScheduleSettings(document.getElementById('enableSchedule').checked);
         this.updateScheduleOptions();
         this.syncPresetActions();
+        this.renderSelectedArchiveReferences();
+        this.renderArchiveSearchResults();
         this.loadPresets();
     }
 
@@ -56,6 +60,8 @@ class NewsletterApp {
         document.getElementById('adminToken').addEventListener('input', (e) => {
             this.persistAdminToken(e.target.value);
             this.loadPresets(this.selectedPresetId);
+            this.loadArchiveSearchResults(document.getElementById('archiveSearchInput').value);
+            this.hydrateArchiveReferences(this.selectedArchiveReferences.map((reference) => reference.job_id));
             this.loadAnalytics();
             this.loadSourcePolicies();
         });
@@ -65,6 +71,14 @@ class NewsletterApp {
         document.getElementById('updatePresetBtn').addEventListener('click', () => this.updateSelectedPreset());
         document.getElementById('deletePresetBtn').addEventListener('click', () => this.deleteSelectedPreset());
         document.getElementById('refreshPresetsBtn').addEventListener('click', () => this.loadPresets(this.selectedPresetId));
+        document.getElementById('searchArchiveBtn').addEventListener('click', () => this.loadArchiveSearchResults());
+        document.getElementById('clearArchiveSelectionBtn').addEventListener('click', () => this.clearArchiveReferences());
+        document.getElementById('archiveSearchInput').addEventListener('keydown', (event) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                this.loadArchiveSearchResults();
+            }
+        });
         document.getElementById('refreshAnalyticsBtn').addEventListener('click', () => this.loadAnalytics());
         document.getElementById('refreshSourcePoliciesBtn').addEventListener('click', () => this.loadSourcePolicies());
         document.getElementById('saveSourcePolicyBtn').addEventListener('click', () => this.saveSourcePolicy());
@@ -137,6 +151,213 @@ class NewsletterApp {
             button.classList.toggle('opacity-50', !hasSelection);
             button.classList.toggle('cursor-not-allowed', !hasSelection);
         });
+    }
+
+    setArchiveStatus(message, tone = 'gray') {
+        const status = document.getElementById('archiveStatus');
+        const toneClassMap = {
+            gray: 'text-gray-600',
+            green: 'text-green-600',
+            yellow: 'text-amber-600',
+            red: 'text-red-600'
+        };
+
+        status.className = `text-sm ${toneClassMap[tone] || toneClassMap.gray}`;
+        status.textContent = message;
+    }
+
+    normalizeArchiveReference(entry = {}) {
+        return {
+            job_id: entry.job_id,
+            title: entry.title || entry.job_id,
+            snippet: entry.snippet || '선택된 참고본 세부 정보를 불러오지 못했습니다.',
+            source_value: entry.source_value || '',
+            created_at: entry.created_at || null
+        };
+    }
+
+    isArchiveReferenceSelected(jobId) {
+        return this.selectedArchiveReferences.some((reference) => reference.job_id === jobId);
+    }
+
+    renderSelectedArchiveReferences() {
+        const container = document.getElementById('selectedArchiveReferences');
+
+        if (!this.selectedArchiveReferences.length) {
+            container.innerHTML = '<p class="text-sm text-gray-500">선택된 참고본이 없습니다.</p>';
+            return;
+        }
+
+        container.innerHTML = this.selectedArchiveReferences.map((reference) => `
+            <div class="rounded-md border border-blue-100 bg-blue-50 p-3">
+                <div class="flex items-start justify-between gap-3">
+                    <div>
+                        <p class="text-sm font-semibold text-gray-900">${reference.title}</p>
+                        <p class="mt-1 text-sm text-gray-600">${reference.snippet}</p>
+                        <p class="mt-2 text-xs text-gray-500">${reference.source_value || reference.job_id}</p>
+                    </div>
+                    <button onclick="app.removeArchiveReference('${reference.job_id}')"
+                            class="rounded-md border border-red-200 bg-white px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50">
+                        제거
+                    </button>
+                </div>
+            </div>
+        `).join('');
+    }
+
+    renderArchiveSearchResults() {
+        const container = document.getElementById('archiveSearchResults');
+
+        if (!this.archiveSearchResults.length) {
+            container.innerHTML = '<p class="text-sm text-gray-500">검색어를 입력하면 최근 뉴스레터를 불러옵니다.</p>';
+            return;
+        }
+
+        container.innerHTML = this.archiveSearchResults.map((reference) => {
+            const isSelected = this.isArchiveReferenceSelected(reference.job_id);
+            return `
+                <div class="rounded-md border border-gray-200 p-3">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <p class="text-sm font-semibold text-gray-900">${reference.title}</p>
+                            <p class="mt-1 text-sm text-gray-600">${reference.snippet}</p>
+                            <p class="mt-2 text-xs text-gray-500">${reference.source_value || reference.job_id}</p>
+                        </div>
+                        <button onclick="app.toggleArchiveReference('${reference.job_id}')"
+                                class="rounded-md px-2 py-1 text-xs font-medium ${isSelected ? 'bg-red-100 text-red-700 hover:bg-red-200' : 'bg-blue-100 text-blue-700 hover:bg-blue-200'}">
+                            ${isSelected ? '선택 해제' : '참고 추가'}
+                        </button>
+                    </div>
+                </div>
+            `;
+        }).join('');
+    }
+
+    async loadArchiveSearchResults(queryOverride = null) {
+        const query = typeof queryOverride === 'string'
+            ? queryOverride.trim()
+            : document.getElementById('archiveSearchInput').value.trim();
+
+        if (!this.hasAdminToken()) {
+            this.archiveSearchResults = [];
+            this.renderArchiveSearchResults();
+            this.setArchiveStatus(this.getProtectedRouteMessage('운영 토큰이 있어야 과거 뉴스레터를 검색할 수 있습니다.'), 'yellow');
+            return;
+        }
+
+        try {
+            const params = new URLSearchParams({
+                limit: '8'
+            });
+            if (query) {
+                params.set('q', query);
+            }
+
+            const response = await fetch(`/api/archive/search?${params.toString()}`, {
+                headers: this.buildHeaders({ includeAdminToken: true })
+            });
+            const result = await response.json();
+
+            if (!response.ok) {
+                const message = response.status === 401 || response.status === 503
+                    ? this.getProtectedRouteMessage(result.error || '과거 뉴스레터를 불러올 수 없습니다.')
+                    : (result.error || '과거 뉴스레터를 불러올 수 없습니다.');
+                this.archiveSearchResults = [];
+                this.renderArchiveSearchResults();
+                this.setArchiveStatus(message, 'yellow');
+                return;
+            }
+
+            this.archiveSearchResults = Array.isArray(result.results)
+                ? result.results.map((entry) => this.normalizeArchiveReference(entry))
+                : [];
+            this.renderArchiveSearchResults();
+            this.setArchiveStatus(
+                this.archiveSearchResults.length
+                    ? `${this.archiveSearchResults.length}개의 과거 뉴스레터를 찾았습니다.`
+                    : '조건에 맞는 과거 뉴스레터가 없습니다.',
+                this.archiveSearchResults.length ? 'green' : 'gray'
+            );
+        } catch (error) {
+            this.archiveSearchResults = [];
+            this.renderArchiveSearchResults();
+            this.setArchiveStatus(`과거 뉴스레터 조회 실패: ${error.message}`, 'red');
+        }
+    }
+
+    async hydrateArchiveReferences(referenceIds = []) {
+        const normalizedIds = Array.isArray(referenceIds)
+            ? referenceIds.map((item) => String(item || '').trim()).filter(Boolean).slice(0, 3)
+            : [];
+
+        if (!normalizedIds.length) {
+            this.selectedArchiveReferences = [];
+            this.renderSelectedArchiveReferences();
+            return;
+        }
+
+        const placeholderMap = new Map(this.selectedArchiveReferences.map((reference) => [reference.job_id, reference]));
+        this.selectedArchiveReferences = normalizedIds.map((jobId) => placeholderMap.get(jobId) || this.normalizeArchiveReference({ job_id: jobId, title: jobId }));
+        this.renderSelectedArchiveReferences();
+
+        if (!this.hasAdminToken()) {
+            this.setArchiveStatus('선택된 참고본 ID는 유지됩니다. 운영 토큰을 입력하면 세부 정보를 복원합니다.', 'yellow');
+            return;
+        }
+
+        const loadedReferences = await Promise.all(normalizedIds.map(async (jobId) => {
+            try {
+                const response = await fetch(`/api/archive/${jobId}`, {
+                    headers: this.buildHeaders({ includeAdminToken: true })
+                });
+                if (!response.ok) {
+                    return placeholderMap.get(jobId) || this.normalizeArchiveReference({ job_id: jobId, title: jobId });
+                }
+                const payload = await response.json();
+                return this.normalizeArchiveReference(payload);
+            } catch (error) {
+                return placeholderMap.get(jobId) || this.normalizeArchiveReference({ job_id: jobId, title: jobId });
+            }
+        }));
+
+        this.selectedArchiveReferences = loadedReferences;
+        this.renderSelectedArchiveReferences();
+    }
+
+    toggleArchiveReference(jobId) {
+        if (this.isArchiveReferenceSelected(jobId)) {
+            this.removeArchiveReference(jobId);
+            return;
+        }
+
+        if (this.selectedArchiveReferences.length >= 3) {
+            this.showError('과거 뉴스레터 참고본은 최대 3개까지 선택할 수 있습니다.');
+            return;
+        }
+
+        const match = this.archiveSearchResults.find((reference) => reference.job_id === jobId);
+        if (!match) {
+            this.showError('선택한 참고본 정보를 찾을 수 없습니다.');
+            return;
+        }
+
+        this.selectedArchiveReferences = [...this.selectedArchiveReferences, match];
+        this.renderSelectedArchiveReferences();
+        this.renderArchiveSearchResults();
+        this.setArchiveStatus(`${this.selectedArchiveReferences.length}개의 참고본을 선택했습니다.`, 'green');
+    }
+
+    removeArchiveReference(jobId) {
+        this.selectedArchiveReferences = this.selectedArchiveReferences.filter((reference) => reference.job_id !== jobId);
+        this.renderSelectedArchiveReferences();
+        this.renderArchiveSearchResults();
+    }
+
+    clearArchiveReferences() {
+        this.selectedArchiveReferences = [];
+        this.renderSelectedArchiveReferences();
+        this.renderArchiveSearchResults();
+        this.setArchiveStatus('선택된 참고본을 초기화했습니다.');
     }
 
     setSourcePolicyStatus(message, tone = 'gray') {
@@ -406,6 +627,7 @@ class NewsletterApp {
         document.getElementById('email').value = params.email || '';
         this.applyScheduleFromRRule(params.rrule || '');
         this.toggleInputMethod();
+        this.hydrateArchiveReferences(params.archive_reference_ids || []);
     }
 
     applyPresetToForm(preset) {
@@ -536,6 +758,9 @@ class NewsletterApp {
         data.period = parseInt(document.getElementById('period').value, 10);
         data.template_style = document.getElementById('templateStyle').value;
         data.email_compatible = document.getElementById('emailCompatible').checked;
+        if (this.selectedArchiveReferences.length) {
+            data.archive_reference_ids = this.selectedArchiveReferences.map((reference) => reference.job_id);
+        }
 
         // Schedule data
         const enableSchedule = document.getElementById('enableSchedule').checked;
@@ -927,6 +1152,9 @@ class NewsletterApp {
         // Input Parameters
         if (result.input_params) {
             const params = result.input_params;
+            const archiveReferences = Array.isArray(result.archive_references)
+                ? result.archive_references
+                : [];
             detailsHtml += `
                 <div class="mb-4 p-4 bg-gray-50 rounded-lg border border-gray-200">
                     <h4 class="text-lg font-semibold text-gray-800 mb-3">
@@ -943,6 +1171,19 @@ class NewsletterApp {
                             <div class="mb-2">
                                 <span class="font-medium text-gray-700">Domain:</span>
                                 <span class="ml-2 px-2 py-1 bg-purple-100 text-purple-800 rounded">${params.domain}</span>
+                            </div>
+                        ` : ''}
+                        ${archiveReferences.length ? `
+                            <div class="mt-3 rounded-md border border-blue-100 bg-blue-50 p-3">
+                                <div class="font-medium text-gray-700">Archive References</div>
+                                <ul class="mt-2 space-y-2">
+                                    ${archiveReferences.map((reference) => `
+                                        <li class="text-sm text-gray-600">
+                                            <span class="font-medium text-gray-800">${reference.title}</span>
+                                            <span class="block text-xs text-gray-500">${reference.source_value || reference.job_id}</span>
+                                        </li>
+                                    `).join('')}
+                                </ul>
                             </div>
                         ` : ''}
                     </div>

--- a/web/tasks.py
+++ b/web/tasks.py
@@ -25,6 +25,7 @@ try:
         DELIVERY_STATUS_SEND_FAILED,
         DELIVERY_STATUS_SENT,
         get_active_source_policies,
+        get_archive_entry,
         update_history_review_state,
         update_history_status,
     )
@@ -37,6 +38,7 @@ except ImportError:
         DELIVERY_STATUS_SEND_FAILED,
         DELIVERY_STATUS_SENT,
         get_active_source_policies,
+        get_archive_entry,
         update_history_review_state,
         update_history_status,
     )
@@ -66,6 +68,11 @@ except ImportError:
         record_generation_started,
     )
 
+try:
+    from archive import inject_archive_references
+except ImportError:
+    from web.archive import inject_archive_references  # pragma: no cover
+
 DATABASE_PATH = os.path.join(os.path.dirname(__file__), "storage.db")
 logger = logging.getLogger("web.tasks")
 
@@ -88,6 +95,29 @@ def _build_request(
         source_allowlist=policies.get("allowlist") or [],
         source_blocklist=policies.get("blocklist") or [],
     )
+
+
+def _resolve_archive_references(
+    db_path: str, archive_reference_ids: list[str] | None
+) -> list[Dict[str, Any]]:
+    references: list[Dict[str, Any]] = []
+    for raw_reference_id in archive_reference_ids or []:
+        reference_id = str(raw_reference_id).strip()
+        if not reference_id:
+            continue
+        archive_entry = get_archive_entry(db_path, reference_id)
+        if not archive_entry:
+            continue
+        references.append(
+            {
+                "job_id": archive_entry["job_id"],
+                "title": archive_entry["title"],
+                "snippet": archive_entry["snippet"],
+                "source_value": archive_entry.get("source_value") or "",
+                "created_at": archive_entry.get("created_at"),
+            }
+        )
+    return references[:3]
 
 
 def generate_newsletter_task(
@@ -125,18 +155,31 @@ def generate_newsletter_task(
 
     email = data.get("email", "")
     approval_required = bool(data.get("require_approval")) and bool(email)
+    archive_references = _resolve_archive_references(
+        db_path,
+        [str(item).strip() for item in data.get("archive_reference_ids", []) or []],
+    )
 
     try:
         source_policies = get_active_source_policies(db_path)
         request = _build_request(data, source_policies=source_policies)
         result = generate_newsletter(request)
+        html_content = inject_archive_references(
+            result["html_content"],
+            archive_references,
+        )
+        input_params = dict(result.get("input_params", {}))
+        input_params["archive_reference_ids"] = [
+            reference["job_id"] for reference in archive_references
+        ]
 
         response: Dict[str, Any] = {
             "status": result["status"],
-            "html_content": result["html_content"],
+            "html_content": html_content,
             "title": result["title"],
             "generation_stats": result.get("generation_stats", {}),
-            "input_params": result.get("input_params", {}),
+            "input_params": input_params,
+            "archive_references": archive_references,
             "error": None,
             "sent": False,
             "email_sent": False,
@@ -160,7 +203,7 @@ def generate_newsletter_task(
                     job_id=job_id,
                     to=email,
                     subject=get_newsletter_subject(result=result, params=data),
-                    html=result["html_content"],
+                    html=html_content,
                 )
                 response["sent"] = True
                 response["email_sent"] = True

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -118,6 +118,47 @@
                         </div>
                     </div>
 
+                    <div class="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4">
+                        <div class="flex flex-col gap-4">
+                            <div class="flex flex-col gap-3 lg:flex-row lg:items-end">
+                                <div class="flex-1">
+                                    <label for="archiveSearchInput" class="block text-sm font-medium text-gray-700">과거 뉴스레터 참고 검색</label>
+                                    <div class="mt-1 flex gap-2">
+                                        <input id="archiveSearchInput"
+                                               type="text"
+                                               placeholder="키워드, 도메인, 제목으로 검색"
+                                               class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm">
+                                        <button id="searchArchiveBtn"
+                                                class="rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700">
+                                            검색
+                                        </button>
+                                    </div>
+                                </div>
+                                <button id="clearArchiveSelectionBtn"
+                                        class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100">
+                                    참고본 초기화
+                                </button>
+                            </div>
+                            <p id="archiveStatus" class="text-sm text-gray-600">
+                                운영 토큰이 있으면 과거 뉴스레터를 검색해 새 생성본의 참고 섹션에 붙일 수 있습니다.
+                            </p>
+                            <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
+                                <div class="rounded-lg border border-white bg-white p-4 shadow-sm">
+                                    <h4 class="text-sm font-semibold text-gray-900">선택된 참고본</h4>
+                                    <div id="selectedArchiveReferences" class="mt-3 space-y-3">
+                                        <p class="text-sm text-gray-500">선택된 참고본이 없습니다.</p>
+                                    </div>
+                                </div>
+                                <div class="rounded-lg border border-white bg-white p-4 shadow-sm">
+                                    <h4 class="text-sm font-semibold text-gray-900">검색 결과</h4>
+                                    <div id="archiveSearchResults" class="mt-3 space-y-3">
+                                        <p class="text-sm text-gray-500">검색어를 입력하면 최근 뉴스레터를 불러옵니다.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Input Method Selection -->
                     <div class="mb-6">
                         <label class="text-base font-medium text-gray-900">입력 방식</label>

--- a/web/types.py
+++ b/web/types.py
@@ -28,6 +28,7 @@ class GenerateNewsletterRequest(BaseModel):
     period: int = Field(default=14)
     email: Optional[str] = None  # 즉시 발송용 이메일 주소
     require_approval: bool = False
+    archive_reference_ids: Optional[List[str]] = None
 
     @field_validator("keywords")  # type: ignore[untyped-decorator]
     @classmethod
@@ -55,6 +56,19 @@ class GenerateNewsletterRequest(BaseModel):
         if v is not None and not EMAIL_PATTERN.match(v):
             raise ValueError("Invalid email format")
         return v
+
+    @field_validator("archive_reference_ids")  # type: ignore[untyped-decorator]
+    @classmethod
+    def validate_archive_reference_ids(
+        cls, value: Optional[List[str]]
+    ) -> Optional[List[str]]:
+        if value is None:
+            return None
+
+        normalized = [str(item).strip() for item in value if str(item).strip()]
+        if len(normalized) > 3:
+            raise ValueError("Archive references are limited to 3 items")
+        return normalized
 
     @model_validator(mode="after")  # type: ignore[untyped-decorator]
     def validate_keywords_or_domain(self) -> "GenerateNewsletterRequest":


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- add archive reference selection to the compose flow so operators can reuse prior newsletters without leaving the canonical Flask runtime
- persist selected archive reference ids through the request/result path and inject a visible archive reference section into generated HTML before send

## Scope
### In Scope
- request schema support for `archive_reference_ids`
- archive lookup and HTML reference injection in `web/tasks.py`
- compose form UI for archive search, selection, hydration, and result display
- regression coverage for archive reuse task behavior

### Out of Scope
- semantic retrieval or vector search
- changes to the core compose pipeline prompt graph
- archive authoring or edit workflows

## Delivery Unit
- RR: #202
- Delivery Unit ID: DU-20260308-archive-reuse
- Merge Boundary: RR-23 archive reuse compose flow only
- Rollback Boundary: revert `ba8ca0e` / PR #204

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): targeted archive reuse, web API, and ops-safety pytest suites

### Commands and Results
```bash
python3 -m py_compile /Users/hojungjung/development/newsletter-generator-rr23/web/archive.py /Users/hojungjung/development/newsletter-generator-rr23/web/tasks.py /Users/hojungjung/development/newsletter-generator-rr23/web/types.py
# pass

node --check /Users/hojungjung/development/newsletter-generator-rr23/web/static/js/app.js
# pass

MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com /Users/hojungjung/development/newsletter-generator-rr23/.venv/bin/python -m pytest /Users/hojungjung/development/newsletter-generator-rr23/tests/unit_tests/test_web_archive_reuse_task.py /Users/hojungjung/development/newsletter-generator-rr23/tests/unit_tests/test_web_archive_routes.py /Users/hojungjung/development/newsletter-generator-rr23/tests/test_web_api.py -q
# 23 passed, 1 skipped

RUN_INTEGRATION_TESTS=1 MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com /Users/hojungjung/development/newsletter-generator-rr23/.venv/bin/python -m pytest /Users/hojungjung/development/newsletter-generator-rr23/tests/integration/test_schedule_execution.py /Users/hojungjung/development/newsletter-generator-rr23/tests/unit_tests/test_schedule_time_sync.py /Users/hojungjung/development/newsletter-generator-rr23/tests/contract/test_web_email_routes_contract.py /Users/hojungjung/development/newsletter-generator-rr23/tests/unit_tests/test_config_import_side_effects.py -q
# 25 passed, 1 skipped

EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr23 make -C /Users/hojungjung/development/newsletter-generator-rr23 check
# pass

EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr23 make -C /Users/hojungjung/development/newsletter-generator-rr23 check-full
# pass
```

## Risk & Rollback
- Risk: archive reference HTML injection changes the final outbound email payload and could duplicate or misplace the inserted section if downstream rendering assumptions change.
- Rollback: revert `ba8ca0e` or revert PR #204 to remove archive reference selection and injection.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 변경 없음. 기존 generate path의 idempotency 정책은 그대로 유지하고, archive reference ids만 request payload/result metadata에 추가했습니다.
- Outbox/send_key 중복 방지 결과: 변경 없음. send-email/outbox dedupe 경로는 건드리지 않았고, 회귀 검증으로 `tests/contract/test_web_email_routes_contract.py -q`를 다시 통과했습니다.
- import-time side effect 제거 여부: 새 import-time side effect 없음. archive lookup과 HTML injection은 task runtime에서만 수행됩니다.

## Not Run (with reason)
- 실제 이메일 발송 연동 테스트: 실 서비스 토큰이 필요한 경로라 로컬 MOCK_MODE 검증으로 대체했습니다.
- 실시간 schedule 실행 수동 검증: 자동 suite에서 manual verification skip 처리되는 기존 테스트 특성 때문입니다.
