### PR TITLE
docs: consolidate canonical architecture docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,6 +4,13 @@
 
 본 문서는 뉴스레터 생성기의 기능, 아키텍처 구조, 그리고 핵심 작성 방식에 대해 설명합니다. 뉴스레터 생성기는 사용자가 제공한 키워드 또는 관심 도메인을 기반으로 다양한 소스에서 최신 뉴스를 수집하고, 이를 **멀티 LLM(Large Language Model) 시스템**을 활용하여 요약 및 편집하여 HTML 형식의 뉴스레터를 생성하고 이메일 발송 또는 Google Drive에 저장하는 기능을 제공하는 Python CLI 도구입니다.
 
+## 문서 역할
+
+- 이 문서는 현재 시스템 구조의 정본(SSOT)입니다.
+- 구조 경계와 CI 강제 규칙은 `docs/technical/adr-0001-architecture-boundaries.md` 를 따릅니다.
+- 변경 이력과 단계별 이관 기록은 `docs/technical/architecture-migration-log.md` 에 남깁니다.
+- shim 제거 계획은 `docs/technical/shim-deprecation-schedule.md` 에서 관리합니다.
+
 ## 0. Multi-LLM 시스템 아키텍처
 
 ### 0.1. 지원되는 LLM 제공자
@@ -148,6 +155,18 @@ html_generation: gemini-pro      # 복잡한 작업에만 고성능 모델
 *   **워크플로우 실행 (`newsletter.graph.generate_newsletter`):**
     *   초기 상태(`NewsletterState`)를 설정하고, 정의된 LangGraph 워크플로우를 실행(`graph.invoke(initial_state)`)합니다.
     *   최종 상태에서 뉴스레터 HTML과 성공/실패 상태를 반환합니다.
+
+### 1.2.1. 통합 Compose 계층
+
+- 현재 뉴스레터 조합 단계는 `compose_newsletter()` 중심의 공용 경로를 사용합니다.
+- 스타일별 차이는 별도 구현 복제가 아니라 설정과 템플릿 선택으로 처리합니다.
+- 공용 조합 단계는 다음 책임을 공유합니다.
+    * 상위 기사 추출
+    * 주제별 그룹화
+    * 용어 정의/부가 콘텐츠 추출
+    * 최종 템플릿 렌더링
+- `newsletter.graph` 와 `newsletter.chains` 는 이 공용 조합 경로를 호출하고, 레거시 wrapper는 호환성 유지를 위해 얇게 남아 있습니다.
+- 현재 지원 스타일과 API 계약은 `docs/reference/web-api.md` 와 `docs/user/CLI_REFERENCE.md` 를 우선 기준으로 봅니다.
 
 ### 1.3. 출력 및 전달 (Delivery)
 

--- a/docs/DOCUMENT_INVENTORY.md
+++ b/docs/DOCUMENT_INVENTORY.md
@@ -29,7 +29,7 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 | [`DOCUMENT_INVENTORY.md`](DOCUMENT_INVENTORY.md) | canonical | Docs/Onboarding | - | keep |
 | [`ARCHITECTURE.md`](ARCHITECTURE.md) | canonical | Architecture | - | keep |
 | [`PRD.md`](PRD.md) | supporting | Product | - | keep |
-| [`UNIFIED_ARCHITECTURE.md`](UNIFIED_ARCHITECTURE.md) | supporting | Architecture | [`ARCHITECTURE.md`](ARCHITECTURE.md) | keep |
+| [`archive/2026-q1/UNIFIED_ARCHITECTURE.md`](archive/2026-q1/UNIFIED_ARCHITECTURE.md) | historical | Architecture | [`ARCHITECTURE.md`](ARCHITECTURE.md), [`technical/adr-0001-architecture-boundaries.md`](technical/adr-0001-architecture-boundaries.md) | archive |
 | [`archive/README.md`](archive/README.md) | canonical | Repo Hygiene | - | keep |
 | [`archive/webservice-prd.md`](archive/webservice-prd.md) | historical | Product | [`PRD.md`](PRD.md) | keep in archive |
 | [`archive/2026-q1/FIXES_SUMMARY.md`](archive/2026-q1/FIXES_SUMMARY.md) | obsolete | Release/Ops | [`../CHANGELOG.md`](../CHANGELOG.md), [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | archive |
@@ -105,3 +105,4 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 3. 허브 문서와 루트 README에는 인벤토리 링크를 추가해 문서 탐색 시작점을 단일화했습니다.
 4. 환경변수 정본과 `.env.example` 의 용어를 맞추기 위해 canonical key와 compatibility key를 분리해 명시했습니다.
 5. 구조/위생 축의 과거 실행 계획 문서는 canonical 참조를 제거한 뒤 [`archive/2026-q1/`](archive/2026-q1/README.md) 로 이관했습니다.
+6. 아키텍처 축은 [`ARCHITECTURE.md`](ARCHITECTURE.md) 1개 정본과 ADR/마이그레이션 로그 보조 구조로 정리하고, 중복 개요 문서는 archive 로 이관했습니다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,9 @@
 
 - 아키텍처/배경
   - [`ARCHITECTURE.md`](ARCHITECTURE.md)
-  - [`UNIFIED_ARCHITECTURE.md`](UNIFIED_ARCHITECTURE.md)
+  - [`technical/adr-0001-architecture-boundaries.md`](technical/adr-0001-architecture-boundaries.md)
+  - [`technical/architecture-migration-log.md`](technical/architecture-migration-log.md)
+  - [`technical/shim-deprecation-schedule.md`](technical/shim-deprecation-schedule.md)
   - [`PRD.md`](PRD.md)
 
 ## Governance
@@ -75,6 +77,7 @@
   - [`archive/2026-q1/MAIN_INTEGRATION_EXECUTION_PLAN.md`](archive/2026-q1/MAIN_INTEGRATION_EXECUTION_PLAN.md)
   - [`archive/2026-q1/BRANCH_MAIN_GAP_ANALYSIS.md`](archive/2026-q1/BRANCH_MAIN_GAP_ANALYSIS.md)
   - [`archive/2026-q1/REFACTORING_EXECUTION_PLAN.md`](archive/2026-q1/REFACTORING_EXECUTION_PLAN.md)
+  - [`archive/2026-q1/UNIFIED_ARCHITECTURE.md`](archive/2026-q1/UNIFIED_ARCHITECTURE.md)
   - [`archive/2026-q1/REPO_HYGIENE_STATUS_2026-02-24.md`](archive/2026-q1/REPO_HYGIENE_STATUS_2026-02-24.md)
   - [`archive/2026-q1/F14_COMPLETION_REPORT.md`](archive/2026-q1/F14_COMPLETION_REPORT.md)
   - [`archive/2026-q1/FIXES_SUMMARY.md`](archive/2026-q1/FIXES_SUMMARY.md)

--- a/docs/archive/2026-q1/README.md
+++ b/docs/archive/2026-q1/README.md
@@ -15,6 +15,7 @@
 | [`MAIN_INTEGRATION_EXECUTION_PLAN.md`](MAIN_INTEGRATION_EXECUTION_PLAN.md) | 현재 release 실행 기준이 아닌 시점별 통합 계획 | [`../../dev/CI_CD_GUIDE.md`](../../dev/CI_CD_GUIDE.md), [`../../../.github/PULL_REQUEST_TEMPLATE/release_integration.md`](../../../.github/PULL_REQUEST_TEMPLATE/release_integration.md) |
 | [`BRANCH_MAIN_GAP_ANALYSIS.md`](BRANCH_MAIN_GAP_ANALYSIS.md) | 과거 `main` 격차 분석 문서 | [`../../dev/CI_CD_GUIDE.md`](../../dev/CI_CD_GUIDE.md) |
 | [`REFACTORING_EXECUTION_PLAN.md`](REFACTORING_EXECUTION_PLAN.md) | 시점 고정형 리팩토링 배치 계획 | [`../../dev/LONG_TERM_REPO_STRATEGY.md`](../../dev/LONG_TERM_REPO_STRATEGY.md), [`../../dev/REPO_HYGIENE_POLICY.md`](../../dev/REPO_HYGIENE_POLICY.md) |
+| [`UNIFIED_ARCHITECTURE.md`](UNIFIED_ARCHITECTURE.md) | 중복된 아키텍처 개요 문서 | [`../../ARCHITECTURE.md`](../../ARCHITECTURE.md), [`../../technical/adr-0001-architecture-boundaries.md`](../../technical/adr-0001-architecture-boundaries.md) |
 
 ## Rollback
 

--- a/docs/archive/2026-q1/UNIFIED_ARCHITECTURE.md
+++ b/docs/archive/2026-q1/UNIFIED_ARCHITECTURE.md
@@ -1,5 +1,10 @@
 # Newsletter Generator - Unified Architecture Summary
 
+> Historical note (2026-03-09): RR-3에서 archive 로 이관된 아키텍처 개요 문서입니다.
+> 현재 아키텍처 정본은 `docs/ARCHITECTURE.md` 이며, 구조 경계와 이관 이력은
+> `docs/technical/adr-0001-architecture-boundaries.md`,
+> `docs/technical/architecture-migration-log.md` 를 따릅니다.
+
 ## Overview
 
 The newsletter generation system has been successfully refactored from separate compact and detailed implementations to a **unified architecture** that shares common logic while maintaining distinct output characteristics. This document summarizes the implementation, benefits, and usage of the new unified system.


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- `docs/ARCHITECTURE.md` 를 아키텍처 정본으로 명시하고 공용 compose 경로 설명을 보강했습니다.
- 중복 개요 문서였던 `docs/UNIFIED_ARCHITECTURE.md` 를 `docs/archive/2026-q1/` 로 이관하고 active 허브/인벤토리를 정리했습니다.

## Scope
### In Scope
- 아키텍처 정본 문서 역할 정의
- `UNIFIED_ARCHITECTURE.md` archive 이관
- docs 허브 및 inventory 정합성 갱신

### Out of Scope
- 코드 구조 변경
- ADR 본문 개정
- 설정 문서 분리 작업

## Delivery Unit
- RR: #259
- Delivery Unit ID: DU-20260309-architecture-canon
- Merge Boundary: RR-3 아키텍처 문서 통합 변경만 포함합니다.
- Rollback Boundary: 이 PR의 단일 커밋을 revert 하면 archive 이동과 허브 링크가 함께 원복됩니다.

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): markdown/link/repo audit/release preflight

### Commands and Results
```bash
python3 scripts/check_markdown_links.py
# passed

python3 scripts/check_markdown_style.py
# passed

python3 scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy --strict
# passed

/Users/hojungjung/development/newsletter-generator/.venv/bin/python scripts/release_preflight.py
# passed

make check
# passed

make check-full
# passed
```

## Risk & Rollback
- Risk: archive 로 이동한 문서를 직접 참조하는 외부 링크가 있다면 stale link가 생길 수 있습니다.
- Rollback: `git revert 8946f47` 로 active 경로와 허브 참조를 복구할 수 있습니다.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 해당 없음
- Outbox/send_key 중복 방지 결과: 해당 없음
- import-time side effect 제거 여부: 해당 없음

## Not Run (with reason)
- 없음
