### PR TITLE
docs: split canonical and experimental env samples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Newsletter Generator Environment Configuration
 # Copy this file to .env and update the values
+# Canonical Flask/CLI runtime sample. Experimental FastAPI settings live in
+# apps/experimental/.env.example.
 
 # Application Environment (canonical)
 APP_ENV=development
@@ -12,32 +14,13 @@ DEBUG=true
 # Server Configuration
 HOST=0.0.0.0
 PORT=8000
+LOG_LEVEL=INFO
+LOG_FORMAT=standard
 
 # Web / Ops
 SECRET_KEY=change-this-in-production
 ADMIN_API_TOKEN=replace-me-with-an-ops-token
-
-# Security Configuration (apps/experimental and legacy security helpers)
 ALLOWED_ORIGINS=http://localhost:3000,https://yourdomain.com
-ALLOWED_HOSTS=localhost,yourdomain.com
-JWT_SECRET_KEY=your-super-secret-jwt-key-change-in-production
-JWT_ACCESS_TOKEN_EXPIRE_MINUTES=30
-
-# Rate Limiting
-RATE_LIMIT_ENABLED=true
-RATE_LIMIT_REQUESTS=100
-RATE_LIMIT_WINDOW=3600
-
-# File Upload
-MAX_UPLOAD_SIZE=10485760  # 10MB in bytes
-
-# Session Security
-SESSION_COOKIE_SECURE=true
-
-# Logging
-LOG_DIR=logs
-SECURITY_AUDIT_LOG=security_audit.log
-APPLICATION_LOG=application.log
 
 # API Keys (Required for functionality)
 SERPER_API_KEY=your-serper-api-key
@@ -63,10 +46,10 @@ LANGCHAIN_API_KEY=your-langsmith-api-key
 LANGCHAIN_TRACING_V2=1
 LANGCHAIN_PROJECT=your-langsmith-project
 
-# Database (Optional)
+# Persistence / Queue (Optional)
 DATABASE_URL=sqlite:///./newsletter.db
 
-# Redis (Optional, for rate limiting)
+# Redis (Optional, for worker / scheduler)
 REDIS_URL=redis://localhost:6379/0
 RQ_QUEUE=default
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ cp .env.example .env
 make check
 ```
 
+Experimental FastAPI entrypoint uses a separate sample at
+[`apps/experimental/.env.example`](apps/experimental/.env.example).
+
 웹 실행/CLI/배포 절차는 아래 정본 문서를 사용하세요.
 
 ## Docs Hub

--- a/apps/experimental/.env.example
+++ b/apps/experimental/.env.example
@@ -1,0 +1,27 @@
+# Experimental FastAPI runtime sample
+# Use this only with apps/experimental/main.py.
+
+# Runtime
+ENVIRONMENT=development
+HOST=0.0.0.0
+PORT=8000
+
+# CORS / host filtering
+ALLOWED_ORIGINS=http://localhost:3000,https://yourdomain.com
+ALLOWED_HOSTS=localhost,yourdomain.com
+
+# Auth / rate limiting
+JWT_SECRET_KEY=change-this-in-production
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES=30
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_REQUESTS=100
+RATE_LIMIT_WINDOW=3600
+
+# Upload / session hardening
+MAX_UPLOAD_SIZE=10485760
+SESSION_COOKIE_SECURE=true
+
+# Audit logging
+LOG_DIR=logs
+SECURITY_AUDIT_LOG=security_audit.log
+APPLICATION_LOG=application.log

--- a/docs/DOCUMENT_INVENTORY.md
+++ b/docs/DOCUMENT_INVENTORY.md
@@ -106,3 +106,4 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 4. 환경변수 정본과 `.env.example` 의 용어를 맞추기 위해 canonical key와 compatibility key를 분리해 명시했습니다.
 5. 구조/위생 축의 과거 실행 계획 문서는 canonical 참조를 제거한 뒤 [`archive/2026-q1/`](archive/2026-q1/README.md) 로 이관했습니다.
 6. 아키텍처 축은 [`ARCHITECTURE.md`](ARCHITECTURE.md) 1개 정본과 ADR/마이그레이션 로그 보조 구조로 정리하고, 중복 개요 문서는 archive 로 이관했습니다.
+7. 환경 샘플은 root `.env.example`(canonical runtime) 과 `apps/experimental/.env.example`(experimental runtime) 로 분리했습니다.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -2,7 +2,32 @@
 
 이 문서는 환경변수 계약의 정본(SSOT)입니다.
 
-## Runtime Contract
+## Sample Files
+
+- 루트 [`../../.env.example`](../../.env.example)는 canonical Flask/CLI runtime 샘플입니다.
+- [`../../apps/experimental/.env.example`](../../apps/experimental/.env.example)는
+  `apps/experimental/main.py` 전용 FastAPI/security 확장 샘플입니다.
+- `HOST`, `PORT`, `ALLOWED_ORIGINS` 는 두 런타임이 공유하지만, root sample을 기준으로 유지합니다.
+
+## Canonical Runtime Contract
+
+### Core Runtime / Web Ops
+
+| 변수 | 필수 여부 | 용도 |
+|---|---|---|
+| `APP_ENV` | 선택 | canonical runtime environment (`development`/`testing`/`production`) |
+| `FLASK_ENV` | 호환용 | legacy web entrypoint dev/prod 토글 |
+| `ENVIRONMENT` | 호환용 | legacy logging/security/runtime fallback |
+| `DEBUG` | 선택 | 개발 편의용 디버그 플래그 |
+| `HOST` | 선택 | 웹 바인딩 호스트 |
+| `PORT` | 배포 시 선택 | 웹 포트 (`.env.example` 기준 `8000`, legacy entrypoint는 미설정 시 `5000` fallback 존재) |
+| `LOG_LEVEL` | 선택 | runtime/application log level |
+| `LOG_FORMAT` | 선택 | logging format (`standard`/`json`) |
+| `SECRET_KEY` | 프로덕션 권장(웹) | Flask 시크릿 키 |
+| `ADMIN_API_TOKEN` | 민감 운영 API 보호 시 필수 | `/api/history`, `/api/schedule*`, `/api/send-email`, `/api/email-config`, `/api/test-email` 보호 토큰 |
+| `ALLOWED_ORIGINS` | 선택 | canonical Flask runtime CORS allow-list |
+
+### Search / LLM / Delivery
 
 | 변수 | 필수 여부 | 용도 |
 |---|---|---|
@@ -12,17 +37,48 @@
 | `ANTHROPIC_API_KEY` | LLM 중 하나 필수 | Anthropic 제공자 |
 | `POSTMARK_SERVER_TOKEN` | 이메일 발송 시 필수 | Postmark 서버 토큰 |
 | `EMAIL_SENDER` | 이메일 발송 시 필수 | 발신자 이메일 (인증 필요) |
-| `APP_ENV` | 선택 | canonical runtime environment (`development`/`testing`/`production`) |
-| `SECRET_KEY` | 프로덕션 권장(웹) | Flask 시크릿 키 |
-| `ADMIN_API_TOKEN` | 민감 운영 API 보호 시 필수 | `/api/history`, `/api/schedule*`, `/api/send-email`, `/api/email-config`, `/api/test-email` 보호 토큰 |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Google Drive 저장 시 선택 | GCP 서비스 계정 키 경로 |
+| `GOOGLE_CLIENT_ID` | OAuth 사용 시 선택 | Google OAuth client id |
+| `GOOGLE_CLIENT_SECRET` | OAuth 사용 시 선택 | Google OAuth client secret |
+| `NAVER_CLIENT_ID` | 네이버 API 사용 시 선택 | Naver client id |
+| `NAVER_CLIENT_SECRET` | 네이버 API 사용 시 선택 | Naver client secret |
+
+### Optional Integrations / Observability / Test
+
+| 변수 | 필수 여부 | 용도 |
+|---|---|---|
+| `LANGCHAIN_API_KEY` | LangSmith 사용 시 선택 | LangSmith API key |
+| `LANGCHAIN_TRACING_V2` | LangSmith 사용 시 선택 | tracing 토글 |
+| `LANGCHAIN_PROJECT` | LangSmith 사용 시 선택 | tracing project name |
+| `DATABASE_URL` | DB persistence 사용 시 선택 | 애플리케이션 DB 연결 문자열 |
 | `REDIS_URL` | worker/scheduler 사용 시 필수 | Redis 연결 |
 | `RQ_QUEUE` | 선택 | RQ 큐 이름 (`default`) |
-| `FLASK_ENV` | 호환용 | legacy web entrypoint dev/prod 토글 |
-| `ENVIRONMENT` | 호환용 | legacy logging/security/runtime fallback |
-| `MOCK_MODE` | 선택 | `true`일 때 mock 데이터 사용 |
-| `TESTING` | 테스트 전용 | 테스트 모드 강제 |
 | `SENTRY_DSN` | 선택 | Sentry 에러 모니터링 |
-| `PORT` | 배포 시 선택 | 웹 포트 (`.env.example` 기준 `8000`, legacy entrypoint는 미설정 시 `5000` fallback 존재) |
+| `SENTRY_TRACES_SAMPLE_RATE` | 선택 | Sentry tracing sample rate |
+| `SENTRY_PROFILES_SAMPLE_RATE` | 선택 | Sentry profiling sample rate |
+| `ADDITIONAL_RSS_FEEDS` | 선택 | 추가 RSS feed 목록 |
+| `TESTING` | 테스트 전용 | 테스트 모드 강제 |
+| `MOCK_MODE` | 선택 | `true`일 때 mock 데이터 사용 |
+
+## Experimental FastAPI / Security Extension
+
+`apps/experimental/main.py` 와 `newsletter.security.*` 계층은 아래 변수를 추가로 사용합니다.
+이 값들은 root `.env.example` 에 두지 않고 [`../../apps/experimental/.env.example`](../../apps/experimental/.env.example)
+로 분리합니다.
+
+| 변수 | 필수 여부 | 용도 |
+|---|---|---|
+| `ALLOWED_HOSTS` | 선택 | FastAPI trusted host allow-list |
+| `JWT_SECRET_KEY` | 실험 API auth 사용 시 필수 | JWT 서명 키 |
+| `JWT_ACCESS_TOKEN_EXPIRE_MINUTES` | 선택 | JWT access token 만료 시간 |
+| `RATE_LIMIT_ENABLED` | 선택 | experimental rate limiting 토글 |
+| `RATE_LIMIT_REQUESTS` | 선택 | rate limit 요청 수 |
+| `RATE_LIMIT_WINDOW` | 선택 | rate limit 윈도우(초) |
+| `MAX_UPLOAD_SIZE` | 선택 | 업로드 파일 최대 크기(byte) |
+| `SESSION_COOKIE_SECURE` | 선택 | secure cookie 강제 여부 |
+| `LOG_DIR` | 선택 | security/app audit log 디렉터리 |
+| `SECURITY_AUDIT_LOG` | 선택 | 보안 감사 로그 파일명 |
+| `APPLICATION_LOG` | 선택 | 애플리케이션 로그 파일명 |
 
 ## LLM Key Rule
 
@@ -54,9 +110,10 @@
 ## Examples
 
 ```bash
-# 최소 생성(비이메일)
+# canonical Flask/CLI runtime
 SERPER_API_KEY=...
 GEMINI_API_KEY=...
+APP_ENV=development
 
 # 이메일 발송 포함
 POSTMARK_SERVER_TOKEN=ps_xxx
@@ -68,5 +125,11 @@ FLASK_ENV=production
 ENVIRONMENT=production
 SECRET_KEY=replace-me-in-production
 ADMIN_API_TOKEN=replace-me-with-an-ops-token
+ALLOWED_ORIGINS=https://app.example.com
 REDIS_URL=redis://localhost:6379/0
+
+# experimental FastAPI runtime extension
+JWT_SECRET_KEY=replace-me-for-experimental-runtime
+ALLOWED_HOSTS=api.example.com
+RATE_LIMIT_ENABLED=true
 ```


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- 루트 `.env.example` 를 canonical Flask/CLI runtime 중심으로 축소했습니다.
- experimental FastAPI/security 전용 변수는 `apps/experimental/.env.example` 로 분리하고, 환경변수 정본 문서에 두 계약의 경계를 명시했습니다.

## Scope
### In Scope
- root `.env.example` 정리
- `apps/experimental/.env.example` 추가
- 환경변수 정본 문서와 README/inventory 정합성 갱신

### Out of Scope
- 런타임 코드 변경
- secret 값 변경
- 배포 설정 변경

## Delivery Unit
- RR: #261
- Delivery Unit ID: DU-20260309-env-sample-split
- Merge Boundary: RR-4 설정 축 문서/샘플 분리만 포함합니다.
- Rollback Boundary: 이 PR의 단일 커밋을 revert 하면 root sample과 문서 링크가 함께 원복됩니다.

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): markdown/link/repo audit/release preflight

### Commands and Results
```bash
python3 scripts/check_markdown_links.py
# passed

python3 scripts/check_markdown_style.py
# passed

python3 scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy --strict
# passed

/Users/hojungjung/development/newsletter-generator/.venv/bin/python scripts/release_preflight.py
# passed

make check
# passed

make check-full
# passed
```

## Risk & Rollback
- Risk: 기존에 root `.env.example` 만 참고하던 experimental runtime 사용자는 새 sample 경로를 확인해야 합니다.
- Rollback: `git revert 8320c3c` 로 root sample과 문서 경계를 이전 상태로 되돌릴 수 있습니다.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 해당 없음
- Outbox/send_key 중복 방지 결과: 해당 없음
- import-time side effect 제거 여부: 해당 없음

## Not Run (with reason)
- 없음
