### PR TITLE
codex(test): lock compose compatibility contracts

### DIFF
--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,7 +1,8 @@
 import os
 import sys
 import unittest
-from unittest.mock import mock_open, patch
+from pathlib import Path
+from unittest.mock import patch
 
 from newsletter.compose import compose_newsletter_html
 
@@ -11,6 +12,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 
 class TestCompose(unittest.TestCase):
+    template_dir = str(Path(__file__).resolve().parents[1] / "templates")
 
     def test_compose_newsletter_html_success(self):
         summaries = [
@@ -29,7 +31,6 @@ class TestCompose(unittest.TestCase):
                 "date": "2025-01-02",
             },
         ]
-        template_dir = "c:\\Development\\newsletter-generator\\templates"
         template_name = "newsletter_template.html"
 
         # Mocking os.getenv to control generation_date and generation_timestamp
@@ -38,7 +39,7 @@ class TestCompose(unittest.TestCase):
             {"GENERATION_DATE": "2025-05-10", "GENERATION_TIMESTAMP": "12:34:56"},
         ):
             html_content = compose_newsletter_html(
-                summaries, template_dir, template_name
+                summaries, self.template_dir, template_name
             )
 
         # Test that the basic structure is correct
@@ -63,14 +64,13 @@ class TestCompose(unittest.TestCase):
 
     def test_compose_newsletter_html_empty_summaries(self):
         summaries = []
-        template_dir = "c:\\Development\\newsletter-generator\\templates"
         template_name = "newsletter_template.html"
         with patch.dict(
             os.environ,
             {"GENERATION_DATE": "2025-05-10", "GENERATION_TIMESTAMP": "12:34:56"},
         ):
             html_content = compose_newsletter_html(
-                summaries, template_dir, template_name
+                summaries, self.template_dir, template_name
             )
         self.assertIn("2025-05-10", html_content)
         self.assertIn(
@@ -90,13 +90,12 @@ class TestCompose(unittest.TestCase):
                 "summary_text": "Summary 1",
             }
         ]
-        template_dir = "c:\\Development\\newsletter-generator\\templates"
         template_name = "non_existent_template.html"
 
         with self.assertRaises(
             Exception
         ):  # Expecting a Jinja2 TemplateNotFound error, but Exception is broader
-            compose_newsletter_html(summaries, template_dir, template_name)
+            compose_newsletter_html(summaries, self.template_dir, template_name)
 
 
 if __name__ == "__main__":

--- a/tests/test_email_compatibility.py
+++ b/tests/test_email_compatibility.py
@@ -11,21 +11,16 @@ Email Compatibility 테스트 모듈
 """
 
 import os
-import re
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from bs4 import BeautifulSoup
 
-# 프로젝트 루트를 Python 경로에 추가
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, project_root)
-
-from newsletter import config
 from newsletter.chains import get_newsletter_chain
 from newsletter.compose import compose_newsletter
+
+project_root = str(Path(__file__).resolve().parents[1])
 
 
 class TestEmailCompatibilityCore:
@@ -90,9 +85,7 @@ class TestEmailCompatibilityCore:
                     "explanation": "기계가 데이터로부터 패턴을 학습하는 기술입니다.",
                 }
             ],
-            "food_for_thought": {
-                "message": "AI 기술 발전에 대응하기 위한 전략적 사고가 필요합니다."
-            },
+            "food_for_thought": {"message": "AI 기술 발전에 대응하기 위한 전략적 사고가 필요합니다."},
             "recipient_greeting": "안녕하세요,",
             "introduction_message": "이번 주 AI 기술 동향을 정리해 드립니다.",
             "closing_message": "다음 주에 더 유익한 정보로 찾아뵙겠습니다.",
@@ -122,9 +115,7 @@ class TestEmailCompatibilityCore:
 
         # 이메일 호환 구조 확인 (테이블 기반 레이아웃)
         tables = soup.find_all("table")
-        assert (
-            len(tables) > 0
-        ), "Email-compatible 템플릿은 테이블 기반 레이아웃을 사용해야 합니다"
+        assert len(tables) > 0, "Email-compatible 템플릿은 테이블 기반 레이아웃을 사용해야 합니다"
 
     def test_inline_css_processing(self, sample_data):
         """CSS가 인라인으로 처리되는지 테스트"""
@@ -135,15 +126,11 @@ class TestEmailCompatibilityCore:
 
         # 인라인 스타일이 존재하는지 확인
         elements_with_style = soup.find_all(attrs={"style": True})
-        assert (
-            len(elements_with_style) > 0
-        ), "Email-compatible 템플릿은 인라인 CSS를 사용해야 합니다"
+        assert len(elements_with_style) > 0, "Email-compatible 템플릿은 인라인 CSS를 사용해야 합니다"
 
         # CSS 변수 사용하지 않는지 확인
         style_content = str(soup)
-        assert (
-            "var(--" not in style_content
-        ), "Email-compatible 템플릿은 CSS 변수를 사용하면 안됩니다"
+        assert "var(--" not in style_content, "Email-compatible 템플릿은 CSS 변수를 사용하면 안됩니다"
 
     def test_template_style_handling(self, sample_data):
         """template_style에 따른 다른 콘텐츠 처리 테스트"""
@@ -159,9 +146,7 @@ class TestEmailCompatibilityCore:
         sample_data["template_style"] = "compact"
         compact_html = compose_newsletter(sample_data, template_dir, "email_compatible")
 
-        assert (
-            detailed_html != compact_html
-        ), "Detailed와 Compact 스타일은 다른 결과를 생성해야 합니다"
+        assert detailed_html != compact_html, "Detailed와 Compact 스타일은 다른 결과를 생성해야 합니다"
 
         # 두 결과 모두 유효한 HTML인지 확인
         for html in [detailed_html, compact_html]:
@@ -186,9 +171,7 @@ class TestEmailCompatibilityCore:
         for field in required_fields:
             field_value = sample_data.get(field, "")
             if field_value:
-                assert (
-                    field_value in html_content
-                ), f"필수 필드 '{field}'가 HTML에 포함되지 않았습니다"
+                assert field_value in html_content, f"필수 필드 '{field}'가 HTML에 포함되지 않았습니다"
 
     def test_content_integrity(self, sample_data):
         """콘텐츠 무결성 테스트 - 모든 데이터가 손실 없이 포함되는지"""
@@ -200,9 +183,7 @@ class TestEmailCompatibilityCore:
             for article in sample_data["top_articles"]:
                 title = article.get("title", "")
                 if title:
-                    assert (
-                        title in html_content
-                    ), f"기사 제목 '{title}'이 누락되었습니다"
+                    assert title in html_content, f"기사 제목 '{title}'이 누락되었습니다"
 
         # 정의(definitions)가 포함되었는지 확인
         if sample_data.get("definitions"):
@@ -272,34 +253,52 @@ class TestEmailCompatibilityIntegration:
             "template_style": "detailed",
         }
 
-    @patch("newsletter.chains.get_llm")
-    def test_full_pipeline_detailed_email_compatible(
-        self, mock_llm, mock_articles_data
-    ):
+    def test_full_pipeline_detailed_email_compatible(self, mock_articles_data):
         """Detailed + Email-Compatible 전체 파이프라인 테스트"""
-        # LLM 모킹
-        mock_llm_instance = MagicMock()
-        mock_llm.return_value = mock_llm_instance
+        categorization_chain = MagicMock()
+        categorization_chain.invoke.return_value = {
+            "categories": [{"title": "AI 기술 발전", "article_indices": [1, 2]}]
+        }
+        summarization_chain = MagicMock()
+        summarization_chain.invoke.return_value = {
+            "sections": [
+                {
+                    "title": "AI 기술 발전",
+                    "summary_paragraphs": ["AI 기술이 발전하고 있습니다."],
+                    "definitions": [{"term": "AI", "explanation": "인공지능"}],
+                    "news_links": [
+                        {
+                            "title": "AI 기술의 미래",
+                            "url": "https://example.com/ai-future",
+                            "source_and_date": "TechNews · 2025-05-29",
+                        }
+                    ],
+                }
+            ]
+        }
+        composition_chain = MagicMock()
+        composition_chain.invoke.return_value = {
+            "newsletter_topic": "AI 기술",
+            "generation_date": "2025-05-30",
+            "recipient_greeting": "안녕하세요",
+            "introduction_message": "AI 기술 동향입니다",
+            "food_for_thought": {"message": "AI에 대해 생각해봅시다"},
+            "closing_message": "감사합니다",
+            "editor_signature": "편집자",
+        }
 
-        # 카테고리 분류 응답 모킹
-        mock_llm_instance.invoke.side_effect = [
-            # 카테고리 분류 응답
-            MagicMock(
-                content='{"categories": [{"title": "AI 기술 발전", "article_indices": [1, 2]}]}'
-            ),
-            # 요약 응답
-            MagicMock(
-                content='{"summary_paragraphs": ["AI 기술이 발전하고 있습니다."], "definitions": [{"term": "AI", "explanation": "인공지능"}], "news_links": [{"title": "AI 기술의 미래", "url": "https://example.com/ai-future", "source_and_date": "TechNews · 2025-05-29"}]}'
-            ),
-            # 종합 구성 응답
-            MagicMock(
-                content='{"newsletter_topic": "AI 기술", "generation_date": "2025-05-30", "recipient_greeting": "안녕하세요", "introduction_message": "AI 기술 동향입니다", "food_for_thought": {"message": "AI에 대해 생각해봅시다"}, "closing_message": "감사합니다", "editor_signature": "편집자"}'
-            ),
-        ]
-
-        # 체인 실행
-        newsletter_chain = get_newsletter_chain(is_compact=False)
-        result = newsletter_chain.invoke(mock_articles_data)
+        with patch(
+            "newsletter.chains.create_categorization_chain",
+            return_value=categorization_chain,
+        ), patch(
+            "newsletter.chains.create_summarization_chain",
+            return_value=summarization_chain,
+        ), patch(
+            "newsletter.chains.create_composition_chain",
+            return_value=composition_chain,
+        ):
+            newsletter_chain = get_newsletter_chain(is_compact=False)
+            result = newsletter_chain.invoke(mock_articles_data)
 
         # 결과 검증
         assert "html" in result
@@ -315,31 +314,52 @@ class TestEmailCompatibilityIntegration:
         assert soup.find("html") is not None
         assert soup.find("body") is not None
 
-    @patch("newsletter.chains.get_llm")
-    def test_full_pipeline_compact_email_compatible(self, mock_llm, mock_articles_data):
+    def test_full_pipeline_compact_email_compatible(self, mock_articles_data):
         """Compact + Email-Compatible 전체 파이프라인 테스트"""
         # 설정 변경
         mock_articles_data["template_style"] = "compact"
+        categorization_chain = MagicMock()
+        categorization_chain.invoke.return_value = {
+            "categories": [{"title": "AI 기술 발전", "article_indices": [1, 2]}]
+        }
+        summarization_chain = MagicMock()
+        summarization_chain.invoke.return_value = {
+            "sections": [
+                {
+                    "title": "AI 기술 발전",
+                    "intro": "AI 기술 동향입니다",
+                    "definitions": [{"term": "AI", "explanation": "인공지능"}],
+                    "articles": [
+                        {
+                            "title": "AI 기술의 미래",
+                            "url": "https://example.com/ai-future",
+                            "source_and_date": "TechNews · 2025-05-29",
+                        }
+                    ],
+                }
+            ]
+        }
+        compact_result = {
+            "html": "<html><body><p>compact</p></body></html>",
+            "structured_data": {
+                "grouped_sections": summarization_chain.invoke.return_value["sections"]
+            },
+            "sections": summarization_chain.invoke.return_value["sections"],
+            "mode": "compact",
+        }
 
-        # LLM 모킹
-        mock_llm_instance = MagicMock()
-        mock_llm.return_value = mock_llm_instance
-
-        # 카테고리 분류 응답 모킹
-        mock_llm_instance.invoke.side_effect = [
-            # 카테고리 분류 응답
-            MagicMock(
-                content='{"categories": [{"title": "AI 기술 발전", "article_indices": [1, 2]}]}'
-            ),
-            # 요약 응답 (compact 형식)
-            MagicMock(
-                content='{"intro": "AI 기술 동향입니다", "definitions": [{"term": "AI", "explanation": "인공지능"}], "news_links": [{"title": "AI 기술의 미래", "url": "https://example.com/ai-future", "source_and_date": "TechNews · 2025-05-29"}]}'
-            ),
-        ]
-
-        # 체인 실행
-        newsletter_chain = get_newsletter_chain(is_compact=True)
-        result = newsletter_chain.invoke(mock_articles_data)
+        with patch(
+            "newsletter.chains.create_categorization_chain",
+            return_value=categorization_chain,
+        ), patch(
+            "newsletter.chains.create_summarization_chain",
+            return_value=summarization_chain,
+        ), patch(
+            "newsletter.chains.build_compact_newsletter_result",
+            return_value=compact_result,
+        ):
+            newsletter_chain = get_newsletter_chain(is_compact=True)
+            result = newsletter_chain.invoke(mock_articles_data)
 
         # 결과 검증
         assert "html" in result
@@ -352,18 +372,22 @@ class TestEmailCompatibilityIntegration:
 
     def test_error_handling_with_email_compatible(self, mock_articles_data):
         """Email-compatible 모드에서 오류 처리 테스트"""
-        # 잘못된 데이터로 테스트
-        invalid_data = {
-            "articles": [],  # 빈 기사 리스트
-            "keywords": "",
-            "email_compatible": True,
-            "template_style": "detailed",
-        }
-
         # 체인이 오류를 적절히 처리하는지 확인
         try:
-            newsletter_chain = get_newsletter_chain(is_compact=False)
-            # 에러 없이 실행되어야 함 (fallback 처리)
+            with patch(
+                "newsletter.chains.create_categorization_chain",
+                return_value=MagicMock(),
+            ), patch(
+                "newsletter.chains.create_summarization_chain",
+                return_value=MagicMock(),
+            ), patch(
+                "newsletter.chains.create_composition_chain",
+                return_value=MagicMock(),
+            ), patch(
+                "newsletter.chains.create_rendering_chain",
+                return_value=MagicMock(),
+            ):
+                get_newsletter_chain(is_compact=False)
         except Exception as e:
             pytest.fail(f"Email-compatible 모드에서 예상치 못한 오류 발생: {e}")
 
@@ -421,9 +445,7 @@ class TestEmailCompatibilityValidation:
         ]
 
         for css_prop in unsupported_css:
-            assert (
-                css_prop not in html_content
-            ), f"이메일에서 지원되지 않는 CSS 속성 사용: {css_prop}"
+            assert css_prop not in html_content, f"이메일에서 지원되지 않는 CSS 속성 사용: {css_prop}"
 
     def test_link_validation(self):
         """링크 유효성 검증"""

--- a/tests/unit_tests/test_compose_contract_lock.py
+++ b/tests/unit_tests/test_compose_contract_lock.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from newsletter.compose import (
+    compose_compact_newsletter_html,
+    compose_newsletter,
+    compose_newsletter_html,
+)
+from newsletter_core.application.generation.compose import (
+    compose_compact_newsletter_html as core_compose_compact_newsletter_html,
+)
+from newsletter_core.application.generation.compose import (
+    compose_newsletter as core_compose_newsletter,
+)
+from newsletter_core.application.generation.compose import (
+    compose_newsletter_html as core_compose_newsletter_html,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE_DIR = str(PROJECT_ROOT / "templates")
+
+
+@pytest.fixture
+def sample_newsletter_data():
+    return {
+        "newsletter_topic": "AI 기술 동향",
+        "domain": "AI",
+        "generation_date": "2026-03-09",
+        "generation_timestamp": "09:30:00",
+        "search_keywords": ["AI", "머신러닝", "반도체"],
+        "sections": [
+            {
+                "title": "AI 기술 발전",
+                "summary_paragraphs": ["AI 기술이 빠르게 발전하고 있습니다."],
+                "definitions": [
+                    {
+                        "term": "머신러닝",
+                        "explanation": "데이터에서 패턴을 학습하는 기술입니다.",
+                    }
+                ],
+                "news_links": [
+                    {
+                        "title": "AI 기술 혁신",
+                        "url": "https://example.com/ai",
+                        "source_and_date": "Tech News, 2026-03-08",
+                    }
+                ],
+            },
+            {
+                "title": "반도체 시장",
+                "summary_paragraphs": ["AI 수요가 반도체 시장을 이끌고 있습니다."],
+                "definitions": [
+                    {
+                        "term": "NPU",
+                        "explanation": "신경망 연산에 특화된 처리 장치입니다.",
+                    }
+                ],
+                "news_links": [
+                    {
+                        "title": "AI 칩 수요 증가",
+                        "url": "https://example.com/chips",
+                        "source_and_date": "Market Watch, 2026-03-07",
+                    }
+                ],
+            },
+        ],
+        "food_for_thought": {"message": "기술 변화 속도에 맞는 포트폴리오 재정렬이 필요합니다."},
+        "recipient_greeting": "안녕하세요,",
+        "introduction_message": "이번 주 주요 산업 동향을 정리했습니다.",
+        "closing_message": "다음 주에 다시 찾아뵙겠습니다.",
+        "editor_signature": "편집팀 드림",
+        "company_name": "Tech Insights",
+    }
+
+
+def test_compose_shim_exposes_core_entrypoints():
+    assert compose_newsletter is core_compose_newsletter
+    assert compose_newsletter_html is core_compose_newsletter_html
+    assert compose_compact_newsletter_html is core_compose_compact_newsletter_html
+
+
+def test_detailed_wrapper_matches_default_compose_output(sample_newsletter_data):
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("GENERATION_DATE", "2026-03-09")
+        monkeypatch.setenv("GENERATION_TIMESTAMP", "09:30:00")
+
+        wrapper_html = compose_newsletter_html(
+            deepcopy(sample_newsletter_data),
+            TEMPLATE_DIR,
+            "newsletter_template.html",
+        )
+        direct_html = compose_newsletter(
+            deepcopy(sample_newsletter_data),
+            TEMPLATE_DIR,
+            "detailed",
+        )
+
+    assert wrapper_html == direct_html
+    assert "검색 키워드: AI, 머신러닝, 반도체" in wrapper_html
+
+
+def test_compact_wrapper_matches_default_compose_output(sample_newsletter_data):
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("GENERATION_DATE", "2026-03-09")
+        monkeypatch.setenv("GENERATION_TIMESTAMP", "09:30:00")
+
+        wrapper_html = compose_compact_newsletter_html(
+            deepcopy(sample_newsletter_data),
+            TEMPLATE_DIR,
+            "newsletter_template_compact.html",
+        )
+        direct_html = compose_newsletter(
+            deepcopy(sample_newsletter_data),
+            TEMPLATE_DIR,
+            "compact",
+        )
+
+    assert wrapper_html == direct_html
+    assert "AI 기술 혁신" in wrapper_html
+
+
+def test_compose_normalizes_list_input_into_detailed_html():
+    articles = [
+        {
+            "title": "첫 번째 기사",
+            "url": "https://example.com/first",
+            "summary_text": "첫 번째 기사 요약입니다.",
+            "source": "Example Source",
+            "date": "2026-03-08",
+        },
+        {
+            "title": "두 번째 기사",
+            "url": "https://example.com/second",
+            "content": "두 번째 기사 본문입니다.",
+            "source": "Another Source",
+            "date": "2026-03-07",
+        },
+    ]
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("GENERATION_DATE", "2026-03-09")
+        monkeypatch.setenv("GENERATION_TIMESTAMP", "09:30:00")
+        html = compose_newsletter(articles, TEMPLATE_DIR, "detailed")
+
+    assert "첫 번째 기사" in html
+    assert "https://example.com/first" in html
+    assert "두 번째 기사" in html
+    assert "2026-03-09" in html
+    assert "09:30:00" in html
+
+
+def test_email_compatible_preserves_explicit_title_and_keyword_rendering(
+    sample_newsletter_data,
+):
+    data = {
+        **sample_newsletter_data,
+        "newsletter_title": "맞춤 제목",
+        "template_style": "detailed",
+    }
+
+    html = compose_newsletter(data, TEMPLATE_DIR, "email_compatible")
+
+    assert "맞춤 제목" in html
+    assert "검색 키워드: AI, 머신러닝, 반도체" in html
+    assert "안녕하세요," in html
+
+
+def test_compose_derives_domain_title_when_explicit_title_is_missing(
+    sample_newsletter_data,
+):
+    data = {
+        key: value
+        for key, value in sample_newsletter_data.items()
+        if key != "newsletter_title"
+    }
+
+    html = compose_newsletter(data, TEMPLATE_DIR, "detailed")
+
+    assert "AI 주간 산업동향 뉴스 클리핑" in html


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Lock compose compatibility behavior before P3 refactors so wrapper equivalence, legacy shim exports, and email-compatible pipeline tests stay stable.

## Scope
### In Scope
- Add compose contract-lock tests for shim exports, wrapper equivalence, list-input normalization, explicit title handling, and domain title fallback
- Make compose template-path tests cross-platform instead of Windows-path specific
- Fix email compatibility pipeline tests to stub actual builder seams instead of relying on unavailable LLM providers

### Out of Scope
- Any compose implementation refactor
- Template HTML changes

## Delivery Unit
- RR: #239
- Delivery Unit ID: DU-20260309-compose-contract-lock
- Merge Boundary: RR-15 test-only contract lock
- Rollback Boundary: revert commit 3cb446a

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed):

### Commands and Results
```bash
COVERAGE_FILE=.coverage.rr15.contract ./.venv/bin/python -m pytest tests/unit_tests/test_compose_contract_lock.py tests/test_compose.py tests/test_unified_architecture.py tests/test_email_compatibility.py -q
# 25 passed, 2 skipped

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: compose behavior could be over-constrained by tests if future output contract intentionally changes.
- Rollback: `git revert 3cb446a`

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: N/A (test-only change)
- Outbox/send_key 중복 방지 결과: N/A (test-only change)
- import-time side effect 제거 여부: no runtime import-time side effects introduced

## Not Run (with reason)
- Real-time schedule execution manual verification remains skipped by existing test gate (`tests/integration/test_schedule_execution.py::test_real_time_schedule_execution`)
- Actual email send verification remains skipped because `TEST_EMAIL_RECIPIENT` is not configured locally
