### PR TITLE
refactor(settings): lock validation coverage before refactors

### DIFF
--- a/docs/dev/REFACTORING_EXECUTION_PLAN.md
+++ b/docs/dev/REFACTORING_EXECUTION_PLAN.md
@@ -1,43 +1,286 @@
-# Refactoring Execution Plan (Phase 5)
+# Refactoring Execution Plan
 
-대상 대형 파일을 충돌 없이 분해하기 위한 실행 규칙입니다.
+기준일: 2026-03-08
 
-## Scope
+이 문서는 현재 코드 상태를 기준으로 리팩토링 업무단위, 단계, 우선순위 근거를 다시 정리한 실행 문서입니다.
+장기 방향은 `docs/dev/LONG_TERM_REPO_STRATEGY.md`를 따르고, 본 문서는 그 전략을 당장 실행 가능한 작업 배치로 쪼개는 데 목적이 있습니다.
 
-- `web/app.py`
-- `newsletter/cli.py`
-- `newsletter/chains.py`
+## 1. 실행 기준
 
-## Rules
+1. 운영 안전이 미관보다 우선이다.
+2. 한 PR은 가급적 300 LOC, 8 files 이내의 작은 배치로 유지한다.
+3. 계약 테스트와 ops-safety 게이트를 깨는 구조 변경은 금지한다.
+4. Web runtime은 다음 제약을 유지한다.
+   - `newsletter_core.public.generation.generate_newsletter`를 사용한다.
+   - sync/async/fallback 경로는 공통 DB state-transition 함수를 공유한다.
+   - 응답 스키마 `status`, `html_content`, `title`, `generation_stats`, `input_params`, `error`를 유지한다.
+   - runtime code에 새로운 동적 모듈 로딩을 추가하지 않는다.
+5. 설정은 `newsletter/centralized_settings.py`를 단일 진실 공급원으로 두고, `newsletter/config_manager.py`는 얇은 호환 어댑터로 수렴시킨다.
 
-1. 한 PR당 변경량은 300 LOC, 8 files 이내를 목표로 한다.
-2. 계약(Contract) 테스트를 먼저 고정한 뒤 리팩터를 진행한다.
-3. 각 PR은 독립적으로 `make check-full`을 통과해야 한다.
-4. 아키텍처 경계(`scripts/architecture/*`)를 깨면 즉시 롤백한다.
+## 2. 현재 상태 스냅샷
 
-## Temporary Gate Ratchet (Phase 5 only)
+2026-03-08 기준 로컬 검증 결과:
 
-- strict mypy/bandit 대상에서 아래 3개 레거시 대형 파일은 임시 제외한다.
-- 제외 파일: `web/app.py`, `newsletter/cli.py`, `newsletter/chains.py`
-- 목표: 대형 파일 분해 중 fail-fast 블로킹을 줄이고, 분해된 신규 모듈에는 strict gate를 즉시 적용
-- 종료 조건: 3개 파일 분해 완료 후 임시 제외 규칙 제거
+- `make check`: PASS
+- `make check-full`: PASS
+- preflight, docs-check, skills-check, ops-safety-check: PASS
 
-## Suggested Slice Order
+현재 대형 파일 상위권(`wc -l` 기준):
 
-1. `web/app.py`
-- 라우트 등록과 비즈니스 로직을 분리
-- `web/routes/*`, `web/services/*` 단위로 점진 이동
+| 파일 | 라인 수 | 판단 |
+|---|---:|---|
+| `web/static/js/app.js` | 2270 | 가장 크지만 백엔드 계약 안정화 이후 착수하는 편이 안전 |
+| `web/db_state.py` | 1433 | idempotency/outbox/history를 품은 핵심 운영 리스크 |
+| `newsletter_core/application/generation/compose.py` | 1119 | 도메인 조합 로직 집중, 후속 핵심 후보 |
+| `web/routes_generation.py` | 958 | 요청 검증, job orchestration, 스케줄 처리가 섞여 있음 |
+| `web/schedule_runner.py` | 707 | 스케줄 안정성 핵심, `db_state` 분리와 강하게 결합 |
+| `newsletter/config_manager.py` | 375 | "thin compatibility adapter" 목표 대비 책임 과다 |
+| `web/app.py` | 316 | 이전 우선 대상이었지만 지금은 bootstrap 정리 수준 |
+| `newsletter/cli.py` | 258 | 이미 1차 분해가 진행돼 우선순위 하락 |
+| `newsletter/chains.py` | 158 | 이미 많이 축소돼 우선순위 하락 |
 
-2. `newsletter/cli.py`
-- 커맨드 그룹별 모듈 분리 (`run`, `suggest`, `email`, `admin`)
-- 엔트리 포인트는 파라미터 파싱/디스패치만 유지
+추가 관찰:
 
-3. `newsletter/chains.py`
-- provider adapter, prompt builder, retry policy 분리
-- 네트워크 호출 경계와 순수 함수 경계를 명확히 분리
+- `web/routes_generation.py`는 아직 `importlib.util.spec_from_file_location` 기반 동적 로딩을 사용한다.
+- `web/app.py`는 `sys.path` 조작과 fallback import가 반복된다.
+- `docs/dev/TODOs.md`에는 Settings unit test 미완료 항목이 남아 있다.
 
-## Definition of Done per Slice
+## 3. 우선순위 기준과 근거
 
-- 기능 회귀 없음 (관련 unit/integration 통과)
+우선순위는 아래 순서로 결정한다.
+
+1. 운영 장애 가능성
+   - scheduler, idempotency, outbox, config SSOT를 건드리는 파일을 먼저 정리한다.
+2. 제약 위반 또는 구조 경계 누수
+   - 동적 로딩, 과도한 import fallback, import-time side effect 가능성은 조기 제거 대상이다.
+3. 변경 파급도
+   - 여러 경로가 공용으로 의존하는 모듈은 먼저 분해해야 후속 작업이 쉬워진다.
+4. 테스트 가능성
+   - 계약 테스트/ops-safety 테스트로 보호할 수 있는 영역부터 쪼개는 편이 안전하다.
+5. 순수 규모
+   - 단순히 큰 파일이라는 이유만으로 최우선으로 올리지 않는다.
+
+## 4. 현재 우선순위 백로그
+
+### P0. 리팩토링 시작 전에 잠가야 할 기반
+
+#### WU-0. 테스트/계약 잠금
+
+- 목표
+  - 현재 동작을 더 명확하게 고정한 뒤 리팩토링한다.
+- 포함 작업
+  - Settings unit test 보강: happy path, 필수값 누락, 타입 오류, secret masking
+  - `routes_generation` 핵심 응답 shape와 dedupe 동작 확인
+  - 현재 ops-safety 필수 테스트 목록을 문서/PR 템플릿에 명시
+- 우선 근거
+  - 설정과 웹 런타임은 ops-safety-sensitive 경로이며, 테스트 잠금 없이 분해하면 회귀 탐지가 늦어진다.
+- 완료 조건
+  - 관련 테스트가 추가되거나 기존 게이트로 충분히 보호된다는 근거가 문서화된다.
+
+### P1. 웹 런타임 안정화
+
+#### WU-1. `web/routes_generation.py` 분해
+
+- 목표
+  - generation 라우트 파일에서 요청 검증, job orchestration, 스케줄/히스토리 응답 직렬화 책임을 분리한다.
+- 포함 작업
+  - request parsing/validation helper 추출
+  - job submission/idempotency 흐름 service 추출
+  - schedule/history response serializer 추출
+  - 동적 로딩 제거 후 정적 import 경로로 전환
+- 우선 근거
+  - Web runtime 제약 위반이 직접 존재하고, generation API는 사용자 영향이 가장 큰 진입점이다.
+  - idempotency와 response schema를 동시에 다루므로 후속 작업의 기준점 역할을 한다.
+- 제안 slice
+  1. 검증 로직 추출 + 동적 로딩 제거
+  2. generate/send path의 job orchestration 추출
+  3. schedule/history 관련 핸들러 정리
+- 검증
+  - `make check-full`
+  - `pytest tests/test_web_api.py -q`
+  - `pytest tests/contract/test_web_email_routes_contract.py -q`
+- 롤백
+  - route 등록 구조만 되돌리고, 추출한 helper/service는 미사용 상태로 남기지 않고 함께 롤백한다.
+
+#### WU-2. `newsletter/config_manager.py` 축소
+
+- 목표
+  - 설정 접근 경로를 중앙집중식 설정으로 더 수렴시키고, YAML/기본값 병합 책임을 분리한다.
+- 포함 작업
+  - runtime env 접근과 config file 로딩 책임 분리
+  - 레거시 경로 fallback은 유지하되 adapter surface를 최소화
+  - 테스트 reset/test mode 동작 정리
+- 우선 근거
+  - repo policy상 `config_manager.py`는 thin adapter여야 하며, 현재는 캐시/파일 로딩/기본값 병합까지 들고 있다.
+  - 이 영역이 정리되어야 후속 runtime cleanup에서 설정 참조 일관성을 확보할 수 있다.
+- 제안 slice
+  1. 파일 로더/기본값 병합 책임 분리
+  2. adapter public surface 축소
+  3. settings unit test와 compatibility test 보강
+- 검증
+  - `make check-full`
+  - `pytest tests/unit_tests/test_config_import_side_effects.py -q`
+- 롤백
+  - adapter surface를 유지한 채 내부 위임만 복구한다.
+
+#### WU-3. `web/app.py` bootstrap 정리
+
+- 목표
+  - app bootstrap을 route registration 중심으로 단순화하고 `sys.path` 조작을 줄인다.
+- 포함 작업
+  - bootstrap/init 함수 추출
+  - import fallback 최소화
+  - route registration과 runtime setup을 분리
+- 우선 근거
+  - 예전 대형 파일이었지만 현재는 크기보다 경계 정리가 핵심이다.
+  - `routes_generation` 분해가 끝난 뒤에 처리해야 충돌이 적다.
+- 검증
+  - `make check-full`
+  - `pytest tests/test_web_api.py -q`
+
+### P2. 운영 상태 저장소와 스케줄러 분리
+
+#### WU-4. `web/db_state.py` 도메인별 분할
+
+- 목표
+  - 1,400+ 라인 상태 저장소를 schema, history/idempotency, archive/analytics, presets/source policies 단위로 분리한다.
+- 포함 작업
+  - schema/bootstrap 함수 분리
+  - history/job/idempotency 함수 분리
+  - archive/preset/source policy 함수 분리
+  - 기존 import path를 유지할 re-export 또는 shim 제공
+- 우선 근거
+  - idempotency/outbox는 장기 전략 문서가 가장 먼저 잠그라고 한 운영 안전 핵심이다.
+  - `schedule_runner`, `routes_generation`, approval/email route가 공통으로 의존하므로 선행 정리가 필요하다.
+- 제안 slice
+  1. schema + connection helper
+  2. history/idempotency
+  3. archive/analytics
+  4. presets/source policies
+- 검증
+  - `make check-full`
+  - `pytest tests/integration/test_schedule_execution.py -q`
+  - `pytest tests/unit_tests/test_schedule_time_sync.py -q`
+  - `pytest tests/contract/test_web_email_routes_contract.py -q`
+- 롤백
+  - re-export layer를 남겨 import 경로를 즉시 복원할 수 있게 한다.
+
+#### WU-5. `web/schedule_runner.py` 분해
+
+- 목표
+  - RRULE 계산, pending scan, enqueue, reschedule, telemetry를 분리한다.
+- 포함 작업
+  - time window 계산 helper 추출
+  - due schedule scan과 reschedule 분리
+  - enqueue path를 공통 job creation 흐름에 더 명확히 연결
+- 우선 근거
+  - 스케줄러는 운영 사고 빈도가 높은 영역이며 `db_state` 분리 없이는 안전하게 손대기 어렵다.
+- 선행 조건
+  - WU-4 완료
+- 검증
+  - `make check-full`
+  - `pytest tests/integration/test_schedule_execution.py -q`
+  - `pytest tests/unit_tests/test_schedule_time_sync.py -q`
+
+### P3. 도메인 조합 로직 정리
+
+#### WU-6. `newsletter_core/application/generation/compose.py` 분해
+
+- 목표
+  - 입력 정규화, 섹션 조합, HTML payload assembly, 보조 메타데이터 계산을 분리한다.
+- 포함 작업
+  - pure function 경계 확대
+  - 외부 의존성 호출과 템플릿 조립 경계 분리
+  - 테스트 작성이 쉬운 구조로 재배치
+- 우선 근거
+  - 크기가 크고 도메인 규칙이 밀집돼 있지만, web runtime 안정화보다 한 단계 뒤에 해도 된다.
+- 검증
+  - `make check-full`
+  - generation smoke/contract 관련 테스트
+
+### P4. UI/CLI 후속 정리
+
+#### WU-7. `web/static/js/app.js` 모듈화
+
+- 목표
+  - API client, state store, DOM binding, feature modules를 분리한다.
+- 우선 근거
+  - 가장 큰 파일이지만, backend API shape가 먼저 안정돼야 재작업을 줄일 수 있다.
+- 선행 조건
+  - WU-1 완료
+
+#### WU-8. CLI 잔여 정리
+
+- 대상
+  - `newsletter/cli.py`
+  - `newsletter/cli_diagnostics.py`
+  - `newsletter/cli_run.py`
+  - `newsletter/cli_test.py`
+- 우선 근거
+  - 구 문서에서는 최상위 대상이었지만, 현재는 웹 런타임과 설정 정리보다 ROI가 낮다.
+
+## 5. 단계별 실행 순서
+
+### Phase 0. 기준선 잠금
+
+1. WU-0 실행
+2. 현재 게이트/테스트 매트릭스 문서화
+3. 리팩토링 PR 템플릿에 검증 명령과 롤백 항목 고정
+
+### Phase 1. 웹 런타임 1차 안정화
+
+1. WU-1 `routes_generation`
+2. WU-2 `config_manager`
+3. WU-3 `web/app`
+
+### Phase 2. 상태 저장소와 스케줄러
+
+1. WU-4 `db_state`
+2. WU-5 `schedule_runner`
+
+### Phase 3. 도메인 조합 로직
+
+1. WU-6 `compose.py`
+
+### Phase 4. 후속 사용자 경험 정리
+
+1. WU-7 `app.js`
+2. WU-8 CLI
+
+## 6. 업무단위별 산출물 형식
+
+각 업무단위는 아래 산출물을 남긴다.
+
+1. RR 또는 작업 요청 링크
+2. 대상 파일과 제외 파일
+3. 리스크 요약
+4. 롤백 방법
+5. 실행한 검증 명령과 결과
+6. 후속 업무로 넘길 미해결 항목
+
+## 7. 이번 주 바로 시작할 순서
+
+1. WU-0 중 Settings unit test 미완료 항목을 먼저 정리한다.
+2. `web/routes_generation.py`에서 동적 로딩 제거와 validation helper 추출을 첫 PR로 진행한다.
+3. 같은 흐름에서 `job orchestration` 추출을 두 번째 PR로 진행한다.
+4. 이후 `newsletter/config_manager.py`를 thin adapter 방향으로 줄인다.
+5. 그 다음 `web/db_state.py` 분해에 착수한다.
+
+## 8. 지금 하지 않을 것
+
+- `newsletter/chains.py` 재분해
+  - 이미 많이 줄어 우선순위가 낮다.
+- `web/static/js/app.js` 선행 리팩토링
+  - backend API shape가 더 안정된 뒤 진행하는 편이 낫다.
+- 대규모 rename 또는 디렉터리 재배치
+  - 현재 단계에서는 운영 안전성 대비 효익이 낮다.
+
+## 9. Definition of Done
+
+각 slice는 아래를 만족해야 완료로 본다.
+
+- 기능 회귀 없음
+- 필요한 경우 ops-safety 필수 테스트 통과
 - `make check-full` 통과
-- 변경 이유/리스크/롤백 절차를 PR에 기록
+- 변경 이유, 리스크, 롤백 절차 기록
+- 다음 slice를 막는 기술 부채를 새로 만들지 않음

--- a/tests/unit_tests/test_centralized_settings.py
+++ b/tests/unit_tests/test_centralized_settings.py
@@ -3,14 +3,17 @@
 Unit tests for F-14 Centralized Settings Layer
 """
 
+import logging
 import os
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
 from newsletter.centralized_settings import (
     CentralizedSettings,
+    _SecretFilter,
     clear_settings_cache,
     disable_test_mode,
     enable_test_mode,
@@ -38,16 +41,15 @@ class TestCentralizedSettings:
         finally:
             disable_test_mode()
 
-    def test_missing_required_field_raises_validation_error(self):
-        """필수 필드 누락 시 ValidationError 발생"""
-        incomplete_env = {
-            # POSTMARK_SERVER_TOKEN 누락 (여전히 필수)
+    def test_invalid_port_raises_validation_error(self):
+        """유효하지 않은 포트 범위는 ValidationError를 발생시켜야 한다."""
+        env_vars = {
             "EMAIL_SENDER": "test@example.com",
             "OPENAI_API_KEY": "sk-test-openai-key-1234567890123456",
+            "PORT": "70000",
         }
 
-        # 테스트 모드를 사용하지 않고 직접 환경변수 패치
-        with patch.dict(os.environ, incomplete_env, clear=True):
+        with patch.dict(os.environ, env_vars, clear=True):
             with pytest.raises(ValidationError):
                 CentralizedSettings()
 
@@ -158,8 +160,8 @@ class TestF14PerformanceSettings:
             assert settings.llm_test_timeout == 60
             assert settings.llm_max_retries == 3
             assert settings.llm_retry_delay == 1.0
-            assert settings.enable_fast_mode == False
-            assert settings.batch_processing == True
+            assert settings.enable_fast_mode is False
+            assert settings.batch_processing is True
             assert settings.concurrent_requests == 5
         finally:
             disable_test_mode()
@@ -188,7 +190,7 @@ class TestF14PerformanceSettings:
             assert settings.llm_test_timeout == 90
             assert settings.llm_max_retries == 5
             assert settings.llm_retry_delay == 2.0
-            assert settings.enable_fast_mode == True
+            assert settings.enable_fast_mode is True
             assert settings.concurrent_requests == 10
         finally:
             disable_test_mode()
@@ -207,7 +209,7 @@ class TestF14PerformanceSettings:
         enable_test_mode(env_vars)
         try:
             settings = get_settings()
-            assert settings.enable_fast_mode == True
+            assert settings.enable_fast_mode is True
             assert settings.llm_request_timeout == 150
         finally:
             disable_test_mode()
@@ -254,6 +256,56 @@ class TestF14PerformanceSettings:
             assert "has_gemini_key" in summary
 
             # F-14: 성능 설정이 올바르게 로드되는지 확인
-            assert settings.enable_fast_mode == True
+            assert settings.enable_fast_mode is True
+            assert summary["has_gemini_key"] is True
+            assert summary["has_postmark_token"] is True
+            assert env_vars["GEMINI_API_KEY"] not in str(summary)
+            assert env_vars["POSTMARK_SERVER_TOKEN"] not in str(summary)
         finally:
             disable_test_mode()
+
+    def test_secret_filter_masks_values_in_log_messages(self):
+        """로그 필터가 시크릿 원문을 남기지 않아야 한다."""
+        secret = "test-postmark-token-1234567890"
+        fake_settings = SimpleNamespace(
+            serper_api_key=None,
+            postmark_server_token=SecretStr(secret),
+            openai_api_key=None,
+            anthropic_api_key=None,
+            gemini_api_key=None,
+        )
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=0,
+            msg=f"token={secret}",
+            args=(),
+            exc_info=None,
+        )
+
+        with patch(
+            "newsletter.centralized_settings.get_settings",
+            return_value=fake_settings,
+        ):
+            assert _SecretFilter().filter(record) is True
+
+        assert secret not in record.msg
+        assert "POSTMARK_SERVER_TOKEN" in record.msg
+        assert "len:" in record.msg
+
+    def test_get_settings_logs_critical_on_validation_failure(self, caplog):
+        """설정 생성 실패 시 critical 로그를 남기고 예외를 다시 발생시킨다."""
+        clear_settings_cache()
+        with (
+            patch("newsletter.centralized_settings._load_dotenv_if_needed"),
+            patch(
+                "newsletter.centralized_settings.CentralizedSettings",
+                side_effect=ValueError("boom"),
+            ),
+            caplog.at_level(logging.CRITICAL),
+            pytest.raises(ValueError, match="boom"),
+        ):
+            get_settings()
+
+        assert "Settings validation failed: boom" in caplog.text


### PR DESCRIPTION
## Summary (what / why)
- lock settings-side validation behavior before runtime refactors
- add masking and failure-path assertions for `newsletter.centralized_settings`
- sync the refactoring execution document to the current hotspot-based sequence

## Scope
### In Scope
- `tests/unit_tests/test_centralized_settings.py`
- `docs/dev/REFACTORING_EXECUTION_PLAN.md`

### Out of Scope
- runtime implementation changes in `newsletter/centralized_settings.py`
- `newsletter/config_manager.py` refactor
- web runtime route changes

## Delivery Unit
- RR: #210
- Delivery Unit ID: DU-20260308-settings-validation-lock
- Merge Boundary: test/documentation lock for settings validation before RR-02+
- Rollback Boundary: revert this PR to remove only added tests and plan sync

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed):

### Commands and Results
```bash
COVERAGE_FILE=.coverage.rr01.settings2 .venv/bin/python -m pytest tests/unit_tests/test_centralized_settings.py -q
# 15 passed

COVERAGE_FILE=.coverage.rr01.imports .venv/bin/python -m pytest tests/unit_tests/test_config_import_side_effects.py -q
# 8 passed

COVERAGE_FILE=.coverage.rr01.configmgr .venv/bin/python -m pytest tests/unit_tests/test_config_manager.py -q
# 16 passed

COVERAGE_FILE=.coverage.rr01.configfix .venv/bin/python -m pytest tests/test_config_fix.py -q
# 4 passed

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: the refreshed execution plan is broader than the test-only code change and needs future updates as slices complete
- Rollback: revert commit `13766fb` or revert this PR; no data migration or runtime rollback needed

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 변경 없음
- Outbox/send_key 중복 방지 결과: 변경 없음
- import-time side effect 제거 여부: 구현 변경 없음, import-safety tests 유지/보강

## Not Run (with reason)
- GitHub Actions remote CI checks: PR 생성 후 GitHub에서 확인
