### PR TITLE
docs: consolidate contributor workflow docs

### DIFF
--- a/docs/DOCUMENT_INVENTORY.md
+++ b/docs/DOCUMENT_INVENTORY.md
@@ -45,12 +45,12 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 | [`dev/DEVELOPMENT_GUIDE.md`](dev/DEVELOPMENT_GUIDE.md) | supporting | Contributor Workflow | [`../setup/LOCAL_SETUP.md`](setup/LOCAL_SETUP.md) | keep |
 | [`dev/LOCAL_CI_GUIDE.md`](dev/LOCAL_CI_GUIDE.md) | supporting | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | keep |
 | [`archive/2026-q1/CODE_QUALITY.md`](archive/2026-q1/CODE_QUALITY.md) | obsolete | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md), [`dev/LOCAL_CI_GUIDE.md`](dev/LOCAL_CI_GUIDE.md) | archive |
-| [`dev/WORKFLOW_TEMPLATES.md`](dev/WORKFLOW_TEMPLATES.md) | supporting | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | keep |
-| [`dev/RR_REQUEST_TEMPLATE.md`](dev/RR_REQUEST_TEMPLATE.md) | supporting | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | keep |
-| [`dev/AGENT_SKILL_REQUEST_PLAYBOOK.md`](dev/AGENT_SKILL_REQUEST_PLAYBOOK.md) | supporting | Contributor Workflow | [`../AGENTS.md`](../AGENTS.md) | keep |
+| [`archive/2026-q1/WORKFLOW_TEMPLATES.md`](archive/2026-q1/WORKFLOW_TEMPLATES.md) | obsolete | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | archive |
+| [`archive/2026-q1/RR_REQUEST_TEMPLATE.md`](archive/2026-q1/RR_REQUEST_TEMPLATE.md) | obsolete | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md), [`../.github/ISSUE_TEMPLATE/review-request.yml`](../.github/ISSUE_TEMPLATE/review-request.yml) | archive |
+| [`dev/AGENT_SKILL_REQUEST_PLAYBOOK.md`](dev/AGENT_SKILL_REQUEST_PLAYBOOK.md) | supporting | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md), [`../AGENTS.md`](../AGENTS.md) | keep |
 | [`dev/AGENTS_GOVERNANCE.md`](dev/AGENTS_GOVERNANCE.md) | supporting | Repo Governance | [`../AGENTS.md`](../AGENTS.md) | keep |
 | [`dev/langsmith_setup.md`](dev/langsmith_setup.md) | supporting | Runtime Config | [`technical/LLM_CONFIGURATION.md`](technical/LLM_CONFIGURATION.md) | keep |
-| [`archive/2026-q1/MAIN_INTEGRATION_EXECUTION_PLAN.md`](archive/2026-q1/MAIN_INTEGRATION_EXECUTION_PLAN.md) | historical | Release/Ops | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md), [`dev/WORKFLOW_TEMPLATES.md`](dev/WORKFLOW_TEMPLATES.md) | archive |
+| [`archive/2026-q1/MAIN_INTEGRATION_EXECUTION_PLAN.md`](archive/2026-q1/MAIN_INTEGRATION_EXECUTION_PLAN.md) | historical | Release/Ops | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md), [`dev/AGENT_SKILL_REQUEST_PLAYBOOK.md`](dev/AGENT_SKILL_REQUEST_PLAYBOOK.md) | archive |
 | [`archive/2026-q1/BRANCH_MAIN_GAP_ANALYSIS.md`](archive/2026-q1/BRANCH_MAIN_GAP_ANALYSIS.md) | historical | Release/Ops | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | archive |
 | [`archive/2026-q1/REFACTORING_EXECUTION_PLAN.md`](archive/2026-q1/REFACTORING_EXECUTION_PLAN.md) | historical | Repo Hygiene | [`dev/LONG_TERM_REPO_STRATEGY.md`](dev/LONG_TERM_REPO_STRATEGY.md), [`dev/REPO_HYGIENE_POLICY.md`](dev/REPO_HYGIENE_POLICY.md) | archive |
 | [`archive/2026-q1/MULTI_LLM_IMPLEMENTATION_SUMMARY.md`](archive/2026-q1/MULTI_LLM_IMPLEMENTATION_SUMMARY.md) | historical | Architecture | [`technical/LLM_CONFIGURATION.md`](technical/LLM_CONFIGURATION.md), [`ARCHITECTURE.md`](ARCHITECTURE.md) | archive |
@@ -109,3 +109,4 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 7. 환경 샘플은 root `.env.example`(canonical runtime) 과 `apps/experimental/.env.example`(experimental runtime) 로 분리했습니다.
 8. `docs/dev/CODEX_INSTRUCTION_LAYOUT.md` 는 활성 거버넌스 문서 역할에 맞게 [`dev/AGENTS_GOVERNANCE.md`](dev/AGENTS_GOVERNANCE.md) 로 rename 했습니다.
 9. stale 상태였던 `docs/dev/CODE_QUALITY.md` 는 [`archive/2026-q1/CODE_QUALITY.md`](archive/2026-q1/CODE_QUALITY.md) 로 이관하고, active 품질 기준은 [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) 로 흡수했습니다.
+10. contributor workflow 중복 문서는 [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) 정본으로 통합하고, `WORKFLOW_TEMPLATES` 및 `RR_REQUEST_TEMPLATE` 는 archive 로 이관했습니다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,11 +15,8 @@
 | 리포 구조/운영 전략 | [`dev/LONG_TERM_REPO_STRATEGY.md`](dev/LONG_TERM_REPO_STRATEGY.md) | 장기 구조 개편/운영 플레이북 |
 | Repo hygiene 정책 | [`dev/REPO_HYGIENE_POLICY.md`](dev/REPO_HYGIENE_POLICY.md) | 루트 분류/soft gate/dot 추적 범위 |
 | 문서 전수조사표 | [`DOCUMENT_INVENTORY.md`](DOCUMENT_INVENTORY.md) | 문서 상태/owner/disposition 정리 |
-| Agent/Skill 요청 표준 | [`dev/AGENT_SKILL_REQUEST_PLAYBOOK.md`](dev/AGENT_SKILL_REQUEST_PLAYBOOK.md) | commit/PR/CI 중심 실행 요청 템플릿 |
 | AGENTS/Skill 거버넌스 | [`dev/AGENTS_GOVERNANCE.md`](dev/AGENTS_GOVERNANCE.md) | 글로벌/레포/하위 AGENTS precedence와 skill 경계 |
-| RR 요청 템플릿 | [`dev/RR_REQUEST_TEMPLATE.md`](dev/RR_REQUEST_TEMPLATE.md) | 작업 요청 문장 표준 |
 | PR/Commit/Branch 프로세스 | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | 템플릿 경로 + PR policy check gate |
-| 워크플로 템플릿 종합 | [`dev/WORKFLOW_TEMPLATES.md`](dev/WORKFLOW_TEMPLATES.md) | RR/브랜치/커밋/PR/머지 운영 표준 |
 
 ## Audience Paths
 
@@ -38,8 +35,6 @@
   - [`dev/REPO_HYGIENE_POLICY.md`](dev/REPO_HYGIENE_POLICY.md)
   - [`dev/AGENT_SKILL_REQUEST_PLAYBOOK.md`](dev/AGENT_SKILL_REQUEST_PLAYBOOK.md)
   - [`dev/AGENTS_GOVERNANCE.md`](dev/AGENTS_GOVERNANCE.md)
-  - [`dev/RR_REQUEST_TEMPLATE.md`](dev/RR_REQUEST_TEMPLATE.md)
-  - [`dev/WORKFLOW_TEMPLATES.md`](dev/WORKFLOW_TEMPLATES.md)
   - [`developer/CENTRALIZED_SETTINGS_GUIDE.md`](developer/CENTRALIZED_SETTINGS_GUIDE.md)
   - [`technical/LLM_CONFIGURATION.md`](technical/LLM_CONFIGURATION.md)
 
@@ -85,5 +80,7 @@
   - [`archive/2026-q1/FIXES_SUMMARY.md`](archive/2026-q1/FIXES_SUMMARY.md)
   - [`archive/2026-q1/PROJECT_STRUCTURE.md`](archive/2026-q1/PROJECT_STRUCTURE.md)
   - [`archive/2026-q1/CODE_QUALITY.md`](archive/2026-q1/CODE_QUALITY.md)
+  - [`archive/2026-q1/RR_REQUEST_TEMPLATE.md`](archive/2026-q1/RR_REQUEST_TEMPLATE.md)
+  - [`archive/2026-q1/WORKFLOW_TEMPLATES.md`](archive/2026-q1/WORKFLOW_TEMPLATES.md)
   - [`archive/2026-q1/MULTI_LLM_IMPLEMENTATION_SUMMARY.md`](archive/2026-q1/MULTI_LLM_IMPLEMENTATION_SUMMARY.md)
   - [`archive/webservice-prd.md`](archive/webservice-prd.md)

--- a/docs/archive/2026-q1/README.md
+++ b/docs/archive/2026-q1/README.md
@@ -17,6 +17,8 @@
 | [`REFACTORING_EXECUTION_PLAN.md`](REFACTORING_EXECUTION_PLAN.md) | 시점 고정형 리팩토링 배치 계획 | [`../../dev/LONG_TERM_REPO_STRATEGY.md`](../../dev/LONG_TERM_REPO_STRATEGY.md), [`../../dev/REPO_HYGIENE_POLICY.md`](../../dev/REPO_HYGIENE_POLICY.md) |
 | [`UNIFIED_ARCHITECTURE.md`](UNIFIED_ARCHITECTURE.md) | 중복된 아키텍처 개요 문서 | [`../../ARCHITECTURE.md`](../../ARCHITECTURE.md), [`../../technical/adr-0001-architecture-boundaries.md`](../../technical/adr-0001-architecture-boundaries.md) |
 | [`CODE_QUALITY.md`](CODE_QUALITY.md) | 현재 게이트 구성과 어긋난 예전 코드 품질 안내 | [`../../dev/CI_CD_GUIDE.md`](../../dev/CI_CD_GUIDE.md), [`../../dev/LOCAL_CI_GUIDE.md`](../../dev/LOCAL_CI_GUIDE.md) |
+| [`RR_REQUEST_TEMPLATE.md`](RR_REQUEST_TEMPLATE.md) | GitHub RR 템플릿과 중복된 요청 예시 문서 | [`../../dev/CI_CD_GUIDE.md`](../../dev/CI_CD_GUIDE.md), [`../../../.github/ISSUE_TEMPLATE/review-request.yml`](../../../.github/ISSUE_TEMPLATE/review-request.yml) |
+| [`WORKFLOW_TEMPLATES.md`](WORKFLOW_TEMPLATES.md) | contributor workflow 정본과 중복된 템플릿 문서 | [`../../dev/CI_CD_GUIDE.md`](../../dev/CI_CD_GUIDE.md) |
 
 ## Rollback
 

--- a/docs/archive/2026-q1/RR_REQUEST_TEMPLATE.md
+++ b/docs/archive/2026-q1/RR_REQUEST_TEMPLATE.md
@@ -1,5 +1,9 @@
 # RR (Request/Review) Template
 
+> Historical note (2026-03-09): RR-07에서 active docs tree 밖으로 이관된 문서입니다.
+> 현재 RR 요청 정본은 `.github/ISSUE_TEMPLATE/review-request.yml` 와
+> `docs/dev/CI_CD_GUIDE.md` 의 request entry 패턴을 기준으로 유지합니다.
+
 이 문서는 에이전트 작업 요청(RR)을 표준화하기 위한 템플릿입니다.
 GitHub 이슈 기반 RR의 정본은 `.github/ISSUE_TEMPLATE/review-request.yml`입니다.
 

--- a/docs/archive/2026-q1/WORKFLOW_TEMPLATES.md
+++ b/docs/archive/2026-q1/WORKFLOW_TEMPLATES.md
@@ -1,5 +1,8 @@
 # Workflow Templates (RR / Branch / Commit / PR)
 
+> Historical note (2026-03-09): RR-07에서 active docs tree 밖으로 이관된 문서입니다.
+> 현재 contributor workflow 정본은 `docs/dev/CI_CD_GUIDE.md` 입니다.
+
 이 문서는 작업 요청(RR)부터 브랜치/커밋/PR/머지까지 하나의 운영 표준으로 맞추기 위한 템플릿 모음입니다.
 
 ## 1) RR(Review Request) 템플릿

--- a/docs/dev/AGENT_SKILL_REQUEST_PLAYBOOK.md
+++ b/docs/dev/AGENT_SKILL_REQUEST_PLAYBOOK.md
@@ -1,48 +1,19 @@
 # Agent/Skill Request Playbook
 
-This document standardizes work as `RR -> Branch -> Commit -> PR -> CI -> Merge`.
+This document complements the canonical workflow in `docs/dev/CI_CD_GUIDE.md`.
+Use it when you need skill-specific request wording rather than the base RR/PR process.
 
 ## Purpose
 
-- Manage work as clear PR-sized delivery units.
-- Split CI failure handling and review-comment handling into dedicated skills.
-- Standardize request wording so long-running work stays reproducible.
+- Route specialized requests to the right skill or agent.
+- Keep CI failure handling and review-comment handling distinct from general RR execution.
+- Reuse concise request patterns without duplicating the full workflow standard.
 
-## Basic Execution Contract
+## Canonical Workflow Boundary
 
-Include the following nine requirements in the request by default.
-
-1. Create an RR (Review Request) first: `.github/ISSUE_TEMPLATE/review-request.yml`
-2. Require a `Delivery Unit ID` in the RR, and keep a strict 1:1 mapping between RR and PR
-3. Use the branch pattern `<type>/<scope>-<topic>` such as `codex/workflow-template-standard`
-4. Use `.gitmessage.txt` as the commit-message template and split commits by meaning
-5. Keep commit count in the default `1-6` range (exempt labels: `docs-only`, `trivial`, `hotfix`)
-6. Run local gates: `make check`, `make check-full`, and `make repo-audit` when needed
-7. Include the `## Delivery Unit` section in `.github/pull_request_template.md`
-8. Check GitHub Actions results and report status
-9. When a check fails, classify the cause and add a follow-up fix commit; avoid force-push unless there is a strong reason
-
-## Enforcement Principles
-
-- Codex/agents follow the repository root `AGENTS.md` first.
-- Use CI policy checks so the same governance applies to human contributors.
-- CI enforcement: `.github/workflows/pr-policy-check.yml`
-- Delivery Unit validator: `scripts/ci/validate_delivery_unit.py`
-- RR auto-close after merge: `.github/workflows/rr-lifecycle-close.yml` (parses `RR: #<n>`)
-
-## Standard Template Locations
-
-- RR template: `.github/ISSUE_TEMPLATE/review-request.yml`
-- Commit template: `.gitmessage.txt`
-- PR template: `.github/pull_request_template.md`
-- Consolidated workflow guide: `docs/dev/WORKFLOW_TEMPLATES.md`
-- Delivery Unit check: `scripts/ci/validate_delivery_unit.py`
-
-Set the local commit template once:
-
-```bash
-git config commit.template .gitmessage.txt
-```
+- RR/branch/commit/PR/merge 운영 표준은 `docs/dev/CI_CD_GUIDE.md` 가 정본입니다.
+- `AGENTS.md` 와 `docs/dev/AGENTS_GOVERNANCE.md` 는 agent policy precedence를 다룹니다.
+- 이 문서는 위 정본을 대체하지 않고, skill 사용 시의 요청 문장 예시만 제공합니다.
 
 ## Skill Selection
 
@@ -57,7 +28,7 @@ git config commit.template .gitmessage.txt
 
 ## Request Templates
 
-### 1) Structure improvement request
+### 1) PR-sized structure improvement request
 
 ```text
 Handle this as a PR-sized unit of work.
@@ -83,12 +54,12 @@ Use $gh-address-comments to collect PR comments for the current branch.
 List the comment items first, then apply only the ones I select.
 ```
 
-## PR Completion Report
+## Output Reminder
 
-Use this format when work is complete.
+When a skill-assisted task completes, report:
 
-1. Commit list (hash + summary)
+1. commit hash or commit list
 2. PR link
-3. Local validation results (`make check`, `make check-full`, and any extras)
-4. GitHub Actions status (success/failure, and the failure cause if applicable)
-5. Risk and rollback note
+3. local validation results
+4. GitHub Actions status
+5. risk and rollback note

--- a/docs/dev/CI_CD_GUIDE.md
+++ b/docs/dev/CI_CD_GUIDE.md
@@ -114,6 +114,61 @@ python scripts/repo_audit.py \
 - 형식: `<type>(<scope>): <summary>`
 - summary 최대 72자
 
+## Contributor Workflow Standard
+
+기여자 workflow 정본은 이 섹션을 기준으로 유지합니다.
+
+1. RR 생성
+- GitHub RR 템플릿: `.github/ISSUE_TEMPLATE/review-request.yml`
+- RR 1건은 기본적으로 PR 1건과 1:1로 대응합니다.
+- `Delivery Unit ID` 를 RR과 PR 모두에 유지합니다.
+
+2. 브랜치 네이밍
+- 기본 패턴: `<type>/<scope>-<topic>`
+- 허용 type: `feat|fix|chore|docs|refactor|release|codex`
+
+3. 커밋 메시지
+- 기본 패턴: `<type>(<scope>): <summary>`
+- summary는 72자 이하, 명령형, 마침표 없이 작성합니다.
+- 기본 커밋 수는 PR당 `1-6` 범위를 권장합니다.
+
+4. PR 본문
+- `.github/pull_request_template.md` 의 필수 섹션을 모두 채웁니다.
+- `## Delivery Unit` 섹션에 `RR`, `Delivery Unit ID`, merge/rollback boundary를 명시합니다.
+
+5. Merge 정책
+- 기본 merge 방식: squash merge
+- merge 전 조건: `make check-full` 및 GitHub required checks green
+- hotfix 등 예외는 `## Not Run` 에 사유를 남깁니다.
+
+## Request Entry Patterns
+
+### Standard RR request
+
+```text
+이번 작업은 PR 단위로 끝까지 진행해줘.
+- 목표: <목표>
+- 범위: <in-scope / out-of-scope>
+- 브랜치: <type>/<scope>-<topic>
+- 필수 게이트: make check, make check-full
+- 선택 게이트: make repo-audit (구조/정책 변경 시)
+- 산출물: 커밋 해시, PR 링크, CI 상태, merge 결과, 롤백 메모
+```
+
+### CI failure request
+
+```text
+Use $gh-fix-ci to inspect the failing checks on the current PR.
+Summarize the root cause and proposed fix plan first, then implement after approval.
+```
+
+### Review-comment request
+
+```text
+Use $gh-address-comments to collect PR comments for the current branch.
+List the comment items first, then apply only the ones I select.
+```
+
 ## Strict Gate Policy
 
 - `mypy` 실패 시 CI 실패
@@ -142,5 +197,5 @@ make check-full
 - Repo hygiene/구조 정리 PR: `.github/PULL_REQUEST_TEMPLATE/repo_hygiene.md`
 - 릴리즈 통합 PR: `.github/PULL_REQUEST_TEMPLATE/release_integration.md`
 - Commit 템플릿: `.gitmessage.txt`
-- 워크플로 템플릿 가이드: `docs/dev/WORKFLOW_TEMPLATES.md`
+- skill 요청 예시: `docs/dev/AGENT_SKILL_REQUEST_PLAYBOOK.md`
 - 로컬 템플릿 설정: `./scripts/devtools/setup_git_message_template.sh`


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- contributor workflow 정본을 `docs/dev/CI_CD_GUIDE.md` 하나로 모으고, 중복 템플릿 문서를 archive 로 이관했습니다.
- `AGENT_SKILL_REQUEST_PLAYBOOK.md` 는 skill 선택과 요청 예시 중심의 보조 문서로 축소했습니다.

## Scope
### In Scope
- `CI_CD_GUIDE.md` 에 RR/branch/commit/PR/merge 표준 흡수
- `WORKFLOW_TEMPLATES.md`, `RR_REQUEST_TEMPLATE.md` archive-first 이관
- docs hub/inventory/archive index 갱신
- `AGENT_SKILL_REQUEST_PLAYBOOK.md` 역할 축소

### Out of Scope
- PR policy check 로직 변경
- GitHub workflow 변경
- AGENTS 정책 변경

## Delivery Unit
- RR: #267
- Delivery Unit ID: DU-20260309-workflow-docs
- Merge Boundary: RR-07 contributor workflow 문서 통합만 포함합니다.
- Rollback Boundary: 이 PR의 단일 커밋을 revert 하면 active/archive 경로와 참조가 함께 원복됩니다.

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): markdown/link/repo audit/release preflight

### Commands and Results
```bash
python3 scripts/check_markdown_links.py
# passed

python3 scripts/check_markdown_style.py
# passed

python3 scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy --strict
# passed

/Users/hojungjung/development/newsletter-generator/.venv/bin/python scripts/release_preflight.py
# passed

make check
# passed

make check-full
# passed
```

## Risk & Rollback
- Risk: 기존 active 경로를 직접 북마크하던 사용자는 archive 경로 또는 `CI_CD_GUIDE` 로 이동해야 합니다.
- Rollback: `git revert 78857b0` 로 active 경로와 허브 링크를 복구할 수 있습니다.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 해당 없음
- Outbox/send_key 중복 방지 결과: 해당 없음
- import-time side effect 제거 여부: 해당 없음

## Not Run (with reason)
- 없음
