### PR TITLE
docs: archive stale code quality guide

### DIFF
--- a/docs/DOCUMENT_INVENTORY.md
+++ b/docs/DOCUMENT_INVENTORY.md
@@ -44,7 +44,7 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | canonical | Contributor Workflow | - | keep |
 | [`dev/DEVELOPMENT_GUIDE.md`](dev/DEVELOPMENT_GUIDE.md) | supporting | Contributor Workflow | [`../setup/LOCAL_SETUP.md`](setup/LOCAL_SETUP.md) | keep |
 | [`dev/LOCAL_CI_GUIDE.md`](dev/LOCAL_CI_GUIDE.md) | supporting | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | keep |
-| [`dev/CODE_QUALITY.md`](dev/CODE_QUALITY.md) | supporting | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | keep |
+| [`archive/2026-q1/CODE_QUALITY.md`](archive/2026-q1/CODE_QUALITY.md) | obsolete | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md), [`dev/LOCAL_CI_GUIDE.md`](dev/LOCAL_CI_GUIDE.md) | archive |
 | [`dev/WORKFLOW_TEMPLATES.md`](dev/WORKFLOW_TEMPLATES.md) | supporting | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | keep |
 | [`dev/RR_REQUEST_TEMPLATE.md`](dev/RR_REQUEST_TEMPLATE.md) | supporting | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | keep |
 | [`dev/AGENT_SKILL_REQUEST_PLAYBOOK.md`](dev/AGENT_SKILL_REQUEST_PLAYBOOK.md) | supporting | Contributor Workflow | [`../AGENTS.md`](../AGENTS.md) | keep |
@@ -108,3 +108,4 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 6. 아키텍처 축은 [`ARCHITECTURE.md`](ARCHITECTURE.md) 1개 정본과 ADR/마이그레이션 로그 보조 구조로 정리하고, 중복 개요 문서는 archive 로 이관했습니다.
 7. 환경 샘플은 root `.env.example`(canonical runtime) 과 `apps/experimental/.env.example`(experimental runtime) 로 분리했습니다.
 8. `docs/dev/CODEX_INSTRUCTION_LAYOUT.md` 는 활성 거버넌스 문서 역할에 맞게 [`dev/AGENTS_GOVERNANCE.md`](dev/AGENTS_GOVERNANCE.md) 로 rename 했습니다.
+9. stale 상태였던 `docs/dev/CODE_QUALITY.md` 는 [`archive/2026-q1/CODE_QUALITY.md`](archive/2026-q1/CODE_QUALITY.md) 로 이관하고, active 품질 기준은 [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) 로 흡수했습니다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,5 +84,6 @@
   - [`archive/2026-q1/F14_COMPLETION_REPORT.md`](archive/2026-q1/F14_COMPLETION_REPORT.md)
   - [`archive/2026-q1/FIXES_SUMMARY.md`](archive/2026-q1/FIXES_SUMMARY.md)
   - [`archive/2026-q1/PROJECT_STRUCTURE.md`](archive/2026-q1/PROJECT_STRUCTURE.md)
+  - [`archive/2026-q1/CODE_QUALITY.md`](archive/2026-q1/CODE_QUALITY.md)
   - [`archive/2026-q1/MULTI_LLM_IMPLEMENTATION_SUMMARY.md`](archive/2026-q1/MULTI_LLM_IMPLEMENTATION_SUMMARY.md)
   - [`archive/webservice-prd.md`](archive/webservice-prd.md)

--- a/docs/archive/2026-q1/CODE_QUALITY.md
+++ b/docs/archive/2026-q1/CODE_QUALITY.md
@@ -1,6 +1,10 @@
 # 코드 품질 관리 가이드
 
-이 문서는 Newsletter Generator 프로젝트의 코드 품질을 관리하는 방법에 대한 가이드입니다.
+> Historical note (2026-03-09): RR-06에서 active docs tree 밖으로 이관된 문서입니다.
+> 현재 코드 품질/검증의 정본은 `docs/dev/CI_CD_GUIDE.md` 와
+> `docs/dev/LOCAL_CI_GUIDE.md` 를 기준으로 유지합니다.
+
+이 문서는 당시 코드 품질 운영 메모를 보존하기 위한 archive 사본입니다.
 
 ## 코드 포맷팅
 

--- a/docs/archive/2026-q1/README.md
+++ b/docs/archive/2026-q1/README.md
@@ -16,6 +16,7 @@
 | [`BRANCH_MAIN_GAP_ANALYSIS.md`](BRANCH_MAIN_GAP_ANALYSIS.md) | 과거 `main` 격차 분석 문서 | [`../../dev/CI_CD_GUIDE.md`](../../dev/CI_CD_GUIDE.md) |
 | [`REFACTORING_EXECUTION_PLAN.md`](REFACTORING_EXECUTION_PLAN.md) | 시점 고정형 리팩토링 배치 계획 | [`../../dev/LONG_TERM_REPO_STRATEGY.md`](../../dev/LONG_TERM_REPO_STRATEGY.md), [`../../dev/REPO_HYGIENE_POLICY.md`](../../dev/REPO_HYGIENE_POLICY.md) |
 | [`UNIFIED_ARCHITECTURE.md`](UNIFIED_ARCHITECTURE.md) | 중복된 아키텍처 개요 문서 | [`../../ARCHITECTURE.md`](../../ARCHITECTURE.md), [`../../technical/adr-0001-architecture-boundaries.md`](../../technical/adr-0001-architecture-boundaries.md) |
+| [`CODE_QUALITY.md`](CODE_QUALITY.md) | 현재 게이트 구성과 어긋난 예전 코드 품질 안내 | [`../../dev/CI_CD_GUIDE.md`](../../dev/CI_CD_GUIDE.md), [`../../dev/LOCAL_CI_GUIDE.md`](../../dev/LOCAL_CI_GUIDE.md) |
 
 ## Rollback
 

--- a/docs/dev/CI_CD_GUIDE.md
+++ b/docs/dev/CI_CD_GUIDE.md
@@ -53,6 +53,29 @@ make repo-audit-strict
 - `make repo-audit-strict`: CI hard gate와 동일(strict) 경로 점검
 - dev 유틸 실행 스크립트는 `scripts/devtools/`를 기본 경로로 사용합니다.
 
+## Quality Toolchain
+
+현재 품질 게이트는 아래 도구 조합을 기준으로 운영합니다.
+
+| Area | Primary Tool | Canonical Entry |
+|---|---|---|
+| formatting | `black` | `make check`, `make check-full`, `make format` |
+| import ordering | `isort` | `make check`, `make check-full`, `make format` |
+| lint | `flake8` | `make check`, `make check-full` |
+| type check | `mypy` | `make check-full` |
+| security scan | `bandit` | `make check-full` |
+| unit/integration test | `pytest` | `make check`, `make check-full` |
+| docs integrity | Markdown link/style checks | `make docs-check` |
+| repo hygiene | `scripts/repo_audit.py` | `make repo-audit`, `make repo-audit-strict` |
+
+직접 도구를 개별 실행할 수도 있지만, contributor-facing 기준 명령은 Makefile 엔트리를 우선 사용합니다.
+
+## Coverage Reporting
+
+- 커버리지는 `pytest-cov` 리포트(`coverage.xml`, `htmlcov/`)로 계속 수집합니다.
+- 현재 contributor gate는 "고정 퍼센트 임계치" 문서보다 `make check-full` 통과와 테스트 리포트 정합성을 우선 기준으로 사용합니다.
+- 커버리지 개선 작업은 별도 RR/PR 단위로 분리합니다.
+
 ## Repo Hygiene Gate
 
 `main-ci.yml`의 `quality-checks` 단계에서 repo hygiene gate를 실행합니다.

--- a/docs/dev/DEVELOPMENT_GUIDE.md
+++ b/docs/dev/DEVELOPMENT_GUIDE.md
@@ -616,7 +616,7 @@ pip install -r requirements-dev.txt --upgrade
 ## 추가 리소스
 
 - [CI/CD 가이드](CI_CD_GUIDE.md) - GitHub Actions 워크플로우
-- [코드 품질 가이드](CODE_QUALITY.md) - 품질 관리 도구
+- [로컬 CI 가이드](LOCAL_CI_GUIDE.md) - 로컬 게이트와 반복 검증 루프
 - [테스트 가이드](../../tests/TEST_EXECUTION_GUIDE.md) - 테스트 작성 및 실행
 - [아키텍처 문서](../ARCHITECTURE.md) - 시스템 설계
 - [CLI 참조](../user/CLI_REFERENCE.md) - 명령어 및 옵션 참조


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- stale 상태였던 `docs/dev/CODE_QUALITY.md` 를 archive 로 이관했습니다.
- 현재 품질 도구/커버리지 기준은 `docs/dev/CI_CD_GUIDE.md` 에 흡수하고, 개발자 가이드와 인벤토리 참조를 정리했습니다.

## Scope
### In Scope
- `CODE_QUALITY.md` archive-first 이관
- `CI_CD_GUIDE.md` 에 현재 품질 toolchain/coverage 기준 추가
- developer/docs inventory/archive index 참조 정리

### Out of Scope
- CI workflow 변경
- 테스트 정책 변경
- coverage threshold 정책 변경

## Delivery Unit
- RR: #265
- Delivery Unit ID: DU-20260309-code-quality-doc
- Merge Boundary: RR-06 문서 정합성 정리만 포함합니다.
- Rollback Boundary: 이 PR의 단일 커밋을 revert 하면 archive 이동과 canonical 참조가 함께 원복됩니다.

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): markdown/link/repo audit/release preflight

### Commands and Results
```bash
python3 scripts/check_markdown_links.py
# passed

python3 scripts/check_markdown_style.py
# passed

python3 scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy --strict
# passed

/Users/hojungjung/development/newsletter-generator/.venv/bin/python scripts/release_preflight.py
# passed

make check
# passed

make check-full
# passed
```

## Risk & Rollback
- Risk: 기존 `docs/dev/CODE_QUALITY.md` 직접 링크를 쓰던 외부 북마크는 archive 경로로 바뀝니다.
- Rollback: `git revert c79769a` 로 active 경로와 참조를 복원할 수 있습니다.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 해당 없음
- Outbox/send_key 중복 방지 결과: 해당 없음
- import-time side effect 제거 여부: 해당 없음

## Not Run (with reason)
- 없음
