### PR TITLE
test(web): lock generation route contracts

### DIFF
--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -19,6 +19,13 @@ from web.db_state import record_analytics_event  # noqa: E402
 
 pytestmark = [pytest.mark.api, pytest.mark.email]
 
+EXPECTED_GENERATE_RESPONSE_KEYS = {
+    "deduplicated",
+    "idempotency_key",
+    "job_id",
+    "status",
+}
+
 
 def _delete_schedule(schedule_id: str) -> None:
     conn = sqlite3.connect(DATABASE_PATH)
@@ -95,6 +102,18 @@ def _insert_history_row(
     conn.close()
 
 
+def _assert_generate_response_contract(
+    payload: dict[str, object], *, expected_statuses: set[str]
+) -> None:
+    assert set(payload) == EXPECTED_GENERATE_RESPONSE_KEYS
+    assert isinstance(payload["job_id"], str)
+    assert payload["job_id"]
+    assert payload["status"] in expected_statuses
+    assert isinstance(payload["deduplicated"], bool)
+    assert isinstance(payload["idempotency_key"], str)
+    assert payload["idempotency_key"]
+
+
 class TestWebAPI:
     """Test web API endpoints"""
 
@@ -120,8 +139,11 @@ class TestWebAPI:
 
         assert response.status_code == 202
         result = json.loads(response.data)
-        assert "job_id" in result
-        assert result["status"] in ["queued", "processing"]
+        _assert_generate_response_contract(
+            result, expected_statuses={"processing", "queued"}
+        )
+        assert result["deduplicated"] is False
+        assert result["idempotency_key"].startswith("generate:")
 
     def test_generate_newsletter_with_email(self, client):
         """Test newsletter generation with email"""
@@ -139,8 +161,11 @@ class TestWebAPI:
 
         assert response.status_code == 202
         result = json.loads(response.data)
-        assert "job_id" in result
-        assert result["status"] in ["queued", "processing"]
+        _assert_generate_response_contract(
+            result, expected_statuses={"processing", "queued"}
+        )
+        assert result["deduplicated"] is False
+        assert result["idempotency_key"].startswith("generate:")
 
     def test_generate_newsletter_idempotency_reuses_job(self, client):
         """Same Idempotency-Key should return same job_id with deduplicated flag."""
@@ -170,10 +195,50 @@ class TestWebAPI:
 
         first_payload = json.loads(first.data)
         second_payload = json.loads(second.data)
+        _assert_generate_response_contract(
+            first_payload, expected_statuses={"processing", "queued"}
+        )
+        _assert_generate_response_contract(
+            second_payload, expected_statuses={"pending", "processing", "queued"}
+        )
         assert first_payload["job_id"] == second_payload["job_id"]
         assert first_payload["deduplicated"] is False
         assert second_payload["deduplicated"] is True
+        assert first_payload["idempotency_key"] == unique_key
         assert second_payload["idempotency_key"] == unique_key
+
+    def test_generate_newsletter_payload_hash_reuses_job_without_header(self, client):
+        """Same payload should deduplicate even without an explicit Idempotency-Key."""
+        unique_topic = f"AI-{uuid.uuid4()}"
+        data = {
+            "keywords": f"{unique_topic}, machine learning",
+            "template_style": "compact",
+            "period": 14,
+        }
+
+        first = client.post(
+            "/api/generate", data=json.dumps(data), content_type="application/json"
+        )
+        second = client.post(
+            "/api/generate", data=json.dumps(data), content_type="application/json"
+        )
+
+        assert first.status_code == 202
+        assert second.status_code == 202
+
+        first_payload = json.loads(first.data)
+        second_payload = json.loads(second.data)
+        _assert_generate_response_contract(
+            first_payload, expected_statuses={"processing", "queued"}
+        )
+        _assert_generate_response_contract(
+            second_payload, expected_statuses={"pending", "processing", "queued"}
+        )
+        assert first_payload["job_id"] == second_payload["job_id"]
+        assert first_payload["deduplicated"] is False
+        assert second_payload["deduplicated"] is True
+        assert first_payload["idempotency_key"] == second_payload["idempotency_key"]
+        assert first_payload["idempotency_key"].startswith("generate:")
 
     def test_generate_newsletter_invalid_email(self, client):
         """Test newsletter generation with invalid email"""

--- a/tests/unit_tests/test_web_preview_and_run_now_routes.py
+++ b/tests/unit_tests/test_web_preview_and_run_now_routes.py
@@ -16,6 +16,13 @@ import routes_generation  # noqa: E402
 
 pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
 
+EXPECTED_GENERATE_RESPONSE_KEYS = {
+    "deduplicated",
+    "idempotency_key",
+    "job_id",
+    "status",
+}
+
 
 def _build_generation_app(database_path: str) -> Flask:
     app = Flask(__name__)
@@ -49,8 +56,11 @@ def test_generate_route_accepts_preview_only_field(tmp_path: Path) -> None:
     assert response.status_code == 202
     payload = response.get_json()
     assert payload is not None
+    assert set(payload) == EXPECTED_GENERATE_RESPONSE_KEYS
+    assert payload["job_id"].startswith("job_")
     assert payload["status"] == "processing"
     assert payload["deduplicated"] is False
+    assert payload["idempotency_key"].startswith("generate:")
 
 
 def test_schedule_run_now_executes_scheduled_job(


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Lock `/api/generate` response fields before `web/routes_generation.py` refactors change route structure.
- Pin canonical payload-hash idempotency reuse so duplicate generation requests keep reusing the same job when no explicit `Idempotency-Key` is sent.
- Keep `preview_only` accepted while preserving the same generation response contract.

## Scope
### In Scope
- `tests/test_web_api.py`
- `tests/unit_tests/test_web_preview_and_run_now_routes.py`

### Out of Scope
- runtime route implementation changes
- scheduler or outbox behavior changes

## Delivery Unit
- RR: #212
- Delivery Unit ID: DU-20260308-web-generation-contract-lock
- Merge Boundary: test-only contract lock for generation route responses and deduplication
- Rollback Boundary: revert commit `90c3f17`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): focused generation contract tests

### Commands and Results
```bash
COVERAGE_FILE=.coverage.rr02.webapi .venv/bin/python -m pytest tests/test_web_api.py -q
# 21 passed, 1 skipped

COVERAGE_FILE=.coverage.rr02.contract .venv/bin/python -m pytest tests/contract/test_web_email_routes_contract.py -q
# 7 passed

COVERAGE_FILE=.coverage.rr02.preview .venv/bin/python -m pytest tests/unit_tests/test_web_preview_and_run_now_routes.py -q
# 2 passed

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: low; test-only change that tightens existing generation-route contracts.
- Rollback: revert commit `90c3f17`.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: explicit `Idempotency-Key` reuse and canonical payload-hash reuse are both asserted through `/api/generate` tests.
- Outbox/send_key 중복 방지 결과: no runtime change in this PR; existing send-email contract coverage remains unchanged.
- import-time side effect 제거 여부: none introduced.

## Not Run (with reason)
- No additional live email-provider tests were run; existing email-service dependent case in `tests/test_web_api.py` stays skipped in local/mock verification.
