### PR TITLE
codex(config): slim config manager adapter

### DIFF
--- a/newsletter/config_manager.py
+++ b/newsletter/config_manager.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict
 
@@ -6,10 +7,222 @@ import yaml  # type: ignore[import-untyped]
 from pydantic import SecretStr
 
 DEFAULT_CONFIG_PATHS = ("config/config.yml", "config.yml")
+_DEFAULT_NEWSLETTER_SETTINGS = {
+    "newsletter_title": "주간 산업 동향 뉴스 클리핑",
+    "tagline": "이번 주, 주요 산업 동향을 미리 만나보세요.",
+    "publisher_name": "Your Company",
+    "company_name": "Your Company",
+    "company_tagline": "",
+    "editor_name": "",
+    "editor_title": "편집자",
+    "editor_email": "",
+    "footer_disclaimer": "이 뉴스레터는 정보 제공을 목적으로 하며, 내용의 정확성을 보장하지 않습니다.",
+    "footer_contact": "",
+}
+_DEFAULT_SCORING_WEIGHTS = {
+    "relevance": 0.35,
+    "impact": 0.25,
+    "novelty": 0.15,
+    "source_tier": 0.15,
+    "recency": 0.10,
+}
+_MAJOR_NEWS_SOURCES = {
+    "tier1": [
+        "조선일보",
+        "중앙일보",
+        "동아일보",
+        "한국일보",
+        "한겨레",
+        "경향신문",
+        "매일경제",
+        "한국경제",
+        "서울경제",
+        "파이낸셜뉴스",
+        "연합뉴스",
+        "YTN",
+        "KBS",
+        "MBC",
+        "SBS",
+        "JTBC",
+        "Bloomberg",
+        "Reuters",
+        "Wall Street Journal",
+        "Financial Times",
+        "The Economist",
+    ],
+    "tier2": [
+        "뉴시스",
+        "뉴스1",
+        "아시아경제",
+        "아주경제",
+        "이데일리",
+        "머니투데이",
+        "비즈니스워치",
+        "디지털타임스",
+        "전자신문",
+        "IT조선",
+        "ZDNet Korea",
+        "디지털데일리",
+        "테크M",
+        "블로터",
+        "채널A",
+        "MBN",
+        "TV조선",
+        "TechCrunch",
+        "Wired",
+    ],
+}
 
 
 def _read_secret(value: SecretStr | None) -> str | None:
     return value.get_secret_value() if value is not None else None
+
+
+def _build_default_llm_config() -> Dict[str, Any]:
+    return {
+        "default_provider": "gemini",
+        "api_keys": {
+            "gemini": "GEMINI_API_KEY",
+            "openai": "OPENAI_API_KEY",
+            "anthropic": "ANTHROPIC_API_KEY",
+        },
+        "models": {
+            "keyword_generation": {
+                "provider": "gemini",
+                "model": "gemini-2.5-pro-preview-03-25",
+                "temperature": 0.7,
+                "max_retries": 2,
+                "timeout": 60,
+            },
+            "theme_extraction": {
+                "provider": "gemini",
+                "model": "gemini-1.5-flash-latest",
+                "temperature": 0.2,
+                "max_retries": 2,
+                "timeout": 60,
+            },
+            "news_summarization": {
+                "provider": "gemini",
+                "model": "gemini-2.5-pro-preview-03-25",
+                "temperature": 0.3,
+                "max_retries": 3,
+                "timeout": 120,
+            },
+            "section_regeneration": {
+                "provider": "gemini",
+                "model": "gemini-1.5-pro",
+                "temperature": 0.3,
+                "max_retries": 2,
+                "timeout": 120,
+            },
+            "introduction_generation": {
+                "provider": "gemini",
+                "model": "gemini-1.5-pro",
+                "temperature": 0.4,
+                "max_retries": 2,
+                "timeout": 60,
+            },
+            "html_generation": {
+                "provider": "gemini",
+                "model": "gemini-2.5-pro-preview-03-25",
+                "temperature": 0.2,
+                "max_retries": 3,
+                "timeout": 180,
+            },
+        },
+        "provider_models": {
+            "gemini": {
+                "fast": "gemini-1.5-flash-latest",
+                "standard": "gemini-1.5-pro",
+                "advanced": "gemini-2.5-pro-preview-03-25",
+            },
+            "openai": {
+                "fast": "gpt-4o-mini",
+                "standard": "gpt-4o",
+                "advanced": "gpt-4o",
+            },
+            "anthropic": {
+                "fast": "claude-3-haiku-20240307",
+                "standard": "claude-3-sonnet-20240229",
+                "advanced": "claude-3-5-sonnet-20241022",
+            },
+        },
+    }
+
+
+def _resolve_llm_config(config_data: Dict[str, Any]) -> Dict[str, Any]:
+    llm_settings = config_data.get("llm_settings", {})
+    if not isinstance(llm_settings, dict) or not llm_settings:
+        return _build_default_llm_config()
+    return llm_settings
+
+
+def _resolve_newsletter_settings(config_data: Dict[str, Any]) -> Dict[str, Any]:
+    newsletter_settings = config_data.get("newsletter_settings", {})
+    merged_settings = deepcopy(_DEFAULT_NEWSLETTER_SETTINGS)
+    if isinstance(newsletter_settings, dict):
+        merged_settings.update(newsletter_settings)
+    return merged_settings
+
+
+def _resolve_scoring_weights(
+    config_data: Dict[str, Any],
+    log_warning: Callable[[str], None],
+) -> Dict[str, float]:
+    scoring_config = config_data.get("scoring", {})
+    default_weights = dict(_DEFAULT_SCORING_WEIGHTS)
+
+    if not scoring_config:
+        return default_weights
+
+    required_keys = set(default_weights.keys())
+    config_keys = set(scoring_config.keys())
+
+    if not required_keys.issubset(config_keys):
+        missing_keys = required_keys - config_keys
+        log_warning(f"스코어링 가중치 키가 누락되었습니다: {missing_keys}. 기본값을 사용합니다.")
+        return default_weights
+
+    try:
+        weights = {k: float(scoring_config[k]) for k in required_keys}
+        total = sum(weights.values())
+        if abs(total - 1.0) < 0.01:
+            return weights
+        log_warning(f"스코어링 가중치의 합이 {total:.3f}이며 1.0이 아닙니다. 기본값을 사용합니다.")
+        return default_weights
+    except (ValueError, TypeError) as e:
+        log_warning(f"스코어링 가중치 값이 올바르지 않습니다: {e}. 기본값을 사용합니다.")
+        return default_weights
+
+
+def _clone_major_news_sources() -> Dict[str, list[str]]:
+    return {tier: list(sources) for tier, sources in _MAJOR_NEWS_SOURCES.items()}
+
+
+def _validate_email_settings(
+    postmark_server_token: str | None,
+    email_sender: str | None,
+) -> Dict[str, bool]:
+    token_valid = bool(
+        postmark_server_token
+        and postmark_server_token
+        not in [
+            "your_postmark_server_token_here",
+            "your-postmark-server-token-here",
+        ]
+    )
+
+    email_valid = bool(
+        email_sender
+        and email_sender
+        not in ["noreply@yourdomain.com", "your_verified_email@yourdomain.com"]
+    )
+
+    return {
+        "postmark_token_configured": token_valid,
+        "from_email_configured": email_valid,
+        "ready": token_valid and email_valid,
+    }
 
 
 class ConfigFileLoader:
@@ -141,228 +354,30 @@ class ConfigManager:
 
     def get_llm_config(self) -> Dict[str, Any]:
         """LLM 설정 반환"""
-        config_data = self.load_config_file()
-        llm_settings = config_data.get("llm_settings", {})
-
-        if not isinstance(llm_settings, dict) or not llm_settings:
-            return self._get_default_llm_config()
-
-        return llm_settings
+        return _resolve_llm_config(self.load_config_file())
 
     def get_newsletter_settings(self) -> Dict[str, Any]:
         """뉴스레터 설정 반환"""
-        config_data = self.load_config_file()
-        newsletter_settings = config_data.get("newsletter_settings", {})
-
-        # 기본값과 병합
-        default_settings = {
-            "newsletter_title": "주간 산업 동향 뉴스 클리핑",
-            "tagline": "이번 주, 주요 산업 동향을 미리 만나보세요.",
-            "publisher_name": "Your Company",
-            "company_name": "Your Company",
-            "company_tagline": "",
-            "editor_name": "",
-            "editor_title": "편집자",
-            "editor_email": "",
-            "footer_disclaimer": "이 뉴스레터는 정보 제공을 목적으로 하며, 내용의 정확성을 보장하지 않습니다.",
-            "footer_contact": "",
-        }
-
-        default_settings.update(newsletter_settings)
-        return default_settings
+        return _resolve_newsletter_settings(self.load_config_file())
 
     def get_scoring_weights(self) -> Dict[str, float]:
         """스코어링 가중치 반환"""
-        config_data = self.load_config_file()
-        scoring_config = config_data.get("scoring", {})
-
-        # 새로운 가중치 구조 사용 (config.yml과 일치)
-        default_weights = {
-            "relevance": 0.35,
-            "impact": 0.25,
-            "novelty": 0.15,
-            "source_tier": 0.15,
-            "recency": 0.10,
-        }
-
-        if not scoring_config:
-            return default_weights
-
-        # 필수 키 검증
-        required_keys = set(default_weights.keys())
-        config_keys = set(scoring_config.keys())
-
-        if not required_keys.issubset(config_keys):
-            missing_keys = required_keys - config_keys
-            self._log_warning(f"스코어링 가중치 키가 누락되었습니다: {missing_keys}. 기본값을 사용합니다.")
-            return default_weights
-
-        try:
-            weights = {k: float(scoring_config[k]) for k in required_keys}
-            total = sum(weights.values())
-
-            if abs(total - 1.0) < 0.01:  # 허용 오차
-                return weights
-            else:
-                self._log_warning(f"스코어링 가중치의 합이 {total:.3f}이며 1.0이 아닙니다. 기본값을 사용합니다.")
-                return default_weights
-
-        except (ValueError, TypeError) as e:
-            self._log_warning(f"스코어링 가중치 값이 올바르지 않습니다: {e}. 기본값을 사용합니다.")
-            return default_weights
+        return _resolve_scoring_weights(self.load_config_file(), self._log_warning)
 
     def _get_default_llm_config(self) -> Dict[str, Any]:
         """기본 LLM 설정 반환"""
-        return {
-            "default_provider": "gemini",
-            "api_keys": {
-                "gemini": "GEMINI_API_KEY",
-                "openai": "OPENAI_API_KEY",
-                "anthropic": "ANTHROPIC_API_KEY",
-            },
-            "models": {
-                "keyword_generation": {
-                    "provider": "gemini",
-                    "model": "gemini-2.5-pro-preview-03-25",
-                    "temperature": 0.7,
-                    "max_retries": 2,
-                    "timeout": 60,
-                },
-                "theme_extraction": {
-                    "provider": "gemini",
-                    "model": "gemini-1.5-flash-latest",
-                    "temperature": 0.2,
-                    "max_retries": 2,
-                    "timeout": 60,
-                },
-                "news_summarization": {
-                    "provider": "gemini",
-                    "model": "gemini-2.5-pro-preview-03-25",
-                    "temperature": 0.3,
-                    "max_retries": 3,
-                    "timeout": 120,
-                },
-                "section_regeneration": {
-                    "provider": "gemini",
-                    "model": "gemini-1.5-pro",
-                    "temperature": 0.3,
-                    "max_retries": 2,
-                    "timeout": 120,
-                },
-                "introduction_generation": {
-                    "provider": "gemini",
-                    "model": "gemini-1.5-pro",
-                    "temperature": 0.4,
-                    "max_retries": 2,
-                    "timeout": 60,
-                },
-                "html_generation": {
-                    "provider": "gemini",
-                    "model": "gemini-2.5-pro-preview-03-25",
-                    "temperature": 0.2,
-                    "max_retries": 3,
-                    "timeout": 180,
-                },
-            },
-            "provider_models": {
-                "gemini": {
-                    "fast": "gemini-1.5-flash-latest",
-                    "standard": "gemini-1.5-pro",
-                    "advanced": "gemini-2.5-pro-preview-03-25",
-                },
-                "openai": {
-                    "fast": "gpt-4o-mini",
-                    "standard": "gpt-4o",
-                    "advanced": "gpt-4o",
-                },
-                "anthropic": {
-                    "fast": "claude-3-haiku-20240307",
-                    "standard": "claude-3-sonnet-20240229",
-                    "advanced": "claude-3-5-sonnet-20241022",
-                },
-            },
-        }
+        return _build_default_llm_config()
 
     def get_major_news_sources(self) -> Dict[str, list]:
         """주요 언론사 목록 반환"""
-        return {
-            "tier1": [
-                # 국내 주요 일간지
-                "조선일보",
-                "중앙일보",
-                "동아일보",
-                "한국일보",
-                "한겨레",
-                "경향신문",
-                # 국내 주요 경제지
-                "매일경제",
-                "한국경제",
-                "서울경제",
-                "파이낸셜뉴스",
-                # 국내 주요 방송/통신사
-                "연합뉴스",
-                "YTN",
-                "KBS",
-                "MBC",
-                "SBS",
-                "JTBC",
-                # 해외 주요 언론사
-                "Bloomberg",
-                "Reuters",
-                "Wall Street Journal",
-                "Financial Times",
-                "The Economist",
-            ],
-            "tier2": [
-                # 국내 주요 통신사
-                "뉴시스",
-                "뉴스1",
-                # 국내 경제/산업 전문지
-                "아시아경제",
-                "아주경제",
-                "이데일리",
-                "머니투데이",
-                "비즈니스워치",
-                # 국내 IT/기술 전문지
-                "디지털타임스",
-                "전자신문",
-                "IT조선",
-                "ZDNet Korea",
-                "디지털데일리",
-                "테크M",
-                "블로터",
-                # 국내 기타 방송사
-                "채널A",
-                "MBN",
-                "TV조선",
-                # 해외 기술 전문지
-                "TechCrunch",
-                "Wired",
-            ],
-        }
+        return _clone_major_news_sources()
 
     def validate_email_config(self) -> Dict[str, bool]:
         """이메일 설정 검증"""
-        token_valid = bool(
-            self.POSTMARK_SERVER_TOKEN
-            and self.POSTMARK_SERVER_TOKEN
-            not in [
-                "your_postmark_server_token_here",
-                "your-postmark-server-token-here",
-            ]
+        return _validate_email_settings(
+            self.POSTMARK_SERVER_TOKEN,
+            self.EMAIL_SENDER,
         )
-
-        email_valid = bool(
-            self.EMAIL_SENDER
-            and self.EMAIL_SENDER
-            not in ["noreply@yourdomain.com", "your_verified_email@yourdomain.com"]
-        )
-
-        return {
-            "postmark_token_configured": token_valid,
-            "from_email_configured": email_valid,
-            "ready": token_valid and email_valid,
-        }
 
     def _log_warning(self, message: str) -> None:
         """경고 메시지 출력"""
@@ -385,6 +400,31 @@ def get_config_manager() -> ConfigManager:
     if _config_manager_instance is None:
         _config_manager_instance = ConfigManager()
     return _config_manager_instance
+
+
+def get_llm_config() -> Dict[str, Any]:
+    return _resolve_llm_config(get_config_manager().load_config_file())
+
+
+def get_newsletter_settings() -> Dict[str, Any]:
+    return _resolve_newsletter_settings(get_config_manager().load_config_file())
+
+
+def get_scoring_weights() -> Dict[str, float]:
+    manager = get_config_manager()
+    return _resolve_scoring_weights(manager.load_config_file(), manager._log_warning)
+
+
+def get_major_news_sources() -> Dict[str, list[str]]:
+    return _clone_major_news_sources()
+
+
+def validate_email_config() -> Dict[str, bool]:
+    manager = get_config_manager()
+    return _validate_email_settings(
+        manager.POSTMARK_SERVER_TOKEN,
+        manager.EMAIL_SENDER,
+    )
 
 
 # 하위 호환성을 위한 별칭

--- a/newsletter_core/public/settings.py
+++ b/newsletter_core/public/settings.py
@@ -10,6 +10,13 @@ from newsletter.centralized_settings import (
     get_settings,
     is_running_in_pytest,
 )
+from newsletter.config_manager import get_config_manager as _get_config_manager
+from newsletter.config_manager import get_llm_config as _get_llm_config
+from newsletter.config_manager import get_major_news_sources as _get_major_news_sources
+from newsletter.config_manager import (
+    get_newsletter_settings as _get_newsletter_settings,
+)
+from newsletter.config_manager import validate_email_config as _validate_email_config
 
 _SETTING_ALIASES = {
     "POSTMARK_FROM_EMAIL": "email_sender",
@@ -55,11 +62,11 @@ def get_setting_value(name: str, default: Any = None) -> Any:
 
 
 def get_llm_config() -> dict[str, Any]:
-    return get_config_manager().get_llm_config()
+    return _get_llm_config()
 
 
 def get_major_news_sources() -> dict[str, Any]:
-    return get_config_manager().get_major_news_sources()
+    return _get_major_news_sources()
 
 
 def get_all_major_news_sources() -> list[str]:
@@ -68,7 +75,7 @@ def get_all_major_news_sources() -> list[str]:
 
 
 def get_newsletter_settings() -> dict[str, Any]:
-    return get_config_manager().get_newsletter_settings()
+    return _get_newsletter_settings()
 
 
 def get_email_config() -> tuple[str | None, str | None]:
@@ -79,12 +86,10 @@ def get_email_config() -> tuple[str | None, str | None]:
 
 
 def validate_email_config() -> dict[str, bool]:
-    return get_config_manager().validate_email_config()
+    return _validate_email_config()
 
 
 def get_config_manager() -> Any:
-    from newsletter.config_manager import get_config_manager as _get_config_manager
-
     return _get_config_manager()
 
 


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Slim `newsletter/config_manager.py` into a thinner compatibility adapter by moving config-derived defaults and validation logic into shared module helpers.
- Point `newsletter_core/public/settings.py` at the same helper functions so compatibility accessors and runtime adapters use the same config resolution path.

## Scope
### In Scope
- Extract shared helpers for LLM config defaults, newsletter settings merging, scoring validation, major news sources, and email config validation
- Reduce `ConfigManager` methods to thin wrappers over the shared helpers
- Update `newsletter_core/public/settings.py` to use the shared config helpers directly

### Out of Scope
- File loader changes beyond RR-06
- Web bootstrap changes
- Storage or scheduler refactors

## Delivery Unit
- RR: #221
- Delivery Unit ID: DU-20260308-config-compat-adapter
- Merge Boundary: `newsletter/config_manager.py` helper extraction plus `newsletter_core/public/settings.py` delegation cleanup
- Rollback Boundary: revert the RR-07 commit to restore the previous class-owned config logic and public-settings indirection

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): focused config manager and import-side-effect tests

### Commands and Results
```bash
COVERAGE_FILE=.coverage.rr07.config ./.venv/bin/python -m pytest tests/unit_tests/test_config_manager.py -q
# 17 passed

COVERAGE_FILE=.coverage.rr07.sideeffects ./.venv/bin/python -m pytest tests/unit_tests/test_config_import_side_effects.py -q
# 8 passed

COVERAGE_FILE=.coverage.rr07.fix ./.venv/bin/python -m pytest tests/test_config_fix.py -q
# 4 passed

COVERAGE_FILE=.coverage.rr07.env ./.venv/bin/python -m pytest tests/integration/test_environment_profiles.py -q
# 11 skipped (integration-gated)

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: shared helper wiring could accidentally diverge compatibility accessors from the lazy `ConfigManager` instance if a helper starts reading state too early.
- Rollback: revert the RR-07 commit to return config-derived logic to `ConfigManager` and restore `public.settings` method-based delegation.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: not applicable; config-layer only.
- Outbox/send_key 중복 방지 결과: not applicable; no send or job paths changed.
- import-time side effect 제거 여부: preserved; import-only tests continue to pass and no eager `ConfigManager` initialization was introduced.

## Not Run (with reason)
- Real integration-mode environment profile execution was not run because `tests/integration/test_environment_profiles.py` is gated off by default in this environment and reported skips.
