### PR TITLE
codex(config): extract config file loader

### DIFF
--- a/newsletter/config_manager.py
+++ b/newsletter/config_manager.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Dict
 
@@ -9,6 +10,69 @@ DEFAULT_CONFIG_PATHS = ("config/config.yml", "config.yml")
 
 def _read_secret(value: SecretStr | None) -> str | None:
     return value.get_secret_value() if value is not None else None
+
+
+class ConfigFileLoader:
+    """YAML config file loading and cache alias management."""
+
+    def __init__(
+        self,
+        cache: Dict[str, Dict[str, Any]],
+        log_warning: Callable[[str], None],
+    ) -> None:
+        self._cache = cache
+        self._log_warning = log_warning
+
+    def load(self, config_file: str = "config.yml") -> Dict[str, Any]:
+        cached = self._cache.get(config_file)
+        if cached is not None:
+            return cached
+
+        config_candidates = self.resolve_candidates(config_file)
+        resolved_config_path = next(
+            (candidate for candidate in config_candidates if candidate.exists()),
+            None,
+        )
+        if resolved_config_path is None:
+            search_paths = ", ".join(str(candidate) for candidate in config_candidates)
+            self._log_warning(
+                f"설정 파일을 찾을 수 없습니다: {config_file} (searched: {search_paths})"
+            )
+            return {}
+
+        resolved_key = str(resolved_config_path)
+        resolved_cached = self._cache.get(resolved_key)
+        if resolved_cached is not None:
+            self._cache[config_file] = resolved_cached
+            return resolved_cached
+
+        try:
+            config_data = self._read_yaml_file(resolved_config_path)
+        except Exception as e:
+            self._log_warning(f"설정 파일 로딩 실패 {resolved_config_path}: {e}")
+            return {}
+
+        self._cache[resolved_key] = config_data
+        self._cache[config_file] = config_data
+        return config_data
+
+    @staticmethod
+    def resolve_candidates(config_file: str) -> list[Path]:
+        """기본 경로/레거시 경로를 포함해 탐색 후보를 반환합니다."""
+        config_path = Path(config_file)
+        if config_path.is_absolute():
+            return [config_path]
+
+        normalized = config_file.replace("\\", "/").lstrip("./")
+        if normalized in {"config.yml", "config/config.yml"}:
+            return [Path(path) for path in DEFAULT_CONFIG_PATHS]
+
+        return [config_path]
+
+    @staticmethod
+    def _read_yaml_file(config_path: Path) -> Dict[str, Any]:
+        with open(config_path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
 
 
 class ConfigManager:
@@ -25,6 +89,9 @@ class ConfigManager:
     def __init__(self) -> None:
         if not hasattr(self, "_initialized"):
             self._initialized = True
+            self._config_loader = ConfigFileLoader(
+                self._config_cache, self._log_warning
+            )
             self._load_environment_variables()
 
     @classmethod
@@ -66,52 +133,11 @@ class ConfigManager:
 
     def load_config_file(self, config_file: str = "config.yml") -> Dict[str, Any]:
         """YAML 설정 파일 로딩 (캐시 지원)"""
-        if config_file in self._config_cache:
-            return self._config_cache[config_file]
-
-        config_candidates = self._resolve_config_candidates(config_file)
-        resolved_config_path = next(
-            (candidate for candidate in config_candidates if candidate.exists()),
-            None,
-        )
-
-        if resolved_config_path is None:
-            search_paths = ", ".join(str(candidate) for candidate in config_candidates)
-            self._log_warning(
-                f"설정 파일을 찾을 수 없습니다: {config_file} (searched: {search_paths})"
-            )
-            return {}
-
-        resolved_key = str(resolved_config_path)
-        if resolved_key in self._config_cache:
-            cached = self._config_cache[resolved_key]
-            self._config_cache[config_file] = cached
-            return cached
-
-        try:
-            with open(resolved_config_path, "r", encoding="utf-8") as f:
-                config_data = yaml.safe_load(f) or {}
-
-            self._config_cache[resolved_key] = config_data
-            self._config_cache[config_file] = config_data
-            return config_data
-
-        except Exception as e:
-            self._log_warning(f"설정 파일 로딩 실패 {resolved_config_path}: {e}")
-            return {}
+        return self._config_loader.load(config_file)
 
     @staticmethod
     def _resolve_config_candidates(config_file: str) -> list[Path]:
-        """기본 경로/레거시 경로를 포함해 탐색 후보를 반환합니다."""
-        config_path = Path(config_file)
-        if config_path.is_absolute():
-            return [config_path]
-
-        normalized = config_file.replace("\\", "/").lstrip("./")
-        if normalized in {"config.yml", "config/config.yml"}:
-            return [Path(path) for path in DEFAULT_CONFIG_PATHS]
-
-        return [config_path]
+        return ConfigFileLoader.resolve_candidates(config_file)
 
     def get_llm_config(self) -> Dict[str, Any]:
         """LLM 설정 반환"""

--- a/tests/unit_tests/test_config_manager.py
+++ b/tests/unit_tests/test_config_manager.py
@@ -1,6 +1,4 @@
-import os
 import sys
-import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import mock_open, patch
@@ -10,7 +8,7 @@ project_root = Path(__file__).parent.parent.parent
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
-from newsletter.config_manager import ConfigManager
+from newsletter.config_manager import ConfigManager  # noqa: E402
 
 
 class TestConfigManager(unittest.TestCase):
@@ -218,13 +216,26 @@ llm_settings:
             patch("pathlib.Path.exists", return_value=True),
             patch("builtins.open", mock_open(read_data="test: value")) as mock_file,
         ):
-
             # 첫 번째 호출
             config1 = manager.load_config_file("test.yml")
             # 두 번째 호출
             config2 = manager.load_config_file("test.yml")
 
             # 캐시에서 가져왔으므로 파일은 한 번만 열려야 함
+            mock_file.assert_called_once()
+            self.assertEqual(config1, config2)
+
+    def test_default_config_aliases_share_resolved_cache(self):
+        """기본 설정 경로 alias가 동일한 캐시 엔트리를 재사용해야 한다."""
+        manager = ConfigManager()
+
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("builtins.open", mock_open(read_data="test: value")) as mock_file,
+        ):
+            config1 = manager.load_config_file("config.yml")
+            config2 = manager.load_config_file("config/config.yml")
+
             mock_file.assert_called_once()
             self.assertEqual(config1, config2)
 


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Extract YAML config file loading and cache alias handling from `newsletter/config_manager.py` into a focused `ConfigFileLoader` helper.
- Keep `ConfigManager`'s public API and lazy initialization stable so RR-07 can slim the adapter without changing caller behavior.

## Scope
### In Scope
- Extract config candidate resolution, resolved-path cache reuse, and YAML read logic into `ConfigFileLoader`
- Keep `ConfigManager.load_config_file()` as a thin delegating wrapper
- Add regression coverage for default config path aliases sharing the same cached result

### Out of Scope
- Removing legacy `ConfigManager` accessors
- Changing centralized settings behavior
- Any web runtime or scheduler changes

## Delivery Unit
- RR: #220
- Delivery Unit ID: DU-20260308-config-loader-extraction
- Merge Boundary: `newsletter/config_manager.py` loader extraction plus config manager regression test updates
- Rollback Boundary: revert commit `8586f3d` to restore inline config loading in `ConfigManager`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): focused config manager and import-side-effect tests

### Commands and Results
```bash
COVERAGE_FILE=.coverage.rr06.config ./.venv/bin/python -m pytest tests/unit_tests/test_config_manager.py -q
# 17 passed

COVERAGE_FILE=.coverage.rr06.sideeffects ./.venv/bin/python -m pytest tests/unit_tests/test_config_import_side_effects.py -q
# 8 passed

COVERAGE_FILE=.coverage.rr06.fix ./.venv/bin/python -m pytest tests/test_config_fix.py -q
# 4 passed

COVERAGE_FILE=.coverage.rr06.env ./.venv/bin/python -m pytest tests/integration/test_environment_profiles.py -q
# 11 skipped (integration-gated)

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: cache alias handling now lives in the extracted loader, so a loader regression could make legacy/default config paths stop sharing cached reads.
- Rollback: revert commit `8586f3d` to move file loading back into `ConfigManager`.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: not applicable; config-layer only.
- Outbox/send_key 중복 방지 결과: not applicable; no delivery path changes.
- import-time side effect 제거 여부: preserved; `ConfigManager` remains lazily instantiated and import-only tests continue to pass.

## Not Run (with reason)
- Real integration-mode environment profile execution was not run because `tests/integration/test_environment_profiles.py` is gated off by default in this environment and reported skips.
