### PR TITLE
fix(web): add canonical request throttles

### DIFF
--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -483,3 +483,39 @@ def test_protected_schedule_routes_require_admin_token_in_production_like_runtim
         assert isinstance(authorized.get_json(), list)
     finally:
         app.config["TESTING"] = original_testing
+
+
+def test_generate_route_rate_limits_burst_requests_in_production_like_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("APP_ENV", "production")
+    original_testing = app.config.get("TESTING", False)
+    app.config["TESTING"] = False
+
+    limiter = app.extensions["request_limiters"]["generate"]
+    limiter.reset()
+    for _ in range(4):
+        limiter.check("generate:127.0.0.1", limit=5, window_seconds=60)
+
+    try:
+        with app.test_client() as client:
+            first = client.post(
+                "/api/generate",
+                data=json.dumps({"keywords": "AI", "period": 14}),
+                content_type="application/json",
+                headers={"Idempotency-Key": "generate-limit-5"},
+            )
+            second = client.post(
+                "/api/generate",
+                data=json.dumps({"keywords": "AI", "period": 14}),
+                content_type="application/json",
+                headers={"Idempotency-Key": "generate-limit-6"},
+            )
+
+        assert first.status_code == 202
+        assert second.status_code == 429
+        assert second.get_json()["error"] == "Generate rate limit exceeded"
+        assert int(second.headers["Retry-After"]) >= 1
+    finally:
+        limiter.reset()
+        app.config["TESTING"] = original_testing

--- a/tests/unit_tests/test_web_access_control.py
+++ b/tests/unit_tests/test_web_access_control.py
@@ -15,14 +15,34 @@ from access_control import configure_access_control, is_protected_route  # noqa:
 pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
 
 
-def _build_app(*, testing: bool, monkeypatch: pytest.MonkeyPatch) -> Flask:
+def _build_app(
+    *,
+    testing: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    generate_rate_limit: int = 5,
+    generate_window_seconds: int = 60,
+    protected_rate_limit: int = 30,
+    protected_window_seconds: int = 60,
+    generate_max_body_bytes: int = 32 * 1024,
+) -> Flask:
     monkeypatch.setenv("APP_ENV", "production")
     app = Flask(__name__)
     app.config["TESTING"] = testing
-    configure_access_control(app)
+    configure_access_control(
+        app,
+        generate_rate_limit=generate_rate_limit,
+        generate_window_seconds=generate_window_seconds,
+        protected_rate_limit=protected_rate_limit,
+        protected_window_seconds=protected_window_seconds,
+        generate_max_body_bytes=generate_max_body_bytes,
+    )
 
     @app.route("/api/schedules")
     def schedules():
+        return jsonify({"ok": True})
+
+    @app.route("/api/generate", methods=["POST"])
+    def generate():
         return jsonify({"ok": True})
 
     @app.route("/health")
@@ -116,3 +136,69 @@ def test_public_routes_remain_open_in_production_like_runtime(
 
     assert response.status_code == 200
     assert response.get_json() == {"status": "ok"}
+
+
+def test_generate_route_is_rate_limited_in_production_like_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_app(
+        testing=False,
+        monkeypatch=monkeypatch,
+        generate_rate_limit=2,
+        generate_window_seconds=60,
+    )
+
+    with app.test_client() as client:
+        first = client.post("/api/generate", json={"keywords": "AI"})
+        second = client.post("/api/generate", json={"keywords": "AI"})
+        third = client.post("/api/generate", json={"keywords": "AI"})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert third.status_code == 429
+    assert third.get_json()["error"] == "Generate rate limit exceeded"
+    assert int(third.headers["Retry-After"]) >= 1
+
+
+def test_generate_route_rejects_large_request_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_app(
+        testing=False,
+        monkeypatch=monkeypatch,
+        generate_max_body_bytes=16,
+    )
+
+    with app.test_client() as client:
+        response = client.post(
+            "/api/generate",
+            data=b"x" * 17,
+            content_type="application/json",
+        )
+
+    assert response.status_code == 413
+    assert response.get_json() == {"error": "Generate request body is too large"}
+
+
+def test_protected_routes_are_rate_limited_even_with_valid_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ADMIN_API_TOKEN", "top-secret-token")
+    app = _build_app(
+        testing=False,
+        monkeypatch=monkeypatch,
+        protected_rate_limit=2,
+        protected_window_seconds=60,
+    )
+
+    with app.test_client() as client:
+        headers = {"X-Admin-Token": "top-secret-token"}
+        first = client.get("/api/schedules", headers=headers)
+        second = client.get("/api/schedules", headers=headers)
+        third = client.get("/api/schedules", headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert third.status_code == 429
+    assert third.get_json()["error"] == "Protected route rate limit exceeded"
+    assert int(third.headers["Retry-After"]) >= 1

--- a/web/access_control.py
+++ b/web/access_control.py
@@ -10,10 +10,20 @@ from typing import Mapping
 from flask import Flask, jsonify, request
 from flask.typing import ResponseReturnValue
 
+try:
+    from request_limits import SlidingWindowRateLimiter
+except ImportError:
+    from web.request_limits import SlidingWindowRateLimiter  # pragma: no cover
+
 LOGGER = logging.getLogger(__name__)
 
 ADMIN_TOKEN_ENV_VAR = "ADMIN_API_TOKEN"  # nosec B105
 ADMIN_TOKEN_HEADER = "X-Admin-Token"  # nosec B105
+DEFAULT_GENERATE_RATE_LIMIT = 5
+DEFAULT_GENERATE_WINDOW_SECONDS = 60
+DEFAULT_PROTECTED_RATE_LIMIT = 30
+DEFAULT_PROTECTED_WINDOW_SECONDS = 60
+DEFAULT_GENERATE_MAX_BODY_BYTES = 32 * 1024
 
 _PROTECTED_PREFIXES: tuple[str, ...] = (
     "/api/history",
@@ -88,24 +98,92 @@ def _resolve_provided_admin_token() -> str | None:
     return None
 
 
+def _client_identifier() -> str:
+    forwarded_for = str(request.headers.get("X-Forwarded-For", "")).strip()
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip() or "unknown"
+
+    return str(request.remote_addr or "unknown")
+
+
+def _rate_limit_response(
+    *,
+    message: str,
+    retry_after_seconds: int,
+) -> ResponseReturnValue:
+    response = jsonify(
+        {
+            "error": message,
+            "retry_after_seconds": retry_after_seconds,
+        }
+    )
+    response.status_code = 429
+    response.headers["Retry-After"] = str(retry_after_seconds)
+    return response
+
+
 def configure_access_control(
     app: Flask,
     *,
     environ: Mapping[str, str] | None = None,
     prefixes: tuple[str, ...] = _PROTECTED_PREFIXES,
+    generate_rate_limit: int = DEFAULT_GENERATE_RATE_LIMIT,
+    generate_window_seconds: int = DEFAULT_GENERATE_WINDOW_SECONDS,
+    protected_rate_limit: int = DEFAULT_PROTECTED_RATE_LIMIT,
+    protected_window_seconds: int = DEFAULT_PROTECTED_WINDOW_SECONDS,
+    generate_max_body_bytes: int = DEFAULT_GENERATE_MAX_BODY_BYTES,
 ) -> None:
     """Register a minimal admin-token guard for sensitive operational routes."""
     env = environ or os.environ
+    generate_limiter = SlidingWindowRateLimiter()
+    protected_limiter = SlidingWindowRateLimiter()
+    app.extensions.setdefault("request_limiters", {})
+    app.extensions["request_limiters"]["generate"] = generate_limiter
+    app.extensions["request_limiters"]["protected"] = protected_limiter
 
     @app.before_request  # type: ignore[untyped-decorator]
     def require_admin_api_token() -> ResponseReturnValue | None:
-        if request.method == "OPTIONS" or not is_protected_route(
-            request.path, prefixes
-        ):
+        if request.method == "OPTIONS":
             return None
 
         if _is_dev_like(app, env):
             return None
+
+        client_identifier = _client_identifier()
+
+        if request.path == "/api/generate":
+            content_length = int(request.content_length or 0)
+            if content_length > generate_max_body_bytes:
+                return (
+                    jsonify({"error": "Generate request body is too large"}),
+                    413,
+                )
+
+            decision = generate_limiter.check(
+                f"generate:{client_identifier}",
+                limit=generate_rate_limit,
+                window_seconds=generate_window_seconds,
+            )
+            if not decision.allowed:
+                return _rate_limit_response(
+                    message="Generate rate limit exceeded",
+                    retry_after_seconds=decision.retry_after_seconds,
+                )
+            return None
+
+        if not is_protected_route(request.path, prefixes):
+            return None
+
+        decision = protected_limiter.check(
+            f"protected:{client_identifier}",
+            limit=protected_rate_limit,
+            window_seconds=protected_window_seconds,
+        )
+        if not decision.allowed:
+            return _rate_limit_response(
+                message="Protected route rate limit exceeded",
+                retry_after_seconds=decision.retry_after_seconds,
+            )
 
         expected_token = _resolve_expected_admin_token(env)
         if not expected_token:

--- a/web/request_limits.py
+++ b/web/request_limits.py
@@ -1,0 +1,49 @@
+"""Small in-process rate limit helpers for the canonical Flask runtime."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RateLimitDecision:
+    allowed: bool
+    retry_after_seconds: int = 0
+
+
+class SlidingWindowRateLimiter:
+    """Track request bursts per key without introducing external dependencies."""
+
+    def __init__(self) -> None:
+        self._events: dict[str, deque[float]] = defaultdict(deque)
+        self._lock = threading.Lock()
+
+    def check(
+        self,
+        key: str,
+        *,
+        limit: int,
+        window_seconds: int,
+        now: float | None = None,
+    ) -> RateLimitDecision:
+        current_time = time.time() if now is None else now
+        window_start = current_time - max(window_seconds, 1)
+
+        with self._lock:
+            events = self._events[key]
+            while events and events[0] <= window_start:
+                events.popleft()
+
+            if len(events) >= max(limit, 1):
+                retry_after = max(1, int(events[0] + window_seconds - current_time))
+                return RateLimitDecision(allowed=False, retry_after_seconds=retry_after)
+
+            events.append(current_time)
+            return RateLimitDecision(allowed=True)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._events.clear()


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Add lightweight in-process throttling for canonical Flask `POST /api/generate` and protected operational routes so the public runtime fails with clear `429` responses before burst traffic turns into expensive work.

## Scope
### In Scope
- add sliding-window request throttles for generate and protected routes
- reject oversized generate request bodies before route execution
- add Flask regression coverage for `429` and `413` behavior

### Out of Scope
- replacing the shared admin token with a stronger auth model
- introducing Redis-backed or distributed rate limiting
- changing generation/idempotency semantics beyond pre-route throttling

## Delivery Unit
- RR: #205
- Delivery Unit ID: DU-20260308-web-rate-throttles
- Merge Boundary: Squash merge PR #208 only.
- Rollback Boundary: Revert the squash commit for PR #208.

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): targeted Flask/access-control regression tests

### Commands and Results
```bash
python3 -m py_compile /Users/hojungjung/development/newsletter-generator-rr25/web/request_limits.py /Users/hojungjung/development/newsletter-generator-rr25/web/access_control.py /Users/hojungjung/development/newsletter-generator-rr25/tests/unit_tests/test_web_access_control.py /Users/hojungjung/development/newsletter-generator-rr25/tests/test_web_api.py
# pass

rm -f /Users/hojungjung/development/newsletter-generator-rr25/web/storage.db && MOCK_MODE=true TESTING=1 OPENAI_API_KEY=test-key SERPER_API_KEY=test-key GEMINI_API_KEY=test-key ANTHROPIC_API_KEY=test-key POSTMARK_SERVER_TOKEN=dummy-token EMAIL_SENDER=test@example.com /Users/hojungjung/development/newsletter-generator/.venv/bin/python -m pytest /Users/hojungjung/development/newsletter-generator-rr25/tests/unit_tests/test_web_access_control.py /Users/hojungjung/development/newsletter-generator-rr25/tests/test_web_api.py -q
# 30 passed, 1 skipped

rm -f /Users/hojungjung/development/newsletter-generator-rr25/web/storage.db && EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr25 make -C /Users/hojungjung/development/newsletter-generator-rr25 check
# pass

rm -f /Users/hojungjung/development/newsletter-generator-rr25/web/storage.db && EXPECTED_CWD=/Users/hojungjung/development/newsletter-generator-rr25 make -C /Users/hojungjung/development/newsletter-generator-rr25 check-full
# pass
```

## Risk & Rollback
- Risk: Request throttles are in-process only, so limits are per app instance and may need later centralization if runtime topology changes.
- Rollback: Revert PR #208 to remove the throttles and restore prior request behavior.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 변경 없음. `/api/generate` 진입 전에 throttling만 추가했고 기존 idempotency key generation/apply path는 유지했습니다.
- Outbox/send_key 중복 방지 결과: 변경 없음. mail/scheduler send path는 수정하지 않았습니다.
- import-time side effect 제거 여부: 신규 import-time side effect 없음.

## Not Run (with reason)
- Manual production traffic test: local/CI 범위 밖이라 실행하지 않았습니다.
