### PR TITLE
codex(web): normalize app bootstrap

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -4,310 +4,189 @@ Newsletter Generator Web Service
 Flask application that provides web interface for the CLI newsletter generator
 """
 
-import json
+from __future__ import annotations
+
 import logging
 import os
-import sqlite3
+import platform
 import sys
-import uuid
-from datetime import datetime
+from pathlib import Path
 from typing import Any, cast
 
 import redis
-from flask import Flask, jsonify, render_template, request, send_file
+from flask import Flask, render_template
 
-# Add current directory to path for local imports
-current_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, current_dir)
+WEB_DIR = Path(__file__).resolve().parent
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
 
-try:
-    from cors_config import configure_cors
-except ImportError:
-    from web.cors_config import configure_cors  # pragma: no cover
+if __package__ in {None, ""}:
+    REPO_ROOT = Path(__file__).resolve().parents[1]
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
 
-try:
-    from access_control import configure_access_control
-except ImportError:
-    from web.access_control import configure_access_control  # pragma: no cover
-
-try:
-    from runtime_paths import (
-        resolve_database_path,
-        resolve_env_file_path,
-        resolve_project_root,
-        resolve_static_dir,
-        resolve_template_dir,
-    )
-except ImportError:
-    from web.runtime_paths import (  # pragma: no cover
-        resolve_database_path,
-        resolve_env_file_path,
-        resolve_project_root,
-        resolve_static_dir,
-        resolve_template_dir,
-    )
-
-try:
-    from db_state import ensure_database_schema
-except ImportError:
-    from web.db_state import ensure_database_schema  # pragma: no cover
-
-try:
-    from ops_logging import log_exception, log_info, log_warning
-except ImportError:
-    from web.ops_logging import log_exception, log_info, log_warning  # pragma: no cover
-
-# Import web types module - will be loaded later to avoid conflicts
-
-
-try:
-    from sentry_integration import setup_sentry
-except ImportError:
-    from web.sentry_integration import setup_sentry  # pragma: no cover
-
-set_sentry_user_context, set_sentry_tags = setup_sentry()
-
-
-# Import task function for RQ
-from tasks import generate_newsletter_task
-
-# Add the parent directory to the path to import newsletter modules
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
-
-# 현재 디렉토리를 파이썬 패스에 추가
-current_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, current_dir)
-
-# 프로젝트 루트를 파이썬 패스에 추가
-project_root = resolve_project_root()
-sys.path.insert(0, project_root)
-
-try:
-    from newsletter_core.public.settings import get_setting_value
-except ImportError:
-    from newsletter_core.public.settings import get_setting_value  # pragma: no cover
-
-try:
-    from newsletter_clients import (
-        MockNewsletterCLI,
-        RealNewsletterCLI,
-        create_newsletter_cli,
-    )
-except ImportError:
-    from web.newsletter_clients import (  # pragma: no cover
-        MockNewsletterCLI,
-        RealNewsletterCLI,
-        create_newsletter_cli,
-    )
-
-newsletter_cli = create_newsletter_cli()
-
-app = Flask(
-    __name__,
-    template_folder=resolve_template_dir(),
-    static_folder=resolve_static_dir(),
+from newsletter_core.public.settings import get_setting_value
+from web.access_control import configure_access_control
+from web.cors_config import configure_cors
+from web.db_state import ensure_database_schema
+from web.newsletter_clients import create_newsletter_cli
+from web.ops_logging import log_exception, log_info, log_warning
+from web.routes_analytics import register_analytics_routes
+from web.routes_approval import register_approval_routes
+from web.routes_archive import register_archive_routes
+from web.routes_email_api import register_email_api_routes
+from web.routes_generation import register_generation_routes
+from web.routes_health import register_health_route
+from web.routes_newsletter_html import register_newsletter_html_route
+from web.routes_ops import register_ops_routes
+from web.routes_presets import register_preset_routes
+from web.routes_send_email import register_send_email_route
+from web.routes_source_policies import register_source_policy_routes
+from web.runtime_paths import (
+    resolve_database_path,
+    resolve_static_dir,
+    resolve_template_dir,
 )
-configure_cors(app)
-configure_access_control(app)
+from web.sentry_integration import setup_sentry
+from web.suggest import bp as suggest_bp
 
-# Enable detailed logging
-logging.basicConfig(
-    level=str(get_setting_value("LOG_LEVEL", "INFO")).upper(),
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-)
-logger = logging.getLogger("web.app")
-log_info(
-    logger,
-    "app.initialized",
-    template_folder=resolve_template_dir(),
-    static_folder=resolve_static_dir(),
-)
+_set_sentry_user_context, _set_sentry_tags = setup_sentry()
 
-# Configuration
-app.config["SECRET_KEY"] = get_setting_value(
-    "SECRET_KEY", "dev-key-change-in-production"
-)
-app.config["REDIS_URL"] = get_setting_value("REDIS_URL", "redis://localhost:6379/0")
-
-# Queue name can be customized via environment variable
 QUEUE_NAME = str(get_setting_value("RQ_QUEUE", "default"))
+DATABASE_PATH = resolve_database_path()
+newsletter_cli = create_newsletter_cli()
+redis_conn: Any = None
+task_queue: Any = None
+in_memory_tasks: dict[str, dict[str, Any]] = {}
+logger = logging.getLogger("web.app")
 
-# Redis connection with fallback to in-memory processing
-try:
-    import platform
 
-    # Windows에서는 RQ Worker가 제대로 작동하지 않으므로 직접 처리 사용
-    if platform.system() == "Windows":
-        log_warning(logger, "app.redis.disabled_for_windows")
-        redis_conn = None
-        task_queue = None
-    else:
+def _configure_logging() -> logging.Logger:
+    logging.basicConfig(
+        level=str(get_setting_value("LOG_LEVEL", "INFO")).upper(),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    configured_logger = logging.getLogger("web.app")
+    log_info(
+        configured_logger,
+        "app.logging_configured",
+        log_level=str(get_setting_value("LOG_LEVEL", "INFO")).upper(),
+    )
+    return configured_logger
+
+
+def _create_task_queue(app: Flask) -> tuple[Any, Any]:
+    redis_url = app.config["REDIS_URL"]
+
+    try:
+        if platform.system() == "Windows":
+            log_warning(logger, "app.redis.disabled_for_windows")
+            return None, None
+
         from rq import Queue
 
-        redis_conn = redis.from_url(app.config["REDIS_URL"])
-        redis_conn.ping()  # Test connection
-        task_queue = Queue(QUEUE_NAME, connection=redis_conn)
+        connected_redis = redis.from_url(redis_url)
+        connected_redis.ping()
+        queue = Queue(QUEUE_NAME, connection=connected_redis)
         log_info(
             logger,
             "app.redis.connected",
             queue_name=QUEUE_NAME,
-            redis_url=app.config["REDIS_URL"],
+            redis_url=redis_url,
         )
-except Exception as e:
-    log_exception(
-        logger,
-        "app.redis.connection_failed",
-        e,
-        redis_url=app.config["REDIS_URL"],
-    )
-    redis_conn = None
-    task_queue = None
-
-# In-memory task storage for when Redis is unavailable
-in_memory_tasks: dict[str, dict[str, Any]] = {}
-
-# Database initialization
-DATABASE_PATH = resolve_database_path()
-
-
-def init_db() -> None:
-    """Initialize SQLite database with required tables"""
-    ensure_database_schema(DATABASE_PATH)
-
-
-# Initialize database on startup
-init_db()
-
-
-@app.route("/")  # type: ignore[untyped-decorator]
-def index() -> str | tuple[str, int]:
-    """Main dashboard page"""
-    try:
-        return cast(str, render_template("index.html"))
+        return connected_redis, queue
     except Exception as e:
-        template_path = os.path.join(app.template_folder, "index.html")
         log_exception(
             logger,
-            "app.template.render_failed",
+            "app.redis.connection_failed",
             e,
-            template_folder=app.template_folder,
-            template_path=template_path,
-            template_exists=os.path.exists(template_path),
+            redis_url=redis_url,
         )
-        return f"Template error: {str(e)}", 500
+        return None, None
 
 
-try:
-    from routes_generation import register_generation_routes
-except ImportError:
-    from web.routes_generation import register_generation_routes  # pragma: no cover
-
-register_generation_routes(
-    app=app,
-    database_path=DATABASE_PATH,
-    newsletter_cli=newsletter_cli,
-    in_memory_tasks=in_memory_tasks,
-    task_queue=task_queue,
-    redis_conn=redis_conn,
-    get_newsletter_cli=lambda: newsletter_cli,
-)
-
-
-try:
-    from routes_health import register_health_route
-except ImportError:
-    from web.routes_health import register_health_route  # pragma: no cover
-
-register_health_route(
-    app=app,
-    database_path=DATABASE_PATH,
-    redis_conn=redis_conn,
-    newsletter_cli=newsletter_cli,
-)
+def _register_index_route(app: Flask) -> None:
+    @app.route("/")  # type: ignore[untyped-decorator]
+    def index() -> str | tuple[str, int]:
+        """Main dashboard page."""
+        try:
+            return cast(str, render_template("index.html"))
+        except Exception as e:
+            template_path = os.path.join(app.template_folder, "index.html")
+            log_exception(
+                logger,
+                "app.template.render_failed",
+                e,
+                template_folder=app.template_folder,
+                template_path=template_path,
+                template_exists=os.path.exists(template_path),
+            )
+            return f"Template error: {str(e)}", 500
 
 
-try:
-    from routes_ops import register_ops_routes
-except ImportError:
-    from web.routes_ops import register_ops_routes  # pragma: no cover
-
-register_ops_routes(app, DATABASE_PATH)
-
-
-try:
-    from routes_send_email import register_send_email_route
-except ImportError:
-    from web.routes_send_email import register_send_email_route  # pragma: no cover
-
-register_send_email_route(app, DATABASE_PATH)
-
-
-try:
-    from routes_approval import register_approval_routes
-except ImportError:
-    from web.routes_approval import register_approval_routes  # pragma: no cover
-
-register_approval_routes(app, DATABASE_PATH)
-
-
-try:
-    from routes_email_api import register_email_api_routes
-except ImportError:
-    from web.routes_email_api import register_email_api_routes  # pragma: no cover
-
-register_email_api_routes(app)
+def _register_routes(app: Flask) -> None:
+    register_generation_routes(
+        app=app,
+        database_path=DATABASE_PATH,
+        newsletter_cli=newsletter_cli,
+        in_memory_tasks=in_memory_tasks,
+        task_queue=task_queue,
+        redis_conn=redis_conn,
+        get_newsletter_cli=lambda: newsletter_cli,
+    )
+    register_health_route(
+        app=app,
+        database_path=DATABASE_PATH,
+        redis_conn=redis_conn,
+        newsletter_cli=newsletter_cli,
+    )
+    register_ops_routes(app, DATABASE_PATH)
+    register_send_email_route(app, DATABASE_PATH)
+    register_approval_routes(app, DATABASE_PATH)
+    register_email_api_routes(app)
+    register_preset_routes(app, DATABASE_PATH)
+    register_source_policy_routes(app, DATABASE_PATH)
+    register_analytics_routes(app, DATABASE_PATH)
+    register_archive_routes(app, DATABASE_PATH)
+    register_newsletter_html_route(app, DATABASE_PATH)
+    app.register_blueprint(suggest_bp)
 
 
-try:
-    from routes_presets import register_preset_routes
-except ImportError:
-    from web.routes_presets import register_preset_routes  # pragma: no cover
+def create_app() -> Flask:
+    global logger, redis_conn, task_queue
 
-register_preset_routes(app, DATABASE_PATH)
+    logger = _configure_logging()
 
+    app = Flask(
+        __name__,
+        template_folder=resolve_template_dir(),
+        static_folder=resolve_static_dir(),
+    )
+    configure_cors(app)
+    configure_access_control(app)
 
-try:
-    from routes_source_policies import register_source_policy_routes
-except ImportError:
-    from web.routes_source_policies import (  # pragma: no cover
-        register_source_policy_routes,
+    app.config["SECRET_KEY"] = get_setting_value(
+        "SECRET_KEY", "dev-key-change-in-production"
+    )
+    app.config["REDIS_URL"] = get_setting_value("REDIS_URL", "redis://localhost:6379/0")
+
+    log_info(
+        logger,
+        "app.initialized",
+        template_folder=resolve_template_dir(),
+        static_folder=resolve_static_dir(),
+        database_path=DATABASE_PATH,
     )
 
-register_source_policy_routes(app, DATABASE_PATH)
+    ensure_database_schema(DATABASE_PATH)
+    redis_conn, task_queue = _create_task_queue(app)
+    _register_index_route(app)
+    _register_routes(app)
+    return app
 
 
-try:
-    from routes_analytics import register_analytics_routes
-except ImportError:
-    from web.routes_analytics import register_analytics_routes  # pragma: no cover
+app = create_app()
 
-register_analytics_routes(app, DATABASE_PATH)
-
-
-try:
-    from routes_archive import register_archive_routes
-except ImportError:
-    from web.routes_archive import register_archive_routes  # pragma: no cover
-
-register_archive_routes(app, DATABASE_PATH)
-
-
-try:
-    from routes_newsletter_html import register_newsletter_html_route
-except ImportError:
-    from web.routes_newsletter_html import (
-        register_newsletter_html_route,  # pragma: no cover
-    )
-
-register_newsletter_html_route(app, DATABASE_PATH)
-
-
-# Blueprint imports
-from suggest import bp as suggest_bp
-
-# Register blueprints
-app.register_blueprint(suggest_bp)
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", 5000))


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Normalize `web/app.py` bootstrap so app creation, logging, Redis queue setup, and route registration are explicit helpers instead of import-time sprawl.
- Remove repeated fallback imports while keeping direct `python web/app.py` execution and legacy sibling imports working during the broader web refactor.
- Preserve exported globals and response/runtime behavior expected by the existing web API and contract tests.

## Scope
### In Scope
- `web/app.py` bootstrap helper extraction
- absolute `web.*` imports in app bootstrap
- compatibility path guard for direct script execution and legacy sibling imports

### Out of Scope
- refactoring individual route modules
- changing request/response schemas
- changing Redis/task execution behavior beyond bootstrap wiring

## Delivery Unit
- RR: #223
- Delivery Unit ID: DU-20260309-web-app-bootstrap-normalization
- Merge Boundary: `web/app.py` bootstrap normalization only
- Rollback Boundary: revert commit `e7e60fb`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): web runtime + API focused regressions

### Commands and Results
```bash
./.venv/bin/python -m black web/app.py
# unchanged
./.venv/bin/python -m isort web/app.py
# passed
COVERAGE_FILE=.coverage.rr08.runtime ./.venv/bin/python -m pytest tests/contract/test_web_runtime_contract.py -q
# 2 passed
COVERAGE_FILE=.coverage.rr08.webapi ./.venv/bin/python -m pytest tests/test_web_api.py -q
# 21 passed, 1 skipped
COVERAGE_FILE=.coverage.rr08.api ./.venv/bin/python -m pytest tests/test_api.py -q
# 15 passed
make check
# PASS
make check-full
# PASS
```

## Risk & Rollback
- Risk: bootstrap import/path changes could affect direct script startup or module-level globals used by tests and runtime.
- Rollback: revert commit `e7e60fb` to restore the prior bootstrap path.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 변경 없음. bootstrap wiring만 정리했고 generation/send route semantics는 그대로 유지했습니다.
- Outbox/send_key 중복 방지 결과: 변경 없음. queue 생성과 route registration 순서만 명시화했습니다.
- import-time side effect 제거 여부: 일부 감소. repeated fallback import blocks는 제거했고, app creation은 `create_app()`으로 집중했습니다. 다만 legacy sibling imports 호환을 위해 `WEB_DIR` path guard는 유지했습니다.

## Not Run (with reason)
- GitHub Actions checks: PR 생성 후 원격에서 확인 예정
