### PR TITLE
codex(web): remove generation route dynamic loading

### DIFF
--- a/tests/unit_tests/test_web_preview_and_run_now_routes.py
+++ b/tests/unit_tests/test_web_preview_and_run_now_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import sys
 from pathlib import Path
@@ -61,6 +62,37 @@ def test_generate_route_accepts_preview_only_field(tmp_path: Path) -> None:
     assert payload["status"] == "processing"
     assert payload["deduplicated"] is False
     assert payload["idempotency_key"].startswith("generate:")
+
+
+def test_generate_route_avoids_dynamic_module_loading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _build_generation_app(str(tmp_path / "storage.db"))
+
+    def fail_spec_from_file_location(*args: object, **kwargs: object) -> None:
+        raise AssertionError("dynamic module loading should not be used")
+
+    monkeypatch.setattr(
+        importlib.util, "spec_from_file_location", fail_spec_from_file_location
+    )
+
+    with app.test_client() as client:
+        response = client.post(
+            "/api/generate",
+            data=json.dumps(
+                {
+                    "keywords": ["AI", "robotics"],
+                    "template_style": "compact",
+                    "period": 14,
+                }
+            ),
+            content_type="application/json",
+        )
+
+    assert response.status_code == 202
+    payload = response.get_json()
+    assert payload is not None
+    assert payload["deduplicated"] is False
 
 
 def test_schedule_run_now_executes_scheduled_job(

--- a/web/routes_generation.py
+++ b/web/routes_generation.py
@@ -60,8 +60,14 @@ try:
 except ImportError:
     from web.analytics import record_schedule_event  # pragma: no cover
 
+from web.types import GenerateNewsletterRequest
 
 logger = logging.getLogger("web.routes_generation")
+
+
+def _validate_generate_request(data: dict[str, Any]) -> GenerateNewsletterRequest:
+    """Validate generation request payload without runtime dynamic loading."""
+    return GenerateNewsletterRequest(**data)
 
 
 def register_generation_routes(
@@ -128,22 +134,9 @@ def register_generation_routes(
                 log_info(logger, "generate.request.empty")
                 return jsonify({"error": "No data provided"}), 400
 
-            # Validate request using Pydantic
             try:
-                # Import here to avoid conflicts with Python's built-in types module
-                import importlib.util
-                import os
-
-                current_dir = os.path.dirname(os.path.abspath(__file__))
-
-                spec = importlib.util.spec_from_file_location(
-                    "web.types", os.path.join(current_dir, "types.py")
-                )
-                web_types_module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(web_types_module)
-
-                validated_data = web_types_module.GenerateNewsletterRequest(**data)
-            except (ValueError, Exception) as e:
+                validated_data = _validate_generate_request(data)
+            except Exception as e:
                 log_exception(logger, "generate.request.invalid", e)
                 return jsonify({"error": f"Invalid request: {str(e)}"}), 400
 


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Replace `spec_from_file_location(... types.py)` in `web/routes_generation.py` with a normal `web.types.GenerateNewsletterRequest` import.
- Extract a small request validation helper so `/api/generate` validation stays readable before the larger route split.
- Add a regression test that fails if request handling reintroduces dynamic module loading.

## Scope
### In Scope
- `web/routes_generation.py`
- `tests/unit_tests/test_web_preview_and_run_now_routes.py`

### Out of Scope
- job orchestration refactor
- schedule/history handler extraction
- `web/app.py` bootstrap cleanup

## Delivery Unit
- RR: #214
- Delivery Unit ID: DU-20260308-web-generation-validation-imports
- Merge Boundary: generation request validation path only
- Rollback Boundary: revert commit `f5ac40a`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): focused route validation/runtime contract tests

### Commands and Results
```bash
COVERAGE_FILE=.coverage.rr03.preview .venv/bin/python -m pytest tests/unit_tests/test_web_preview_and_run_now_routes.py -q
# 3 passed

COVERAGE_FILE=.coverage.rr03.webapi .venv/bin/python -m pytest tests/test_web_api.py -q
# 21 passed, 1 skipped

COVERAGE_FILE=.coverage.rr03.runtime .venv/bin/python -m pytest tests/contract/test_web_runtime_contract.py -q
# 2 passed

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: low to medium; import-path regressions could break `/api/generate` validation if `web.types` is not available in a runtime path.
- Rollback: revert commit `f5ac40a`.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: unchanged; existing `/api/generate` idempotency contract remains covered by `tests/test_web_api.py`.
- Outbox/send_key 중복 방지 결과: unchanged in this PR.
- import-time side effect 제거 여부: no new import-time side effects added; dynamic request-time module loading was removed from `web/routes_generation.py`.

## Not Run (with reason)
- No live provider or non-mock runtime tests were run; local verification stayed in `MOCK_MODE` per repo policy.
