### PR TITLE
codex(web): extract preset source-policy store

### DIFF
--- a/tests/unit_tests/test_db_presets.py
+++ b/tests/unit_tests/test_db_presets.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+from db_presets import (  # noqa: E402
+    create_generation_preset,
+    list_generation_presets,
+    update_generation_preset,
+)
+from db_state import ensure_database_schema  # noqa: E402
+
+
+def test_create_generation_preset_lists_default_first(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    create_generation_preset(
+        str(db_path),
+        "preset-first",
+        "First",
+        None,
+        {"keywords": ["ai"], "template_style": "compact", "period": 7},
+        is_default=False,
+    )
+    create_generation_preset(
+        str(db_path),
+        "preset-default",
+        "Default",
+        "Primary preset",
+        {"domain": "battery", "template_style": "modern", "period": 14},
+        is_default=True,
+    )
+
+    presets = list_generation_presets(str(db_path))
+
+    assert [preset["id"] for preset in presets] == ["preset-default", "preset-first"]
+    assert presets[0]["is_default"] is True
+
+
+def test_update_generation_preset_promotes_only_one_default(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    create_generation_preset(
+        str(db_path),
+        "preset-a",
+        "Preset A",
+        None,
+        {"keywords": ["ai"], "template_style": "compact", "period": 7},
+        is_default=True,
+    )
+    create_generation_preset(
+        str(db_path),
+        "preset-b",
+        "Preset B",
+        None,
+        {"domain": "chips", "template_style": "detailed", "period": 14},
+        is_default=False,
+    )
+
+    updated = update_generation_preset(
+        str(db_path),
+        "preset-b",
+        "Preset B",
+        "Promoted",
+        {"domain": "chips", "template_style": "modern", "period": 30},
+        is_default=True,
+    )
+
+    presets = {preset["id"]: preset for preset in list_generation_presets(str(db_path))}
+    assert updated is not None
+    assert presets["preset-a"]["is_default"] is False
+    assert presets["preset-b"]["is_default"] is True
+    assert presets["preset-b"]["params"]["template_style"] == "modern"

--- a/tests/unit_tests/test_db_source_policies.py
+++ b/tests/unit_tests/test_db_source_policies.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+from db_source_policies import (  # noqa: E402
+    SOURCE_POLICY_ALLOW,
+    SOURCE_POLICY_BLOCK,
+    create_source_policy,
+    get_active_source_policies,
+    list_source_policies,
+    update_source_policy,
+)
+from db_state import ensure_database_schema  # noqa: E402
+
+
+def test_list_source_policies_returns_saved_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    create_source_policy(
+        str(db_path),
+        "policy-allow",
+        "reuters.com",
+        SOURCE_POLICY_ALLOW,
+        is_active=True,
+    )
+    create_source_policy(
+        str(db_path),
+        "policy-block",
+        "spam.example",
+        SOURCE_POLICY_BLOCK,
+        is_active=False,
+    )
+
+    policies = {policy["id"]: policy for policy in list_source_policies(str(db_path))}
+
+    assert policies["policy-allow"]["policy_type"] == SOURCE_POLICY_ALLOW
+    assert policies["policy-block"]["is_active"] is False
+
+
+def test_get_active_source_policies_groups_allow_and_block(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    create_source_policy(
+        str(db_path),
+        "policy-allow",
+        "ft.com",
+        SOURCE_POLICY_ALLOW,
+        is_active=True,
+    )
+    create_source_policy(
+        str(db_path),
+        "policy-block",
+        "spam.example",
+        SOURCE_POLICY_BLOCK,
+        is_active=True,
+    )
+    update_source_policy(
+        str(db_path),
+        "policy-block",
+        "spam.example",
+        SOURCE_POLICY_BLOCK,
+        is_active=True,
+    )
+
+    active = get_active_source_policies(str(db_path))
+
+    assert active == {"allowlist": ["ft.com"], "blocklist": ["spam.example"]}

--- a/web/db_presets.py
+++ b/web/db_presets.py
@@ -1,0 +1,172 @@
+"""Generation preset persistence helpers for the canonical web runtime."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any, Dict, Optional, cast
+
+try:
+    import db_core as _db_core
+except ImportError:
+    from web import db_core as _db_core  # pragma: no cover
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    return cast(sqlite3.Connection, _db_core.connect_db(db_path))
+
+
+def _canonical_json(payload: Dict[str, Any] | None) -> str:
+    return json.dumps(
+        payload or {}, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+
+
+def _decode_generation_preset(row: tuple[Any, ...]) -> Dict[str, Any]:
+    return {
+        "id": row[0],
+        "name": row[1],
+        "description": row[2],
+        "params": json.loads(row[3]) if row[3] else {},
+        "is_default": bool(row[4]),
+        "created_at": row[5],
+        "updated_at": row[6],
+    }
+
+
+def list_generation_presets(db_path: str) -> list[Dict[str, Any]]:
+    """Return generation presets ordered with defaults first."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, name, description, params, is_default, created_at, updated_at
+            FROM generation_presets
+            ORDER BY is_default DESC, updated_at DESC, created_at DESC
+            """
+        )
+        rows = cursor.fetchall()
+        return [_decode_generation_preset(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def get_generation_preset(db_path: str, preset_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch a single generation preset."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, name, description, params, is_default, created_at, updated_at
+            FROM generation_presets
+            WHERE id = ?
+            """,
+            (preset_id,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return _decode_generation_preset(row)
+    finally:
+        conn.close()
+
+
+def create_generation_preset(
+    db_path: str,
+    preset_id: str,
+    name: str,
+    description: str | None,
+    params: Dict[str, Any],
+    *,
+    is_default: bool = False,
+) -> Dict[str, Any]:
+    """Create a generation preset and return the stored row."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        if is_default:
+            cursor.execute("UPDATE generation_presets SET is_default = 0")
+
+        cursor.execute(
+            """
+            INSERT INTO generation_presets (id, name, description, params, is_default)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                preset_id,
+                name,
+                description,
+                _canonical_json(params),
+                int(is_default),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return get_generation_preset(db_path, preset_id) or {}
+
+
+def update_generation_preset(
+    db_path: str,
+    preset_id: str,
+    name: str,
+    description: str | None,
+    params: Dict[str, Any],
+    *,
+    is_default: bool = False,
+) -> Optional[Dict[str, Any]]:
+    """Update a generation preset and return the stored row."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT id FROM generation_presets WHERE id = ?",
+            (preset_id,),
+        )
+        if not cursor.fetchone():
+            return None
+
+        if is_default:
+            cursor.execute(
+                "UPDATE generation_presets SET is_default = 0 WHERE id != ?",
+                (preset_id,),
+            )
+
+        cursor.execute(
+            """
+            UPDATE generation_presets
+            SET name = ?,
+                description = ?,
+                params = ?,
+                is_default = ?,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (
+                name,
+                description,
+                _canonical_json(params),
+                int(is_default),
+                preset_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return get_generation_preset(db_path, preset_id)
+
+
+def delete_generation_preset(db_path: str, preset_id: str) -> bool:
+    """Delete a generation preset."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM generation_presets WHERE id = ?", (preset_id,))
+        conn.commit()
+        return cursor.rowcount > 0
+    finally:
+        conn.close()

--- a/web/db_source_policies.py
+++ b/web/db_source_policies.py
@@ -1,0 +1,165 @@
+"""Source policy persistence helpers for the canonical web runtime."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Dict, Optional, cast
+
+try:
+    import db_core as _db_core
+except ImportError:
+    from web import db_core as _db_core  # pragma: no cover
+
+SOURCE_POLICY_ALLOW = "allow"
+SOURCE_POLICY_BLOCK = "block"
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    return cast(sqlite3.Connection, _db_core.connect_db(db_path))
+
+
+def _decode_source_policy(row: tuple[Any, ...]) -> Dict[str, Any]:
+    return {
+        "id": row[0],
+        "pattern": row[1],
+        "policy_type": row[2],
+        "is_active": bool(row[3]),
+        "created_at": row[4],
+        "updated_at": row[5],
+    }
+
+
+def list_source_policies(db_path: str) -> list[Dict[str, Any]]:
+    """Return source policy rows ordered by type and recency."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, pattern, policy_type, is_active, created_at, updated_at
+            FROM source_policies
+            ORDER BY policy_type ASC, updated_at DESC, created_at DESC
+            """
+        )
+        rows = cursor.fetchall()
+        return [_decode_source_policy(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def get_source_policy(db_path: str, policy_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch a single source policy row."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, pattern, policy_type, is_active, created_at, updated_at
+            FROM source_policies
+            WHERE id = ?
+            """,
+            (policy_id,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return _decode_source_policy(row)
+    finally:
+        conn.close()
+
+
+def create_source_policy(
+    db_path: str,
+    policy_id: str,
+    pattern: str,
+    policy_type: str,
+    *,
+    is_active: bool = True,
+) -> Dict[str, Any]:
+    """Create a source policy row and return it."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO source_policies (id, pattern, policy_type, is_active)
+            VALUES (?, ?, ?, ?)
+            """,
+            (policy_id, pattern, policy_type, int(is_active)),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return get_source_policy(db_path, policy_id) or {}
+
+
+def update_source_policy(
+    db_path: str,
+    policy_id: str,
+    pattern: str,
+    policy_type: str,
+    *,
+    is_active: bool = True,
+) -> Optional[Dict[str, Any]]:
+    """Update an existing source policy row."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM source_policies WHERE id = ?", (policy_id,))
+        if not cursor.fetchone():
+            return None
+
+        cursor.execute(
+            """
+            UPDATE source_policies
+            SET pattern = ?,
+                policy_type = ?,
+                is_active = ?,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (pattern, policy_type, int(is_active), policy_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return get_source_policy(db_path, policy_id)
+
+
+def delete_source_policy(db_path: str, policy_id: str) -> bool:
+    """Delete a source policy row."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM source_policies WHERE id = ?", (policy_id,))
+        conn.commit()
+        return cursor.rowcount > 0
+    finally:
+        conn.close()
+
+
+def get_active_source_policies(db_path: str) -> Dict[str, list[str]]:
+    """Return active source policy patterns grouped by allow/block type."""
+    conn = _connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT pattern, policy_type
+            FROM source_policies
+            WHERE is_active = 1
+            ORDER BY policy_type ASC, updated_at DESC
+            """
+        )
+        allowlist: list[str] = []
+        blocklist: list[str] = []
+        for pattern, policy_type in cursor.fetchall():
+            if policy_type == SOURCE_POLICY_ALLOW:
+                allowlist.append(str(pattern))
+            elif policy_type == SOURCE_POLICY_BLOCK:
+                blocklist.append(str(pattern))
+        return {"allowlist": allowlist, "blocklist": blocklist}
+    finally:
+        conn.close()

--- a/web/db_state.py
+++ b/web/db_state.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import os
 import sqlite3
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, cast
 
 try:
     import db_core as _db_core
@@ -28,6 +28,16 @@ try:
 except ImportError:
     from web import db_analytics as _db_analytics  # pragma: no cover
 
+try:
+    import db_presets as _db_presets
+except ImportError:
+    from web import db_presets as _db_presets  # pragma: no cover
+
+try:
+    import db_source_policies as _db_source_policies
+except ImportError:
+    from web import db_source_policies as _db_source_policies  # pragma: no cover
+
 APPROVAL_STATUS_NOT_REQUESTED = _db_history.APPROVAL_STATUS_NOT_REQUESTED
 APPROVAL_STATUS_PENDING = _db_history.APPROVAL_STATUS_PENDING
 APPROVAL_STATUS_APPROVED = _db_history.APPROVAL_STATUS_APPROVED
@@ -39,8 +49,8 @@ DELIVERY_STATUS_APPROVED = _db_history.DELIVERY_STATUS_APPROVED
 DELIVERY_STATUS_SENT = _db_history.DELIVERY_STATUS_SENT
 DELIVERY_STATUS_SEND_FAILED = _db_history.DELIVERY_STATUS_SEND_FAILED
 
-SOURCE_POLICY_ALLOW = "allow"
-SOURCE_POLICY_BLOCK = "block"
+SOURCE_POLICY_ALLOW = _db_source_policies.SOURCE_POLICY_ALLOW
+SOURCE_POLICY_BLOCK = _db_source_policies.SOURCE_POLICY_BLOCK
 
 
 def is_feature_enabled(env_var: str, default: bool = True) -> bool:
@@ -75,6 +85,17 @@ search_archive_entries = _db_archive.search_archive_entries
 record_analytics_event = _db_analytics.record_analytics_event
 list_analytics_events = _db_analytics.list_analytics_events
 get_analytics_dashboard_data = _db_analytics.get_analytics_dashboard_data
+list_generation_presets = _db_presets.list_generation_presets
+get_generation_preset = _db_presets.get_generation_preset
+create_generation_preset = _db_presets.create_generation_preset
+update_generation_preset = _db_presets.update_generation_preset
+delete_generation_preset = _db_presets.delete_generation_preset
+list_source_policies = _db_source_policies.list_source_policies
+get_source_policy = _db_source_policies.get_source_policy
+create_source_policy = _db_source_policies.create_source_policy
+update_source_policy = _db_source_policies.update_source_policy
+delete_source_policy = _db_source_policies.delete_source_policy
+get_active_source_policies = _db_source_policies.get_active_source_policies
 
 
 def _connect(db_path: str) -> sqlite3.Connection:
@@ -163,315 +184,5 @@ def mark_outbox_failed(db_path: str, send_key: str, error_message: str) -> None:
             (error_message, send_key),
         )
         conn.commit()
-    finally:
-        conn.close()
-
-
-def list_generation_presets(db_path: str) -> list[Dict[str, Any]]:
-    """Return generation presets ordered with defaults first."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT id, name, description, params, is_default, created_at, updated_at
-            FROM generation_presets
-            ORDER BY is_default DESC, updated_at DESC, created_at DESC
-            """
-        )
-        rows = cursor.fetchall()
-        return [
-            {
-                "id": row[0],
-                "name": row[1],
-                "description": row[2],
-                "params": json.loads(row[3]) if row[3] else {},
-                "is_default": bool(row[4]),
-                "created_at": row[5],
-                "updated_at": row[6],
-            }
-            for row in rows
-        ]
-    finally:
-        conn.close()
-
-
-def get_generation_preset(db_path: str, preset_id: str) -> Optional[Dict[str, Any]]:
-    """Fetch a single generation preset."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT id, name, description, params, is_default, created_at, updated_at
-            FROM generation_presets
-            WHERE id = ?
-            """,
-            (preset_id,),
-        )
-        row = cursor.fetchone()
-        if not row:
-            return None
-        return {
-            "id": row[0],
-            "name": row[1],
-            "description": row[2],
-            "params": json.loads(row[3]) if row[3] else {},
-            "is_default": bool(row[4]),
-            "created_at": row[5],
-            "updated_at": row[6],
-        }
-    finally:
-        conn.close()
-
-
-def create_generation_preset(
-    db_path: str,
-    preset_id: str,
-    name: str,
-    description: str | None,
-    params: Dict[str, Any],
-    *,
-    is_default: bool = False,
-) -> Dict[str, Any]:
-    """Create a generation preset and return the stored row."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        if is_default:
-            cursor.execute("UPDATE generation_presets SET is_default = 0")
-
-        cursor.execute(
-            """
-            INSERT INTO generation_presets (id, name, description, params, is_default)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (
-                preset_id,
-                name,
-                description,
-                canonical_json(params),
-                int(is_default),
-            ),
-        )
-        conn.commit()
-    finally:
-        conn.close()
-
-    return get_generation_preset(db_path, preset_id) or {}
-
-
-def update_generation_preset(
-    db_path: str,
-    preset_id: str,
-    name: str,
-    description: str | None,
-    params: Dict[str, Any],
-    *,
-    is_default: bool = False,
-) -> Optional[Dict[str, Any]]:
-    """Update a generation preset and return the stored row."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute(
-            "SELECT id FROM generation_presets WHERE id = ?",
-            (preset_id,),
-        )
-        if not cursor.fetchone():
-            return None
-
-        if is_default:
-            cursor.execute(
-                "UPDATE generation_presets SET is_default = 0 WHERE id != ?",
-                (preset_id,),
-            )
-
-        cursor.execute(
-            """
-            UPDATE generation_presets
-            SET name = ?,
-                description = ?,
-                params = ?,
-                is_default = ?,
-                updated_at = CURRENT_TIMESTAMP
-            WHERE id = ?
-            """,
-            (
-                name,
-                description,
-                canonical_json(params),
-                int(is_default),
-                preset_id,
-            ),
-        )
-        conn.commit()
-    finally:
-        conn.close()
-
-    return get_generation_preset(db_path, preset_id)
-
-
-def delete_generation_preset(db_path: str, preset_id: str) -> bool:
-    """Delete a generation preset."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute("DELETE FROM generation_presets WHERE id = ?", (preset_id,))
-        conn.commit()
-        return cursor.rowcount > 0
-    finally:
-        conn.close()
-
-
-def list_source_policies(db_path: str) -> list[Dict[str, Any]]:
-    """Return source policy rows ordered by type and recency."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT id, pattern, policy_type, is_active, created_at, updated_at
-            FROM source_policies
-            ORDER BY policy_type ASC, updated_at DESC, created_at DESC
-            """
-        )
-        rows = cursor.fetchall()
-        return [
-            {
-                "id": row[0],
-                "pattern": row[1],
-                "policy_type": row[2],
-                "is_active": bool(row[3]),
-                "created_at": row[4],
-                "updated_at": row[5],
-            }
-            for row in rows
-        ]
-    finally:
-        conn.close()
-
-
-def get_source_policy(db_path: str, policy_id: str) -> Optional[Dict[str, Any]]:
-    """Fetch a single source policy row."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT id, pattern, policy_type, is_active, created_at, updated_at
-            FROM source_policies
-            WHERE id = ?
-            """,
-            (policy_id,),
-        )
-        row = cursor.fetchone()
-        if not row:
-            return None
-        return {
-            "id": row[0],
-            "pattern": row[1],
-            "policy_type": row[2],
-            "is_active": bool(row[3]),
-            "created_at": row[4],
-            "updated_at": row[5],
-        }
-    finally:
-        conn.close()
-
-
-def create_source_policy(
-    db_path: str,
-    policy_id: str,
-    pattern: str,
-    policy_type: str,
-    *,
-    is_active: bool = True,
-) -> Dict[str, Any]:
-    """Create a source policy row and return it."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            INSERT INTO source_policies (id, pattern, policy_type, is_active)
-            VALUES (?, ?, ?, ?)
-            """,
-            (policy_id, pattern, policy_type, int(is_active)),
-        )
-        conn.commit()
-    finally:
-        conn.close()
-
-    return get_source_policy(db_path, policy_id) or {}
-
-
-def update_source_policy(
-    db_path: str,
-    policy_id: str,
-    pattern: str,
-    policy_type: str,
-    *,
-    is_active: bool = True,
-) -> Optional[Dict[str, Any]]:
-    """Update an existing source policy row."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute("SELECT id FROM source_policies WHERE id = ?", (policy_id,))
-        if not cursor.fetchone():
-            return None
-
-        cursor.execute(
-            """
-            UPDATE source_policies
-            SET pattern = ?,
-                policy_type = ?,
-                is_active = ?,
-                updated_at = CURRENT_TIMESTAMP
-            WHERE id = ?
-            """,
-            (pattern, policy_type, int(is_active), policy_id),
-        )
-        conn.commit()
-    finally:
-        conn.close()
-
-    return get_source_policy(db_path, policy_id)
-
-
-def delete_source_policy(db_path: str, policy_id: str) -> bool:
-    """Delete a source policy row."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute("DELETE FROM source_policies WHERE id = ?", (policy_id,))
-        conn.commit()
-        return cursor.rowcount > 0
-    finally:
-        conn.close()
-
-
-def get_active_source_policies(db_path: str) -> Dict[str, list[str]]:
-    """Return active source policy patterns grouped by allow/block type."""
-    conn = _connect(db_path)
-    try:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT pattern, policy_type
-            FROM source_policies
-            WHERE is_active = 1
-            ORDER BY policy_type ASC, updated_at DESC
-            """
-        )
-        allowlist: list[str] = []
-        blocklist: list[str] = []
-        for pattern, policy_type in cursor.fetchall():
-            if policy_type == SOURCE_POLICY_ALLOW:
-                allowlist.append(str(pattern))
-            elif policy_type == SOURCE_POLICY_BLOCK:
-                blocklist.append(str(pattern))
-        return {"allowlist": allowlist, "blocklist": blocklist}
     finally:
         conn.close()


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Extract generation preset CRUD and source policy persistence from `web/db_state.py` into dedicated storage modules while keeping `db_state` as the compatibility facade. This keeps preset/policy concerns separate from history, archive, analytics, and outbox state.

## Scope
### In Scope
- Add `web/db_presets.py` for generation preset CRUD helpers
- Add `web/db_source_policies.py` for source policy CRUD and active allow/block lookups
- Preserve the existing `web.db_state` import surface through facade aliases and constant re-exports
- Add direct unit tests for the new preset and source-policy stores

### Out of Scope
- Archive/analytics logic
- Scheduler refactors
- History/idempotency changes

## Delivery Unit
- RR: #227
- Delivery Unit ID: DU-20260309-db-state-preset-source-policy
- Merge Boundary: squash merge of this PR
- Rollback Boundary: revert commit `a93aeef`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): direct module tests for preset/source-policy stores

### Commands and Results
```bash
./.venv/bin/python -m black web/db_presets.py web/db_source_policies.py web/db_state.py tests/unit_tests/test_db_presets.py tests/unit_tests/test_db_source_policies.py
# PASS

./.venv/bin/python -m isort web/db_presets.py web/db_source_policies.py web/db_state.py tests/unit_tests/test_db_presets.py tests/unit_tests/test_db_source_policies.py
# PASS

COVERAGE_FILE=.coverage.rr12.dbpresets ./.venv/bin/python -m pytest tests/unit_tests/test_db_presets.py -q
# PASS (2 passed)

COVERAGE_FILE=.coverage.rr12.dbsource ./.venv/bin/python -m pytest tests/unit_tests/test_db_source_policies.py -q
# PASS (2 passed)

COVERAGE_FILE=.coverage.rr12.presets ./.venv/bin/python -m pytest tests/unit_tests/test_web_preset_routes.py -q
# PASS (3 passed)

COVERAGE_FILE=.coverage.rr12.source_filter ./.venv/bin/python -m pytest tests/unit_tests/test_source_policy_filtering.py -q
# PASS (2 passed)

COVERAGE_FILE=.coverage.rr12.source_task ./.venv/bin/python -m pytest tests/unit_tests/test_web_source_policy_task.py -q
# PASS (1 passed)

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: facade aliasing in `web/db_state.py` could miss a legacy preset/source-policy entry point and break an indirect caller or route import.
- Rollback: revert commit `a93aeef` to restore preset/source-policy storage helpers back into `web/db_state.py`.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 변경 없음. RR-12는 preset/source-policy persistence만 분리했고 generation job state나 idempotency 경로는 건드리지 않았습니다.
- Outbox/send_key 중복 방지 결과: 변경 없음. outbox/send_key helper는 그대로 `web/db_state.py`에 남겨 두었습니다.
- import-time side effect 제거 여부: 신규 모듈은 저장소 함수와 상수 정의만 포함하며 추가 import-time side effect는 없습니다.

## Not Run (with reason)
- 없음
