### PR TITLE
codex(web): extract db schema core

### DIFF
--- a/tests/unit_tests/test_db_core.py
+++ b/tests/unit_tests/test_db_core.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+from db_core import connect_db, ensure_database_schema  # noqa: E402
+
+
+def _table_columns(db_path: Path, table_name: str) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cursor = conn.cursor()
+        cursor.execute(f"PRAGMA table_info({table_name})")
+        return {row[1] for row in cursor.fetchall()}
+    finally:
+        conn.close()
+
+
+def test_ensure_database_schema_creates_runtime_tables(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+
+    ensure_database_schema(str(db_path))
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = {row[0] for row in cursor.fetchall()}
+    finally:
+        conn.close()
+
+    assert {
+        "history",
+        "schedules",
+        "email_outbox",
+        "generation_presets",
+        "source_policies",
+        "analytics_events",
+        "archive_entries",
+    }.issubset(tables)
+
+
+def test_connect_db_applies_additive_history_and_schedule_columns(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE history (
+                id TEXT PRIMARY KEY,
+                params JSON NOT NULL,
+                result JSON,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                status TEXT DEFAULT 'pending'
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE schedules (
+                id TEXT PRIMARY KEY,
+                params JSON NOT NULL,
+                rrule TEXT NOT NULL,
+                next_run TIMESTAMP NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                enabled INTEGER DEFAULT 1
+            )
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    conn = connect_db(str(db_path))
+    conn.close()
+
+    assert {
+        "idempotency_key",
+        "approval_status",
+        "delivery_status",
+        "approved_at",
+        "rejected_at",
+        "approval_note",
+    }.issubset(_table_columns(db_path, "history"))
+    assert {"is_test", "expires_at"}.issubset(_table_columns(db_path, "schedules"))

--- a/web/db_core.py
+++ b/web/db_core.py
@@ -1,0 +1,212 @@
+"""SQLite schema and connection helpers for the web runtime."""
+
+from __future__ import annotations
+
+import sqlite3
+
+_APPROVAL_STATUS_NOT_REQUESTED = "not_requested"
+_DELIVERY_STATUS_DRAFT = "draft"
+
+
+def _ensure_column(
+    cursor: sqlite3.Cursor, table_name: str, column_name: str, column_def: str
+) -> None:
+    cursor.execute(f"PRAGMA table_info({table_name})")
+    existing_columns = {row[1] for row in cursor.fetchall()}
+    if column_name not in existing_columns:
+        cursor.execute(
+            f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_def}"
+        )
+
+
+def _ensure_database_schema(conn: sqlite3.Connection) -> None:
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS history (
+            id TEXT PRIMARY KEY,
+            params JSON NOT NULL,
+            result JSON,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            status TEXT DEFAULT 'pending'
+        )
+        """
+    )
+    _ensure_column(cursor, "history", "params", "JSON")
+    _ensure_column(cursor, "history", "result", "JSON")
+    _ensure_column(cursor, "history", "status", "TEXT DEFAULT 'pending'")
+    _ensure_column(
+        cursor, "history", "created_at", "TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+    )
+    _ensure_column(cursor, "history", "idempotency_key", "TEXT")
+    _ensure_column(
+        cursor,
+        "history",
+        "approval_status",
+        f"TEXT DEFAULT '{_APPROVAL_STATUS_NOT_REQUESTED}'",
+    )
+    _ensure_column(
+        cursor,
+        "history",
+        "delivery_status",
+        f"TEXT DEFAULT '{_DELIVERY_STATUS_DRAFT}'",
+    )
+    _ensure_column(cursor, "history", "approved_at", "TEXT")
+    _ensure_column(cursor, "history", "rejected_at", "TEXT")
+    _ensure_column(cursor, "history", "approval_note", "TEXT")
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schedules (
+            id TEXT PRIMARY KEY,
+            params JSON NOT NULL,
+            rrule TEXT NOT NULL,
+            next_run TIMESTAMP NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            enabled INTEGER DEFAULT 1
+        )
+        """
+    )
+    _ensure_column(cursor, "schedules", "is_test", "INTEGER DEFAULT 0")
+    _ensure_column(cursor, "schedules", "expires_at", "TEXT")
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS email_outbox (
+            send_key TEXT PRIMARY KEY,
+            job_id TEXT NOT NULL,
+            recipient TEXT NOT NULL,
+            subject_hash TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            last_error TEXT,
+            provider_message_id TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS generation_presets (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE,
+            description TEXT,
+            params JSON NOT NULL,
+            is_default INTEGER NOT NULL DEFAULT 0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS source_policies (
+            id TEXT PRIMARY KEY,
+            pattern TEXT NOT NULL,
+            policy_type TEXT NOT NULL,
+            is_active INTEGER NOT NULL DEFAULT 1,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(pattern, policy_type)
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS analytics_events (
+            id TEXT PRIMARY KEY,
+            event_type TEXT NOT NULL,
+            job_id TEXT,
+            schedule_id TEXT,
+            status TEXT,
+            deduplicated INTEGER NOT NULL DEFAULT 0,
+            duration_seconds REAL,
+            cost_usd REAL,
+            payload JSON,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS archive_entries (
+            job_id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            snippet TEXT NOT NULL,
+            source_kind TEXT NOT NULL,
+            source_value TEXT,
+            keywords JSON NOT NULL,
+            metadata JSON,
+            search_text TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_history_created_at ON history(created_at)"
+    )
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_history_status ON history(status)")
+    cursor.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_history_idempotency_key ON history(idempotency_key) WHERE idempotency_key IS NOT NULL"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_schedules_next_run ON schedules(next_run)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_schedules_enabled ON schedules(enabled)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_email_outbox_status ON email_outbox(status)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_generation_presets_default ON generation_presets(is_default)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_generation_presets_updated_at ON generation_presets(updated_at)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_source_policies_type_active ON source_policies(policy_type, is_active)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_analytics_events_type_created ON analytics_events(event_type, created_at DESC)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_analytics_events_job_id ON analytics_events(job_id)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_analytics_events_schedule_id ON analytics_events(schedule_id)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_analytics_events_created_at ON analytics_events(created_at DESC)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_archive_entries_created_at ON archive_entries(created_at DESC)"
+    )
+    cursor.execute(
+        "CREATE INDEX IF NOT EXISTS idx_archive_entries_source_kind ON archive_entries(source_kind, created_at DESC)"
+    )
+
+    conn.commit()
+
+
+def ensure_database_schema(db_path: str) -> None:
+    """Run additive DB migrations and ensure runtime schema is complete."""
+    conn = sqlite3.connect(db_path)
+    try:
+        _ensure_database_schema(conn)
+    finally:
+        conn.close()
+
+
+def connect_db(db_path: str) -> sqlite3.Connection:
+    """Return a connection after ensuring the additive runtime schema."""
+    conn = sqlite3.connect(db_path)
+    _ensure_database_schema(conn)
+    return conn

--- a/web/db_state.py
+++ b/web/db_state.py
@@ -9,12 +9,17 @@ import re
 import sqlite3
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, cast
 
 try:
     from archive import build_archive_entry
 except ImportError:
     from web.archive import build_archive_entry  # pragma: no cover
+
+try:
+    import db_core as _db_core
+except ImportError:
+    from web import db_core as _db_core  # pragma: no cover
 
 APPROVAL_STATUS_NOT_REQUESTED = "not_requested"
 APPROVAL_STATUS_PENDING = "pending"
@@ -92,207 +97,13 @@ def derive_history_review_state(
     return APPROVAL_STATUS_NOT_REQUESTED, DELIVERY_STATUS_DRAFT
 
 
-def _ensure_column(
-    cursor: sqlite3.Cursor, table_name: str, column_name: str, column_def: str
-) -> None:
-    cursor.execute(f"PRAGMA table_info({table_name})")
-    existing_columns = {row[1] for row in cursor.fetchall()}
-    if column_name not in existing_columns:
-        cursor.execute(
-            f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_def}"
-        )
-
-
-def _ensure_database_schema(conn: sqlite3.Connection) -> None:
-    cursor = conn.cursor()
-    cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS history (
-            id TEXT PRIMARY KEY,
-            params JSON NOT NULL,
-            result JSON,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            status TEXT DEFAULT 'pending'
-        )
-        """
-    )
-    _ensure_column(cursor, "history", "params", "JSON")
-    _ensure_column(cursor, "history", "result", "JSON")
-    _ensure_column(cursor, "history", "status", "TEXT DEFAULT 'pending'")
-    _ensure_column(
-        cursor, "history", "created_at", "TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
-    )
-    _ensure_column(cursor, "history", "idempotency_key", "TEXT")
-    _ensure_column(
-        cursor,
-        "history",
-        "approval_status",
-        f"TEXT DEFAULT '{APPROVAL_STATUS_NOT_REQUESTED}'",
-    )
-    _ensure_column(
-        cursor,
-        "history",
-        "delivery_status",
-        f"TEXT DEFAULT '{DELIVERY_STATUS_DRAFT}'",
-    )
-    _ensure_column(cursor, "history", "approved_at", "TEXT")
-    _ensure_column(cursor, "history", "rejected_at", "TEXT")
-    _ensure_column(cursor, "history", "approval_note", "TEXT")
-
-    cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS schedules (
-            id TEXT PRIMARY KEY,
-            params JSON NOT NULL,
-            rrule TEXT NOT NULL,
-            next_run TIMESTAMP NOT NULL,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            enabled INTEGER DEFAULT 1
-        )
-        """
-    )
-    _ensure_column(cursor, "schedules", "is_test", "INTEGER DEFAULT 0")
-    _ensure_column(cursor, "schedules", "expires_at", "TEXT")
-
-    cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS email_outbox (
-            send_key TEXT PRIMARY KEY,
-            job_id TEXT NOT NULL,
-            recipient TEXT NOT NULL,
-            subject_hash TEXT NOT NULL,
-            status TEXT NOT NULL DEFAULT 'pending',
-            attempt_count INTEGER NOT NULL DEFAULT 0,
-            last_error TEXT,
-            provider_message_id TEXT,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-        )
-        """
-    )
-
-    cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS generation_presets (
-            id TEXT PRIMARY KEY,
-            name TEXT NOT NULL UNIQUE,
-            description TEXT,
-            params JSON NOT NULL,
-            is_default INTEGER NOT NULL DEFAULT 0,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-        )
-        """
-    )
-
-    cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS source_policies (
-            id TEXT PRIMARY KEY,
-            pattern TEXT NOT NULL,
-            policy_type TEXT NOT NULL,
-            is_active INTEGER NOT NULL DEFAULT 1,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            UNIQUE(pattern, policy_type)
-        )
-        """
-    )
-
-    cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS analytics_events (
-            id TEXT PRIMARY KEY,
-            event_type TEXT NOT NULL,
-            job_id TEXT,
-            schedule_id TEXT,
-            status TEXT,
-            deduplicated INTEGER NOT NULL DEFAULT 0,
-            duration_seconds REAL,
-            cost_usd REAL,
-            payload JSON,
-            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-        )
-        """
-    )
-
-    cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS archive_entries (
-            job_id TEXT PRIMARY KEY,
-            title TEXT NOT NULL,
-            snippet TEXT NOT NULL,
-            source_kind TEXT NOT NULL,
-            source_value TEXT,
-            keywords JSON NOT NULL,
-            metadata JSON,
-            search_text TEXT NOT NULL,
-            created_at TEXT NOT NULL,
-            updated_at TEXT NOT NULL
-        )
-        """
-    )
-
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_history_created_at ON history(created_at)"
-    )
-    cursor.execute("CREATE INDEX IF NOT EXISTS idx_history_status ON history(status)")
-    cursor.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_history_idempotency_key ON history(idempotency_key) WHERE idempotency_key IS NOT NULL"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_schedules_next_run ON schedules(next_run)"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_schedules_enabled ON schedules(enabled)"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_email_outbox_status ON email_outbox(status)"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_generation_presets_default ON generation_presets(is_default)"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_generation_presets_updated_at ON generation_presets(updated_at)"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_source_policies_type_active ON source_policies(policy_type, is_active)"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_analytics_events_type_created ON analytics_events(event_type, created_at DESC)"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_analytics_events_job_id ON analytics_events(job_id)"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_analytics_events_schedule_id ON analytics_events(schedule_id)"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_analytics_events_created_at ON analytics_events(created_at DESC)"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_archive_entries_created_at ON archive_entries(created_at DESC)"
-    )
-    cursor.execute(
-        "CREATE INDEX IF NOT EXISTS idx_archive_entries_source_kind ON archive_entries(source_kind, created_at DESC)"
-    )
-
-    conn.commit()
+def _connect(db_path: str) -> sqlite3.Connection:
+    return cast(sqlite3.Connection, _db_core.connect_db(db_path))
 
 
 def ensure_database_schema(db_path: str) -> None:
-    """Run additive DB migrations and ensure runtime schema is complete."""
-    conn = sqlite3.connect(db_path)
-    try:
-        _ensure_database_schema(conn)
-    finally:
-        conn.close()
-
-
-def _connect(db_path: str) -> sqlite3.Connection:
-    conn = sqlite3.connect(db_path)
-    _ensure_database_schema(conn)
-    return conn
+    """Preserve the legacy db_state schema API while delegating to db_core."""
+    _db_core.ensure_database_schema(db_path)
 
 
 def create_or_get_history_job(


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Extract the additive SQLite schema and connection helpers from `web/db_state.py` into `web/db_core.py`.
- Keep `db_state.ensure_database_schema()` as a compatibility facade so existing callers do not change behavior while later RR slices can peel off stores independently.
- Add regression tests that lock schema creation and legacy-column backfill behavior for history and schedules.

## Scope
### In Scope
- `web/db_core.py` creation for schema + connection helpers
- `web/db_state.py` delegation to the new core module
- unit tests for schema creation and additive migrations

### Out of Scope
- history/idempotency store extraction
- archive/analytics/preset/source policy extraction
- route/scheduler behavior changes

## Delivery Unit
- RR: #224
- Delivery Unit ID: DU-20260309-db-state-schema-core
- Merge Boundary: `web/db_core.py`, `web/db_state.py`, `tests/unit_tests/test_db_core.py`
- Rollback Boundary: revert commit `e3e4e2c`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): db core regression, web API, schedule execution/time sync

### Commands and Results
```bash
./.venv/bin/python -m black web/db_core.py web/db_state.py tests/unit_tests/test_db_core.py
# passed
./.venv/bin/python -m isort web/db_core.py web/db_state.py tests/unit_tests/test_db_core.py
# passed
COVERAGE_FILE=.coverage.rr09.dbcore ./.venv/bin/python -m pytest tests/unit_tests/test_db_core.py -q
# 2 passed
COVERAGE_FILE=.coverage.rr09.webapi ./.venv/bin/python -m pytest tests/test_web_api.py -q
# 21 passed, 1 skipped
COVERAGE_FILE=.coverage.rr09.schedule ./.venv/bin/python -m pytest tests/integration/test_schedule_execution.py tests/unit_tests/test_schedule_time_sync.py -q
# 4 passed, 8 skipped
make check
# PASS
make check-full
# PASS
```

## Risk & Rollback
- Risk: any caller relying on implicit schema setup could regress if the delegated connection helper diverges from the legacy path.
- Rollback: revert commit `e3e4e2c` to restore the inlined schema/connect logic in `web/db_state.py`.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 변경 없음. history/idempotency logic는 그대로 두고 schema/connect 책임만 분리했습니다.
- Outbox/send_key 중복 방지 결과: 변경 없음. `email_outbox` schema와 unique/index setup를 동일하게 유지했습니다.
- import-time side effect 제거 여부: 일부 개선. schema/connect helper가 `db_state`에서 분리되어 import surface가 줄었고, legacy facade는 유지했습니다.

## Not Run (with reason)
- GitHub Actions checks: PR 생성 후 원격에서 확인 예정
