### PR TITLE
docs: normalize agent governance doc naming

### DIFF
--- a/docs/DOCUMENT_INVENTORY.md
+++ b/docs/DOCUMENT_INVENTORY.md
@@ -48,7 +48,7 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 | [`dev/WORKFLOW_TEMPLATES.md`](dev/WORKFLOW_TEMPLATES.md) | supporting | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | keep |
 | [`dev/RR_REQUEST_TEMPLATE.md`](dev/RR_REQUEST_TEMPLATE.md) | supporting | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | keep |
 | [`dev/AGENT_SKILL_REQUEST_PLAYBOOK.md`](dev/AGENT_SKILL_REQUEST_PLAYBOOK.md) | supporting | Contributor Workflow | [`../AGENTS.md`](../AGENTS.md) | keep |
-| [`dev/CODEX_INSTRUCTION_LAYOUT.md`](dev/CODEX_INSTRUCTION_LAYOUT.md) | supporting | Repo Governance | [`../AGENTS.md`](../AGENTS.md) | keep |
+| [`dev/AGENTS_GOVERNANCE.md`](dev/AGENTS_GOVERNANCE.md) | supporting | Repo Governance | [`../AGENTS.md`](../AGENTS.md) | keep |
 | [`dev/langsmith_setup.md`](dev/langsmith_setup.md) | supporting | Runtime Config | [`technical/LLM_CONFIGURATION.md`](technical/LLM_CONFIGURATION.md) | keep |
 | [`archive/2026-q1/MAIN_INTEGRATION_EXECUTION_PLAN.md`](archive/2026-q1/MAIN_INTEGRATION_EXECUTION_PLAN.md) | historical | Release/Ops | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md), [`dev/WORKFLOW_TEMPLATES.md`](dev/WORKFLOW_TEMPLATES.md) | archive |
 | [`archive/2026-q1/BRANCH_MAIN_GAP_ANALYSIS.md`](archive/2026-q1/BRANCH_MAIN_GAP_ANALYSIS.md) | historical | Release/Ops | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | archive |
@@ -107,3 +107,4 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 5. 구조/위생 축의 과거 실행 계획 문서는 canonical 참조를 제거한 뒤 [`archive/2026-q1/`](archive/2026-q1/README.md) 로 이관했습니다.
 6. 아키텍처 축은 [`ARCHITECTURE.md`](ARCHITECTURE.md) 1개 정본과 ADR/마이그레이션 로그 보조 구조로 정리하고, 중복 개요 문서는 archive 로 이관했습니다.
 7. 환경 샘플은 root `.env.example`(canonical runtime) 과 `apps/experimental/.env.example`(experimental runtime) 로 분리했습니다.
+8. `docs/dev/CODEX_INSTRUCTION_LAYOUT.md` 는 활성 거버넌스 문서 역할에 맞게 [`dev/AGENTS_GOVERNANCE.md`](dev/AGENTS_GOVERNANCE.md) 로 rename 했습니다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@
 | Repo hygiene 정책 | [`dev/REPO_HYGIENE_POLICY.md`](dev/REPO_HYGIENE_POLICY.md) | 루트 분류/soft gate/dot 추적 범위 |
 | 문서 전수조사표 | [`DOCUMENT_INVENTORY.md`](DOCUMENT_INVENTORY.md) | 문서 상태/owner/disposition 정리 |
 | Agent/Skill 요청 표준 | [`dev/AGENT_SKILL_REQUEST_PLAYBOOK.md`](dev/AGENT_SKILL_REQUEST_PLAYBOOK.md) | commit/PR/CI 중심 실행 요청 템플릿 |
+| AGENTS/Skill 거버넌스 | [`dev/AGENTS_GOVERNANCE.md`](dev/AGENTS_GOVERNANCE.md) | 글로벌/레포/하위 AGENTS precedence와 skill 경계 |
 | RR 요청 템플릿 | [`dev/RR_REQUEST_TEMPLATE.md`](dev/RR_REQUEST_TEMPLATE.md) | 작업 요청 문장 표준 |
 | PR/Commit/Branch 프로세스 | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | 템플릿 경로 + PR policy check gate |
 | 워크플로 템플릿 종합 | [`dev/WORKFLOW_TEMPLATES.md`](dev/WORKFLOW_TEMPLATES.md) | RR/브랜치/커밋/PR/머지 운영 표준 |
@@ -36,6 +37,7 @@
   - [`dev/LONG_TERM_REPO_STRATEGY.md`](dev/LONG_TERM_REPO_STRATEGY.md)
   - [`dev/REPO_HYGIENE_POLICY.md`](dev/REPO_HYGIENE_POLICY.md)
   - [`dev/AGENT_SKILL_REQUEST_PLAYBOOK.md`](dev/AGENT_SKILL_REQUEST_PLAYBOOK.md)
+  - [`dev/AGENTS_GOVERNANCE.md`](dev/AGENTS_GOVERNANCE.md)
   - [`dev/RR_REQUEST_TEMPLATE.md`](dev/RR_REQUEST_TEMPLATE.md)
   - [`dev/WORKFLOW_TEMPLATES.md`](dev/WORKFLOW_TEMPLATES.md)
   - [`developer/CENTRALIZED_SETTINGS_GUIDE.md`](developer/CENTRALIZED_SETTINGS_GUIDE.md)

--- a/docs/dev/AGENTS_GOVERNANCE.md
+++ b/docs/dev/AGENTS_GOVERNANCE.md
@@ -1,6 +1,6 @@
-# Codex Instruction Layout
+# AGENTS Governance
 
-Purpose: keep instructions enforceable, not bloated.
+Purpose: keep repository agent policy enforceable, discoverable, and not bloated.
 
 ## Load/Override Order
 1. `~/.codex/AGENTS.md` (global working style)


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- `docs/dev/CODEX_INSTRUCTION_LAYOUT.md` 를 실제 역할에 맞는 `docs/dev/AGENTS_GOVERNANCE.md` 로 rename 했습니다.
- docs hub와 문서 인벤토리에서 같은 명칭으로 노출되도록 정리했습니다.

## Scope
### In Scope
- AGENTS governance 문서 rename
- docs hub 링크 갱신
- document inventory 경로/이력 갱신

### Out of Scope
- AGENTS 정책 내용 변경
- skill 본문 변경
- archive 정책 변경

## Delivery Unit
- RR: #263
- Delivery Unit ID: DU-20260309-agent-governance
- Merge Boundary: RR-5 개발자 내부 운영 문서 naming 정리만 포함합니다.
- Rollback Boundary: 이 PR의 단일 커밋을 revert 하면 문서 경로와 허브 링크가 함께 원복됩니다.

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): markdown/link/repo audit/release preflight

### Commands and Results
```bash
python3 scripts/check_markdown_links.py
# passed

python3 scripts/check_markdown_style.py
# passed

python3 scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy --strict
# passed

/Users/hojungjung/development/newsletter-generator/.venv/bin/python scripts/release_preflight.py
# passed

make check
# passed

make check-full
# passed
```

## Risk & Rollback
- Risk: 기존 경로를 직접 참조하던 외부 북마크가 있다면 새 경로로 갱신이 필요합니다.
- Rollback: `git revert bb1bfcd` 로 기존 파일명과 허브 참조를 복구할 수 있습니다.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 해당 없음
- Outbox/send_key 중복 방지 결과: 해당 없음
- import-time side effect 제거 여부: 해당 없음

## Not Run (with reason)
- 없음
