### PR TITLE
codex(web): extract history idempotency store

### DIFF
--- a/tests/unit_tests/test_db_history.py
+++ b/tests/unit_tests/test_db_history.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+from db_history import (  # noqa: E402
+    APPROVAL_STATUS_APPROVED,
+    APPROVAL_STATUS_PENDING,
+    DELIVERY_STATUS_APPROVED,
+    DELIVERY_STATUS_PENDING_APPROVAL,
+    build_idempotency_key,
+    create_or_get_history_job,
+    derive_job_id,
+    get_history_row,
+    get_history_row_by_idempotency_key,
+    update_history_review_state,
+    update_history_status,
+)
+
+
+def test_create_or_get_history_job_deduplicates_by_idempotency_key(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "storage.db"
+    params = {"email": "ops@example.com", "require_approval": True}
+    idempotency_key = build_idempotency_key(params, namespace="generate")
+
+    first_job_id, deduplicated, stored_status = create_or_get_history_job(
+        str(db_path),
+        derive_job_id(idempotency_key),
+        params,
+        idempotency_key,
+        status="pending",
+    )
+    second_job_id, second_deduplicated, second_status = create_or_get_history_job(
+        str(db_path),
+        "job_should_not_replace_existing",
+        params,
+        idempotency_key,
+        status="pending",
+    )
+
+    assert deduplicated is False
+    assert stored_status == "pending"
+    assert second_deduplicated is True
+    assert second_job_id == first_job_id
+    assert second_status == "pending"
+
+    row = get_history_row_by_idempotency_key(str(db_path), idempotency_key)
+    assert row is not None
+    assert row["approval_status"] == APPROVAL_STATUS_PENDING
+    assert row["delivery_status"] == DELIVERY_STATUS_PENDING_APPROVAL
+
+
+def test_update_history_status_and_review_state_persist_expected_fields(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "storage.db"
+    job_id = "job-review-state"
+    params = {"email": "ops@example.com", "keywords": ["AI"]}
+
+    update_history_status(
+        str(db_path),
+        job_id,
+        "completed",
+        result={"html_content": "<html>ok</html>", "title": "History"},
+        params=params,
+        idempotency_key="generate:test-history",
+    )
+    update_history_review_state(
+        str(db_path),
+        job_id,
+        approval_status=APPROVAL_STATUS_APPROVED,
+        delivery_status=DELIVERY_STATUS_APPROVED,
+        approved_at="2026-03-09T10:00:00Z",
+        approval_note="approved by test",
+    )
+
+    row = get_history_row(str(db_path), job_id)
+    assert row is not None
+    assert row["status"] == "completed"
+    assert json.loads(str(row["result"]))["title"] == "History"
+    assert row["approval_status"] == APPROVAL_STATUS_APPROVED
+    assert row["delivery_status"] == DELIVERY_STATUS_APPROVED
+    assert row["approved_at"] == "2026-03-09T10:00:00Z"
+    assert row["approval_note"] == "approved by test"

--- a/web/db_history.py
+++ b/web/db_history.py
@@ -1,0 +1,325 @@
+"""History and idempotency store helpers for the web runtime."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple, cast
+
+try:
+    import db_core as _db_core
+except ImportError:
+    from web import db_core as _db_core  # pragma: no cover
+
+APPROVAL_STATUS_NOT_REQUESTED = "not_requested"
+APPROVAL_STATUS_PENDING = "pending"
+APPROVAL_STATUS_APPROVED = "approved"
+APPROVAL_STATUS_REJECTED = "rejected"
+
+DELIVERY_STATUS_DRAFT = "draft"
+DELIVERY_STATUS_PENDING_APPROVAL = "pending_approval"
+DELIVERY_STATUS_APPROVED = "approved"
+DELIVERY_STATUS_SENT = "sent"
+DELIVERY_STATUS_SEND_FAILED = "send_failed"
+
+_UNSET = object()
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    return cast(sqlite3.Connection, _db_core.connect_db(db_path))
+
+
+def _canonical_json(payload: Dict[str, Any] | None) -> str:
+    return json.dumps(
+        payload or {}, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+
+
+def build_idempotency_key(
+    payload: Dict[str, Any] | None,
+    provided_key: str | None = None,
+    namespace: str = "generate",
+) -> str:
+    """Build an idempotency key using client key first, otherwise canonical hash."""
+    if provided_key and str(provided_key).strip():
+        return str(provided_key).strip()
+
+    digest = hashlib.sha256(
+        f"{namespace}:{_canonical_json(payload)}".encode("utf-8")
+    ).hexdigest()
+    return f"{namespace}:{digest}"
+
+
+def build_schedule_idempotency_key(schedule_id: str, intended_run_at: datetime) -> str:
+    """Derive deterministic schedule idempotency key from schedule and intended run."""
+    intended_utc = intended_run_at.astimezone(timezone.utc).isoformat()
+    return build_idempotency_key(
+        {"schedule_id": schedule_id, "intended_run_at": intended_utc},
+        namespace="schedule",
+    )
+
+
+def derive_job_id(idempotency_key: str, prefix: str = "job") -> str:
+    """Build stable job ID from idempotency key."""
+    digest = hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest()[:24]
+    return f"{prefix}_{digest}"
+
+
+def derive_history_review_state(
+    params: Dict[str, Any] | None,
+) -> tuple[str, str]:
+    """Derive initial approval and delivery state from request params."""
+    payload = params or {}
+    has_email = bool(str(payload.get("email", "") or "").strip())
+    requires_approval = bool(payload.get("require_approval")) and has_email
+
+    if requires_approval:
+        return APPROVAL_STATUS_PENDING, DELIVERY_STATUS_PENDING_APPROVAL
+
+    return APPROVAL_STATUS_NOT_REQUESTED, DELIVERY_STATUS_DRAFT
+
+
+def create_or_get_history_job(
+    db_path: str,
+    job_id: str,
+    params: Dict[str, Any],
+    idempotency_key: str | None,
+    status: str = "pending",
+) -> Tuple[str, bool, str]:
+    """Insert a new history row or return existing one by idempotency key."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        approval_status, delivery_status = derive_history_review_state(params)
+        if idempotency_key:
+            cursor.execute(
+                "SELECT id, status FROM history WHERE idempotency_key = ?",
+                (idempotency_key,),
+            )
+            existing = cursor.fetchone()
+            if existing:
+                return existing[0], True, existing[1]
+
+        cursor.execute(
+            """
+            INSERT OR IGNORE INTO history (
+                id,
+                params,
+                status,
+                idempotency_key,
+                approval_status,
+                delivery_status
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                job_id,
+                _canonical_json(params),
+                status,
+                idempotency_key,
+                approval_status,
+                delivery_status,
+            ),
+        )
+        conn.commit()
+        return job_id, False, status
+    finally:
+        conn.close()
+
+
+def ensure_history_row(
+    db_path: str,
+    job_id: str,
+    params: Dict[str, Any] | None = None,
+    status: str = "pending",
+    idempotency_key: str | None = None,
+) -> None:
+    """Ensure history row exists for a job."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        approval_status, delivery_status = derive_history_review_state(params)
+        cursor.execute(
+            """
+            INSERT OR IGNORE INTO history (
+                id,
+                params,
+                status,
+                idempotency_key,
+                approval_status,
+                delivery_status
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                job_id,
+                _canonical_json(params),
+                status,
+                idempotency_key,
+                approval_status,
+                delivery_status,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def update_history_status(
+    db_path: str,
+    job_id: str,
+    status: str,
+    result: Dict[str, Any] | None = None,
+    params: Dict[str, Any] | None = None,
+    idempotency_key: str | None = None,
+) -> None:
+    """Update history status/result in one consistent path."""
+    ensure_history_row(
+        db_path=db_path,
+        job_id=job_id,
+        params=params,
+        status="pending",
+        idempotency_key=idempotency_key,
+    )
+
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        if result is None:
+            cursor.execute(
+                "UPDATE history SET status = ? WHERE id = ?",
+                (status, job_id),
+            )
+        else:
+            cursor.execute(
+                "UPDATE history SET status = ?, result = ? WHERE id = ?",
+                (status, _canonical_json(result), job_id),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_history_row_by_idempotency_key(
+    db_path: str, idempotency_key: str
+) -> Optional[Dict[str, Any]]:
+    """Fetch a history row by idempotency key."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, status, result, params, approval_status, delivery_status
+            FROM history
+            WHERE idempotency_key = ?
+            """,
+            (idempotency_key,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return {
+            "id": row[0],
+            "status": row[1],
+            "result": row[2],
+            "params": row[3],
+            "approval_status": row[4],
+            "delivery_status": row[5],
+        }
+    finally:
+        conn.close()
+
+
+def get_history_row(db_path: str, job_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch a history row by job id."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT
+                id,
+                status,
+                result,
+                params,
+                idempotency_key,
+                approval_status,
+                delivery_status,
+                approved_at,
+                rejected_at,
+                approval_note
+            FROM history
+            WHERE id = ?
+            """,
+            (job_id,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return {
+            "id": row[0],
+            "status": row[1],
+            "result": row[2],
+            "params": row[3],
+            "idempotency_key": row[4],
+            "approval_status": row[5],
+            "delivery_status": row[6],
+            "approved_at": row[7],
+            "rejected_at": row[8],
+            "approval_note": row[9],
+        }
+    finally:
+        conn.close()
+
+
+def update_history_review_state(
+    db_path: str,
+    job_id: str,
+    *,
+    approval_status: str | None = None,
+    delivery_status: str | None = None,
+    approved_at: str | None | object = _UNSET,
+    rejected_at: str | None | object = _UNSET,
+    approval_note: str | None | object = _UNSET,
+) -> None:
+    """Update approval and delivery metadata for a history row."""
+    if (
+        approval_status is None
+        and delivery_status is None
+        and approved_at is _UNSET
+        and rejected_at is _UNSET
+        and approval_note is _UNSET
+    ):
+        return
+
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            UPDATE history
+            SET
+                approval_status = COALESCE(?, approval_status),
+                delivery_status = COALESCE(?, delivery_status),
+                approved_at = CASE WHEN ? THEN ? ELSE approved_at END,
+                rejected_at = CASE WHEN ? THEN ? ELSE rejected_at END,
+                approval_note = CASE WHEN ? THEN ? ELSE approval_note END
+            WHERE id = ?
+            """,
+            (
+                approval_status,
+                delivery_status,
+                approved_at is not _UNSET,
+                None if approved_at is _UNSET else approved_at,
+                rejected_at is not _UNSET,
+                None if rejected_at is _UNSET else rejected_at,
+                approval_note is not _UNSET,
+                None if approval_note is _UNSET else approval_note,
+                job_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()

--- a/web/db_state.py
+++ b/web/db_state.py
@@ -9,7 +9,7 @@ import re
 import sqlite3
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional, Tuple, cast
+from typing import Any, Dict, Optional, cast
 
 try:
     from archive import build_archive_entry
@@ -21,21 +21,24 @@ try:
 except ImportError:
     from web import db_core as _db_core  # pragma: no cover
 
-APPROVAL_STATUS_NOT_REQUESTED = "not_requested"
-APPROVAL_STATUS_PENDING = "pending"
-APPROVAL_STATUS_APPROVED = "approved"
-APPROVAL_STATUS_REJECTED = "rejected"
+try:
+    import db_history as _db_history
+except ImportError:
+    from web import db_history as _db_history  # pragma: no cover
 
-DELIVERY_STATUS_DRAFT = "draft"
-DELIVERY_STATUS_PENDING_APPROVAL = "pending_approval"
-DELIVERY_STATUS_APPROVED = "approved"
-DELIVERY_STATUS_SENT = "sent"
-DELIVERY_STATUS_SEND_FAILED = "send_failed"
+APPROVAL_STATUS_NOT_REQUESTED = _db_history.APPROVAL_STATUS_NOT_REQUESTED
+APPROVAL_STATUS_PENDING = _db_history.APPROVAL_STATUS_PENDING
+APPROVAL_STATUS_APPROVED = _db_history.APPROVAL_STATUS_APPROVED
+APPROVAL_STATUS_REJECTED = _db_history.APPROVAL_STATUS_REJECTED
+
+DELIVERY_STATUS_DRAFT = _db_history.DELIVERY_STATUS_DRAFT
+DELIVERY_STATUS_PENDING_APPROVAL = _db_history.DELIVERY_STATUS_PENDING_APPROVAL
+DELIVERY_STATUS_APPROVED = _db_history.DELIVERY_STATUS_APPROVED
+DELIVERY_STATUS_SENT = _db_history.DELIVERY_STATUS_SENT
+DELIVERY_STATUS_SEND_FAILED = _db_history.DELIVERY_STATUS_SEND_FAILED
 
 SOURCE_POLICY_ALLOW = "allow"
 SOURCE_POLICY_BLOCK = "block"
-
-_UNSET = object()
 
 
 def is_feature_enabled(env_var: str, default: bool = True) -> bool:
@@ -53,48 +56,16 @@ def canonical_json(payload: Dict[str, Any] | None) -> str:
     )
 
 
-def build_idempotency_key(
-    payload: Dict[str, Any] | None,
-    provided_key: str | None = None,
-    namespace: str = "generate",
-) -> str:
-    """Build an idempotency key using client key first, otherwise canonical hash."""
-    if provided_key and str(provided_key).strip():
-        return str(provided_key).strip()
-
-    digest = hashlib.sha256(
-        f"{namespace}:{canonical_json(payload)}".encode("utf-8")
-    ).hexdigest()
-    return f"{namespace}:{digest}"
-
-
-def build_schedule_idempotency_key(schedule_id: str, intended_run_at: datetime) -> str:
-    """Derive deterministic schedule idempotency key from schedule and intended run."""
-    intended_utc = intended_run_at.astimezone(timezone.utc).isoformat()
-    return build_idempotency_key(
-        {"schedule_id": schedule_id, "intended_run_at": intended_utc},
-        namespace="schedule",
-    )
-
-
-def derive_job_id(idempotency_key: str, prefix: str = "job") -> str:
-    """Build stable job ID from idempotency key."""
-    digest = hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest()[:24]
-    return f"{prefix}_{digest}"
-
-
-def derive_history_review_state(
-    params: Dict[str, Any] | None,
-) -> tuple[str, str]:
-    """Derive initial approval and delivery state from request params."""
-    payload = params or {}
-    has_email = bool(str(payload.get("email", "") or "").strip())
-    requires_approval = bool(payload.get("require_approval")) and has_email
-
-    if requires_approval:
-        return APPROVAL_STATUS_PENDING, DELIVERY_STATUS_PENDING_APPROVAL
-
-    return APPROVAL_STATUS_NOT_REQUESTED, DELIVERY_STATUS_DRAFT
+build_idempotency_key = _db_history.build_idempotency_key
+build_schedule_idempotency_key = _db_history.build_schedule_idempotency_key
+derive_job_id = _db_history.derive_job_id
+derive_history_review_state = _db_history.derive_history_review_state
+create_or_get_history_job = _db_history.create_or_get_history_job
+ensure_history_row = _db_history.ensure_history_row
+update_history_status = _db_history.update_history_status
+get_history_row_by_idempotency_key = _db_history.get_history_row_by_idempotency_key
+get_history_row = _db_history.get_history_row
+update_history_review_state = _db_history.update_history_review_state
 
 
 def _connect(db_path: str) -> sqlite3.Connection:
@@ -104,250 +75,6 @@ def _connect(db_path: str) -> sqlite3.Connection:
 def ensure_database_schema(db_path: str) -> None:
     """Preserve the legacy db_state schema API while delegating to db_core."""
     _db_core.ensure_database_schema(db_path)
-
-
-def create_or_get_history_job(
-    db_path: str,
-    job_id: str,
-    params: Dict[str, Any],
-    idempotency_key: str | None,
-    status: str = "pending",
-) -> Tuple[str, bool, str]:
-    """Insert a new history row or return existing one by idempotency key."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        approval_status, delivery_status = derive_history_review_state(params)
-        if idempotency_key:
-            cursor.execute(
-                "SELECT id, status FROM history WHERE idempotency_key = ?",
-                (idempotency_key,),
-            )
-            existing = cursor.fetchone()
-            if existing:
-                return existing[0], True, existing[1]
-
-        cursor.execute(
-            """
-            INSERT OR IGNORE INTO history (
-                id,
-                params,
-                status,
-                idempotency_key,
-                approval_status,
-                delivery_status
-            )
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (
-                job_id,
-                canonical_json(params),
-                status,
-                idempotency_key,
-                approval_status,
-                delivery_status,
-            ),
-        )
-        conn.commit()
-        return job_id, False, status
-    finally:
-        conn.close()
-
-
-def ensure_history_row(
-    db_path: str,
-    job_id: str,
-    params: Dict[str, Any] | None = None,
-    status: str = "pending",
-    idempotency_key: str | None = None,
-) -> None:
-    """Ensure history row exists for a job."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        approval_status, delivery_status = derive_history_review_state(params)
-        cursor.execute(
-            """
-            INSERT OR IGNORE INTO history (
-                id,
-                params,
-                status,
-                idempotency_key,
-                approval_status,
-                delivery_status
-            )
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (
-                job_id,
-                canonical_json(params),
-                status,
-                idempotency_key,
-                approval_status,
-                delivery_status,
-            ),
-        )
-        conn.commit()
-    finally:
-        conn.close()
-
-
-def update_history_status(
-    db_path: str,
-    job_id: str,
-    status: str,
-    result: Dict[str, Any] | None = None,
-    params: Dict[str, Any] | None = None,
-    idempotency_key: str | None = None,
-) -> None:
-    """Update history status/result in one consistent path."""
-    ensure_history_row(
-        db_path=db_path,
-        job_id=job_id,
-        params=params,
-        status="pending",
-        idempotency_key=idempotency_key,
-    )
-
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        if result is None:
-            cursor.execute(
-                "UPDATE history SET status = ? WHERE id = ?",
-                (status, job_id),
-            )
-        else:
-            cursor.execute(
-                "UPDATE history SET status = ?, result = ? WHERE id = ?",
-                (status, canonical_json(result), job_id),
-            )
-        conn.commit()
-    finally:
-        conn.close()
-
-
-def get_history_row_by_idempotency_key(
-    db_path: str, idempotency_key: str
-) -> Optional[Dict[str, Any]]:
-    """Fetch a history row by idempotency key."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT id, status, result, params, approval_status, delivery_status
-            FROM history
-            WHERE idempotency_key = ?
-            """,
-            (idempotency_key,),
-        )
-        row = cursor.fetchone()
-        if not row:
-            return None
-        return {
-            "id": row[0],
-            "status": row[1],
-            "result": row[2],
-            "params": row[3],
-            "approval_status": row[4],
-            "delivery_status": row[5],
-        }
-    finally:
-        conn.close()
-
-
-def get_history_row(db_path: str, job_id: str) -> Optional[Dict[str, Any]]:
-    """Fetch a history row by job id."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT
-                id,
-                status,
-                result,
-                params,
-                idempotency_key,
-                approval_status,
-                delivery_status,
-                approved_at,
-                rejected_at,
-                approval_note
-            FROM history
-            WHERE id = ?
-            """,
-            (job_id,),
-        )
-        row = cursor.fetchone()
-        if not row:
-            return None
-        return {
-            "id": row[0],
-            "status": row[1],
-            "result": row[2],
-            "params": row[3],
-            "idempotency_key": row[4],
-            "approval_status": row[5],
-            "delivery_status": row[6],
-            "approved_at": row[7],
-            "rejected_at": row[8],
-            "approval_note": row[9],
-        }
-    finally:
-        conn.close()
-
-
-def update_history_review_state(
-    db_path: str,
-    job_id: str,
-    *,
-    approval_status: str | None = None,
-    delivery_status: str | None = None,
-    approved_at: str | None | object = _UNSET,
-    rejected_at: str | None | object = _UNSET,
-    approval_note: str | None | object = _UNSET,
-) -> None:
-    """Update approval and delivery metadata for a history row."""
-    if (
-        approval_status is None
-        and delivery_status is None
-        and approved_at is _UNSET
-        and rejected_at is _UNSET
-        and approval_note is _UNSET
-    ):
-        return
-
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            UPDATE history
-            SET
-                approval_status = COALESCE(?, approval_status),
-                delivery_status = COALESCE(?, delivery_status),
-                approved_at = CASE WHEN ? THEN ? ELSE approved_at END,
-                rejected_at = CASE WHEN ? THEN ? ELSE rejected_at END,
-                approval_note = CASE WHEN ? THEN ? ELSE approval_note END
-            WHERE id = ?
-            """,
-            (
-                approval_status,
-                delivery_status,
-                approved_at is not _UNSET,
-                None if approved_at is _UNSET else approved_at,
-                rejected_at is not _UNSET,
-                None if rejected_at is _UNSET else rejected_at,
-                approval_note is not _UNSET,
-                None if approval_note is _UNSET else approval_note,
-                job_id,
-            ),
-        )
-        conn.commit()
-    finally:
-        conn.close()
 
 
 def hash_subject(subject: str) -> str:


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Extract history and idempotency helpers from `web/db_state.py` into `web/db_history.py`.
- Keep the `db_state` public surface stable by re-exporting the moved constants and helpers, so route/task callers do not need to change in this slice.
- Add regression tests for idempotency deduplication and persisted history/review-state updates.

## Scope
### In Scope
- `web/db_history.py` creation for history/idempotency store logic
- `web/db_state.py` facade aliases for moved history helpers
- unit tests for dedupe and history status/review persistence

### Out of Scope
- outbox extraction
- archive/analytics/preset/source policy extraction
- route import rewiring to use `db_history` directly

## Delivery Unit
- RR: #225
- Delivery Unit ID: DU-20260309-db-state-history-idempotency
- Merge Boundary: `web/db_history.py`, `web/db_state.py`, `tests/unit_tests/test_db_history.py`
- Rollback Boundary: revert commit `7fe4ac4`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): history/idempotency regression, approval routes/gate, web API, schedule execution/time sync

### Commands and Results
```bash
./.venv/bin/python -m black web/db_history.py web/db_state.py tests/unit_tests/test_db_history.py
# passed
./.venv/bin/python -m isort web/db_history.py web/db_state.py tests/unit_tests/test_db_history.py
# passed
COVERAGE_FILE=.coverage.rr10.history ./.venv/bin/python -m pytest tests/unit_tests/test_db_history.py -q
# 2 passed
COVERAGE_FILE=.coverage.rr10.approval ./.venv/bin/python -m pytest tests/unit_tests/test_web_approval_routes.py tests/unit_tests/test_web_approval_gate.py -q
# 6 passed
COVERAGE_FILE=.coverage.rr10.webapi ./.venv/bin/python -m pytest tests/test_web_api.py -q
# 21 passed, 1 skipped
COVERAGE_FILE=.coverage.rr10.schedule ./.venv/bin/python -m pytest tests/integration/test_schedule_execution.py tests/unit_tests/test_schedule_time_sync.py -q
# 4 passed, 8 skipped
make check
# PASS
make check-full
# PASS
```

## Risk & Rollback
- Risk: facade aliasing could miss a moved helper or constant and break route/task imports at runtime.
- Rollback: revert commit `7fe4ac4` to restore the inlined history/idempotency implementation in `web/db_state.py`.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 동일합니다. `build_idempotency_key`, `build_schedule_idempotency_key`, `derive_job_id`, history row dedupe 흐름을 그대로 새 store로 이동했습니다.
- Outbox/send_key 중복 방지 결과: 변경 없음. outbox helpers는 이번 RR 범위 밖이며 기존 `db_state`에 남겨두었습니다.
- import-time side effect 제거 여부: 일부 개선. `db_state`가 history/idempotency 구현을 직접 들고 있지 않고 facade 역할만 수행합니다.

## Not Run (with reason)
- GitHub Actions checks: PR 생성 후 원격에서 확인 예정
