### PR TITLE
codex(refactor): extract compose render context

### DIFF
--- a/newsletter_core/application/generation/compose.py
+++ b/newsletter_core/application/generation/compose.py
@@ -5,12 +5,12 @@ import os
 from datetime import datetime
 from typing import Any, Dict, List
 
-import yaml
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from newsletter.date_utils import extract_source_and_date, format_date_for_display
 from newsletter.utils.logger import get_logger
 
+from .compose_context import build_render_context, load_newsletter_settings
 from .compose_inputs import (
     NewsletterConfig,
     normalize_compose_input,
@@ -133,7 +133,6 @@ def render_newsletter_template(
     food_for_thought: Any,
 ) -> str:
     """템플릿을 렌더링하여 최종 HTML 생성"""
-
     env = Environment(
         loader=FileSystemLoader(template_dir),
         autoescape=select_autoescape(["html", "xml"]),
@@ -143,152 +142,14 @@ def render_newsletter_template(
     logger.debug(f"템플릿 로딩 중: {template_name}")
     template = env.get_template(template_name)
     logger.debug(f"템플릿 로딩 완료: {template_name}")
-
-    # 현재 날짜와 시간 가져오기
-    current_date = datetime.now().strftime("%Y-%m-%d")
-    current_time = datetime.now().strftime("%H:%M:%S")
-
-    generation_date = data.get(
-        "generation_date", os.environ.get("GENERATION_DATE", current_date)
+    context = build_render_context(
+        data=data,
+        config=config,
+        top_articles=top_articles,
+        grouped_sections=grouped_sections,
+        definitions=definitions,
+        food_for_thought=food_for_thought,
     )
-    generation_timestamp = data.get(
-        "generation_timestamp", os.environ.get("GENERATION_TIMESTAMP", current_time)
-    )
-
-    # 설정 파일에서 뉴스레터 설정 로드
-    newsletter_settings = load_newsletter_settings()
-
-    # 뉴스레터 제목 생성 로직 개선
-    newsletter_topic = data.get("newsletter_topic")
-    newsletter_title = data.get("newsletter_title")
-
-    # 제목이 명시적으로 설정되지 않은 경우 도메인 기반 제목 생성
-    if not newsletter_title and newsletter_topic:
-        # 도메인이 있거나 의미 있는 주제가 있는 경우 "도메인명 주간 산업 동향 뉴스 클리핑" 형식 사용
-        domain = data.get("domain")
-        if domain:
-            # 명시적 도메인이 있는 경우
-            newsletter_title = f"{domain} 주간 산업동향 뉴스 클리핑"
-        elif newsletter_topic and newsletter_topic not in [
-            "최신 산업 동향",
-            "General News",
-        ]:
-            # 의미 있는 주제가 추출된 경우
-            # "외 N개 분야" 형식이면 첫 번째 키워드만 사용
-            if " 외 " in newsletter_topic and "개 분야" in newsletter_topic:
-                main_topic = newsletter_topic.split(" 외 ")[0]
-                newsletter_title = f"{main_topic} 주간 산업 동향 뉴스 클리핑"
-            else:
-                newsletter_title = f"{newsletter_topic} 주간 산업 동향 뉴스 클리핑"
-        else:
-            newsletter_title = newsletter_settings.get(
-                "newsletter_title", config["title_default"]
-            )
-    elif not newsletter_title:
-        newsletter_title = newsletter_settings.get(
-            "newsletter_title", config["title_default"]
-        )
-
-    # 공통 컨텍스트 변수들 (설정 파일 값을 기본값으로 사용)
-    common_context = {
-        "generation_date": generation_date,
-        "generation_timestamp": generation_timestamp,
-        "newsletter_topic": newsletter_topic,
-        "newsletter_title": newsletter_title,
-        "issue_no": data.get("issue_no"),
-        "top_articles": top_articles,
-        "definitions": definitions,
-        "food_for_thought": food_for_thought,
-        "copyright_year": generation_date.split("-")[0],
-        "publisher_name": data.get(
-            "publisher_name",
-            data.get(
-                "company_name",
-                newsletter_settings.get("publisher_name", "Your Company"),
-            ),
-        ),
-        "company_name": data.get(
-            "company_name", newsletter_settings.get("company_name", "Your Company")
-        ),
-        "company_tagline": data.get(
-            "company_tagline", newsletter_settings.get("company_tagline")
-        ),
-        "footer_disclaimer": data.get(
-            "footer_disclaimer", newsletter_settings.get("footer_disclaimer")
-        ),
-        "footer_contact": data.get(
-            "footer_contact", newsletter_settings.get("footer_contact")
-        ),
-        "editor_name": data.get("editor_name", newsletter_settings.get("editor_name")),
-        "editor_email": data.get(
-            "editor_email", newsletter_settings.get("editor_email")
-        ),
-        "editor_title": data.get(
-            "editor_title", newsletter_settings.get("editor_title", "편집자")
-        ),
-    }
-
-    # 스타일별 컨텍스트 준비
-    if config["template_name"] == "newsletter_template_compact.html":
-        # Compact 템플릿용 컨텍스트
-        context = {
-            **common_context,
-            "tagline": data.get(
-                "tagline",
-                newsletter_settings.get("tagline", "이번 주, 주요 산업 동향을 미리 만나보세요."),
-            ),
-            "grouped_sections": grouped_sections,
-        }
-    elif config["template_name"] == "newsletter_template_email_compatible.html":
-        # Email-compatible 템플릿용 컨텍스트 (template_style에 따라 다른 데이터 사용)
-        context = {
-            **common_context,
-            "recipient_greeting": data.get("recipient_greeting", "안녕하세요,"),
-            "introduction_message": data.get(
-                "introduction_message",
-                "지난 한 주간의 주요 산업 동향을 정리해 드립니다.",
-            ),
-            "closing_message": data.get(
-                "closing_message",
-                "다음 주에 더 유익한 정보로 찾아뵙겠습니다. 감사합니다.",
-            ),
-            "editor_signature": data.get("editor_signature", "편집자 드림"),
-            # Email-compatible 템플릿은 template_style에 따라 다른 데이터를 사용
-            "template_style": data.get("template_style", "detailed"),
-            "grouped_sections": grouped_sections,  # compact style용
-            "sections": data.get("sections", []),  # detailed style용
-        }
-
-        # 검색 키워드 추가
-        if "search_keywords" in data and data["search_keywords"]:
-            if isinstance(data["search_keywords"], list):
-                context["search_keywords"] = ", ".join(data["search_keywords"])
-            else:
-                context["search_keywords"] = data["search_keywords"]
-    else:
-        # Detailed 템플릿용 컨텍스트
-        context = {
-            **common_context,
-            "recipient_greeting": data.get("recipient_greeting", "안녕하세요,"),
-            "introduction_message": data.get(
-                "introduction_message",
-                "지난 한 주간의 주요 산업 동향을 정리해 드립니다.",
-            ),
-            "sections": data.get("sections", []),
-            "closing_message": data.get(
-                "closing_message",
-                "다음 주에 더 유익한 정보로 찾아뵙겠습니다. 감사합니다.",
-            ),
-            "editor_signature": data.get("editor_signature", "편집자 드림"),
-        }
-
-        # 검색 키워드 추가
-        if "search_keywords" in data and data["search_keywords"]:
-            if isinstance(data["search_keywords"], list):
-                context["search_keywords"] = ", ".join(data["search_keywords"])
-            else:
-                context["search_keywords"] = data["search_keywords"]
-
     return template.render(context)
 
 
@@ -465,51 +326,6 @@ def process_compact_newsletter_data(newsletter_data: Dict[str, Any]) -> Dict[str
             compact_data["food_for_thought"] = {"message": str(food_for_thought)}
 
     return compact_data
-
-
-def load_newsletter_settings(config_file: str = "config.yml") -> Dict[str, Any]:
-    """
-    설정 파일에서 뉴스레터 설정을 로드합니다.
-
-    Args:
-        config_file: 설정 파일 경로 (호환성을 위해 유지)
-
-    Returns:
-        Dict[str, Any]: 뉴스레터 설정 딕셔너리
-    """
-    try:
-        from newsletter_core.public.settings import get_newsletter_settings
-
-        return get_newsletter_settings()
-    except ImportError:
-        # Fallback to original implementation
-        default_settings = {
-            "newsletter_title": "주간 산업 동향 뉴스 클리핑",
-            "tagline": "이번 주, 주요 산업 동향을 미리 만나보세요.",
-            "publisher_name": "Your Company",
-            "company_name": "Your Company",
-            "company_tagline": "",
-            "editor_name": "",
-            "editor_title": "편집자",
-            "editor_email": "",
-            "footer_disclaimer": "이 뉴스레터는 정보 제공을 목적으로 하며, 내용의 정확성을 보장하지 않습니다.",
-            "footer_contact": "",
-        }
-
-        try:
-            if os.path.exists(config_file):
-                with open(config_file, "r", encoding="utf-8") as f:
-                    config_data = yaml.safe_load(f)
-
-                newsletter_settings = config_data.get("newsletter_settings", {})
-                # 기본 설정과 병합
-                default_settings.update(newsletter_settings)
-        except Exception as e:
-            print(
-                f"Warning: Could not load newsletter settings from {config_file}: {e}"
-            )
-
-        return default_settings
 
 
 # Example usage (for testing purposes):

--- a/newsletter_core/application/generation/compose_context.py
+++ b/newsletter_core/application/generation/compose_context.py
@@ -1,0 +1,219 @@
+"""Render-context and settings helpers for compose."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Any, Dict, List
+
+import yaml
+
+
+def build_render_context(
+    data: Dict[str, Any],
+    config: Dict[str, Any],
+    top_articles: List[Dict[str, Any]],
+    grouped_sections: List[Dict[str, Any]],
+    definitions: List[Dict[str, str]],
+    food_for_thought: Any,
+) -> Dict[str, Any]:
+    """Build the final template context for the active compose style."""
+    generation_date, generation_timestamp = resolve_generation_metadata(data)
+    newsletter_settings = load_newsletter_settings()
+    newsletter_topic = data.get("newsletter_topic")
+    newsletter_title = resolve_newsletter_title(
+        data, newsletter_settings, config["title_default"]
+    )
+    common_context = build_common_context(
+        data=data,
+        newsletter_settings=newsletter_settings,
+        generation_date=generation_date,
+        generation_timestamp=generation_timestamp,
+        newsletter_topic=newsletter_topic,
+        newsletter_title=newsletter_title,
+        top_articles=top_articles,
+        definitions=definitions,
+        food_for_thought=food_for_thought,
+    )
+
+    if config["template_name"] == "newsletter_template_compact.html":
+        return {
+            **common_context,
+            "tagline": data.get(
+                "tagline",
+                newsletter_settings.get("tagline", "이번 주, 주요 산업 동향을 미리 만나보세요."),
+            ),
+            "grouped_sections": grouped_sections,
+        }
+
+    if config["template_name"] == "newsletter_template_email_compatible.html":
+        context = {
+            **common_context,
+            "recipient_greeting": data.get("recipient_greeting", "안녕하세요,"),
+            "introduction_message": data.get(
+                "introduction_message",
+                "지난 한 주간의 주요 산업 동향을 정리해 드립니다.",
+            ),
+            "closing_message": data.get(
+                "closing_message",
+                "다음 주에 더 유익한 정보로 찾아뵙겠습니다. 감사합니다.",
+            ),
+            "editor_signature": data.get("editor_signature", "편집자 드림"),
+            "template_style": data.get("template_style", "detailed"),
+            "grouped_sections": grouped_sections,
+            "sections": data.get("sections", []),
+        }
+        return _append_search_keywords(context, data.get("search_keywords"))
+
+    context = {
+        **common_context,
+        "recipient_greeting": data.get("recipient_greeting", "안녕하세요,"),
+        "introduction_message": data.get(
+            "introduction_message",
+            "지난 한 주간의 주요 산업 동향을 정리해 드립니다.",
+        ),
+        "sections": data.get("sections", []),
+        "closing_message": data.get(
+            "closing_message",
+            "다음 주에 더 유익한 정보로 찾아뵙겠습니다. 감사합니다.",
+        ),
+        "editor_signature": data.get("editor_signature", "편집자 드림"),
+    }
+    return _append_search_keywords(context, data.get("search_keywords"))
+
+
+def resolve_generation_metadata(data: Dict[str, Any]) -> tuple[str, str]:
+    """Resolve generation date/timestamp from payload or environment defaults."""
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    current_time = datetime.now().strftime("%H:%M:%S")
+    generation_date = data.get(
+        "generation_date", os.environ.get("GENERATION_DATE", current_date)
+    )
+    generation_timestamp = data.get(
+        "generation_timestamp", os.environ.get("GENERATION_TIMESTAMP", current_time)
+    )
+    return generation_date, generation_timestamp
+
+
+def resolve_newsletter_title(
+    data: Dict[str, Any], newsletter_settings: Dict[str, Any], title_default: str
+) -> str:
+    """Resolve the effective newsletter title while preserving legacy rules."""
+    newsletter_title = data.get("newsletter_title")
+    newsletter_topic = data.get("newsletter_topic")
+
+    if not newsletter_title and newsletter_topic:
+        domain = data.get("domain")
+        if domain:
+            return f"{domain} 주간 산업동향 뉴스 클리핑"
+        if newsletter_topic not in ["최신 산업 동향", "General News"]:
+            if " 외 " in newsletter_topic and "개 분야" in newsletter_topic:
+                main_topic = newsletter_topic.split(" 외 ")[0]
+                return f"{main_topic} 주간 산업 동향 뉴스 클리핑"
+            return f"{newsletter_topic} 주간 산업 동향 뉴스 클리핑"
+        return newsletter_settings.get("newsletter_title", title_default)
+
+    if not newsletter_title:
+        return newsletter_settings.get("newsletter_title", title_default)
+
+    return newsletter_title
+
+
+def build_common_context(
+    *,
+    data: Dict[str, Any],
+    newsletter_settings: Dict[str, Any],
+    generation_date: str,
+    generation_timestamp: str,
+    newsletter_topic: str | None,
+    newsletter_title: str,
+    top_articles: List[Dict[str, Any]],
+    definitions: List[Dict[str, str]],
+    food_for_thought: Any,
+) -> Dict[str, Any]:
+    """Build the common context shared by every compose template."""
+    return {
+        "generation_date": generation_date,
+        "generation_timestamp": generation_timestamp,
+        "newsletter_topic": newsletter_topic,
+        "newsletter_title": newsletter_title,
+        "issue_no": data.get("issue_no"),
+        "top_articles": top_articles,
+        "definitions": definitions,
+        "food_for_thought": food_for_thought,
+        "copyright_year": generation_date.split("-")[0],
+        "publisher_name": data.get(
+            "publisher_name",
+            data.get(
+                "company_name",
+                newsletter_settings.get("publisher_name", "Your Company"),
+            ),
+        ),
+        "company_name": data.get(
+            "company_name", newsletter_settings.get("company_name", "Your Company")
+        ),
+        "company_tagline": data.get(
+            "company_tagline", newsletter_settings.get("company_tagline")
+        ),
+        "footer_disclaimer": data.get(
+            "footer_disclaimer", newsletter_settings.get("footer_disclaimer")
+        ),
+        "footer_contact": data.get(
+            "footer_contact", newsletter_settings.get("footer_contact")
+        ),
+        "editor_name": data.get("editor_name", newsletter_settings.get("editor_name")),
+        "editor_email": data.get(
+            "editor_email", newsletter_settings.get("editor_email")
+        ),
+        "editor_title": data.get(
+            "editor_title", newsletter_settings.get("editor_title", "편집자")
+        ),
+    }
+
+
+def load_newsletter_settings(config_file: str = "config.yml") -> Dict[str, Any]:
+    """Load newsletter settings, preserving the legacy public-settings fallback."""
+    try:
+        from newsletter_core.public.settings import get_newsletter_settings
+
+        return get_newsletter_settings()
+    except ImportError:
+        default_settings = {
+            "newsletter_title": "주간 산업 동향 뉴스 클리핑",
+            "tagline": "이번 주, 주요 산업 동향을 미리 만나보세요.",
+            "publisher_name": "Your Company",
+            "company_name": "Your Company",
+            "company_tagline": "",
+            "editor_name": "",
+            "editor_title": "편집자",
+            "editor_email": "",
+            "footer_disclaimer": "이 뉴스레터는 정보 제공을 목적으로 하며, 내용의 정확성을 보장하지 않습니다.",
+            "footer_contact": "",
+        }
+
+        try:
+            if os.path.exists(config_file):
+                with open(config_file, "r", encoding="utf-8") as file_obj:
+                    config_data = yaml.safe_load(file_obj)
+
+                newsletter_settings = config_data.get("newsletter_settings", {})
+                default_settings.update(newsletter_settings)
+        except Exception as exc:
+            print(
+                f"Warning: Could not load newsletter settings from {config_file}: {exc}"
+            )
+
+        return default_settings
+
+
+def _append_search_keywords(
+    context: Dict[str, Any], search_keywords: Any
+) -> Dict[str, Any]:
+    if not search_keywords:
+        return context
+
+    if isinstance(search_keywords, list):
+        context["search_keywords"] = ", ".join(search_keywords)
+    else:
+        context["search_keywords"] = search_keywords
+    return context


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Extract newsletter title resolution, generation metadata defaults, shared render-context assembly, and settings loading seams from `newsletter_core.application.generation.compose` into `compose_context.py` so the compose orchestrator can keep shrinking without changing HTML behavior.

## Scope
### In Scope
- Move title derivation, generation date/timestamp resolution, shared/style-specific context building, and settings loading fallback into `compose_context.py`
- Keep compose entrypoints and rendered output contracts stable by delegating context assembly from `render_newsletter_template`

### Out of Scope
- Jinja environment/template loading changes
- Legacy wrapper restructuring
- Public API signature changes

## Delivery Unit
- RR: #245
- Delivery Unit ID: DU-20260309-compose-render-context
- Merge Boundary: RR-18 only (`compose.py` render-context/settings extraction)
- Rollback Boundary: Revert this PR to restore inline context assembly in `compose.py`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): compose context contract suite

### Commands and Results
```bash
COVERAGE_FILE=.coverage.rr18.contract ./.venv/bin/python -m pytest tests/unit_tests/test_compose_contract_lock.py tests/test_email_compatibility.py -q
# 18 passed, 2 skipped

COVERAGE_FILE=.coverage.rr18.search ./.venv/bin/python -m pytest tests/unit_tests/test_search_keywords.py -q
# 2 passed

COVERAGE_FILE=.coverage.rr18.arch ./.venv/bin/python -m pytest tests/test_unified_architecture.py -q
# 4 passed

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: Low. The change moves context assembly and settings fallback behind a new helper module but preserves template selection and output rules.
- Rollback: `git revert <merge-commit>` for this PR.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: N/A
- Outbox/send_key 중복 방지 결과: N/A
- import-time side effect 제거 여부: No import-time side effects added

## Not Run (with reason)
- Additional live-provider chain tests were not expanded beyond existing `make check-full` coverage because RR-18 only changes render-context assembly, not LLM execution flow
