### PR TITLE
docs: consolidate LangSmith setup guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,8 @@ NAVER_CLIENT_SECRET=your-naver-client-secret
 LANGCHAIN_API_KEY=your-langsmith-api-key
 LANGCHAIN_TRACING_V2=1
 LANGCHAIN_PROJECT=your-langsmith-project
+ENABLE_COST_TRACKING=false
+DEBUG_COST_TRACKING=false
 
 # Persistence / Queue (Optional)
 DATABASE_URL=sqlite:///./newsletter.db

--- a/docs/DOCUMENT_INVENTORY.md
+++ b/docs/DOCUMENT_INVENTORY.md
@@ -49,7 +49,7 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 | [`archive/2026-q1/RR_REQUEST_TEMPLATE.md`](archive/2026-q1/RR_REQUEST_TEMPLATE.md) | obsolete | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md), [`../.github/ISSUE_TEMPLATE/review-request.yml`](../.github/ISSUE_TEMPLATE/review-request.yml) | archive |
 | [`dev/AGENT_SKILL_REQUEST_PLAYBOOK.md`](dev/AGENT_SKILL_REQUEST_PLAYBOOK.md) | supporting | Contributor Workflow | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md), [`../AGENTS.md`](../AGENTS.md) | keep |
 | [`dev/AGENTS_GOVERNANCE.md`](dev/AGENTS_GOVERNANCE.md) | supporting | Repo Governance | [`../AGENTS.md`](../AGENTS.md) | keep |
-| [`dev/langsmith_setup.md`](dev/langsmith_setup.md) | supporting | Runtime Config | [`technical/LLM_CONFIGURATION.md`](technical/LLM_CONFIGURATION.md) | keep |
+| [`archive/2026-q1/langsmith_setup.md`](archive/2026-q1/langsmith_setup.md) | obsolete | Runtime Config | [`technical/LLM_CONFIGURATION.md`](technical/LLM_CONFIGURATION.md), [`reference/environment-variables.md`](reference/environment-variables.md) | archive |
 | [`archive/2026-q1/MAIN_INTEGRATION_EXECUTION_PLAN.md`](archive/2026-q1/MAIN_INTEGRATION_EXECUTION_PLAN.md) | historical | Release/Ops | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md), [`dev/AGENT_SKILL_REQUEST_PLAYBOOK.md`](dev/AGENT_SKILL_REQUEST_PLAYBOOK.md) | archive |
 | [`archive/2026-q1/BRANCH_MAIN_GAP_ANALYSIS.md`](archive/2026-q1/BRANCH_MAIN_GAP_ANALYSIS.md) | historical | Release/Ops | [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) | archive |
 | [`archive/2026-q1/REFACTORING_EXECUTION_PLAN.md`](archive/2026-q1/REFACTORING_EXECUTION_PLAN.md) | historical | Repo Hygiene | [`dev/LONG_TERM_REPO_STRATEGY.md`](dev/LONG_TERM_REPO_STRATEGY.md), [`dev/REPO_HYGIENE_POLICY.md`](dev/REPO_HYGIENE_POLICY.md) | archive |
@@ -110,3 +110,4 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 8. `docs/dev/CODEX_INSTRUCTION_LAYOUT.md` 는 활성 거버넌스 문서 역할에 맞게 [`dev/AGENTS_GOVERNANCE.md`](dev/AGENTS_GOVERNANCE.md) 로 rename 했습니다.
 9. stale 상태였던 `docs/dev/CODE_QUALITY.md` 는 [`archive/2026-q1/CODE_QUALITY.md`](archive/2026-q1/CODE_QUALITY.md) 로 이관하고, active 품질 기준은 [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) 로 흡수했습니다.
 10. contributor workflow 중복 문서는 [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) 정본으로 통합하고, `WORKFLOW_TEMPLATES` 및 `RR_REQUEST_TEMPLATE` 는 archive 로 이관했습니다.
+11. LangSmith/cost-tracking standalone 문서는 [`technical/LLM_CONFIGURATION.md`](technical/LLM_CONFIGURATION.md) 와 [`reference/environment-variables.md`](reference/environment-variables.md) 로 흡수하고 archive-first 로 이관했습니다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,5 +82,6 @@
   - [`archive/2026-q1/CODE_QUALITY.md`](archive/2026-q1/CODE_QUALITY.md)
   - [`archive/2026-q1/RR_REQUEST_TEMPLATE.md`](archive/2026-q1/RR_REQUEST_TEMPLATE.md)
   - [`archive/2026-q1/WORKFLOW_TEMPLATES.md`](archive/2026-q1/WORKFLOW_TEMPLATES.md)
+  - [`archive/2026-q1/langsmith_setup.md`](archive/2026-q1/langsmith_setup.md)
   - [`archive/2026-q1/MULTI_LLM_IMPLEMENTATION_SUMMARY.md`](archive/2026-q1/MULTI_LLM_IMPLEMENTATION_SUMMARY.md)
   - [`archive/webservice-prd.md`](archive/webservice-prd.md)

--- a/docs/archive/2026-q1/README.md
+++ b/docs/archive/2026-q1/README.md
@@ -19,6 +19,7 @@
 | [`CODE_QUALITY.md`](CODE_QUALITY.md) | 현재 게이트 구성과 어긋난 예전 코드 품질 안내 | [`../../dev/CI_CD_GUIDE.md`](../../dev/CI_CD_GUIDE.md), [`../../dev/LOCAL_CI_GUIDE.md`](../../dev/LOCAL_CI_GUIDE.md) |
 | [`RR_REQUEST_TEMPLATE.md`](RR_REQUEST_TEMPLATE.md) | GitHub RR 템플릿과 중복된 요청 예시 문서 | [`../../dev/CI_CD_GUIDE.md`](../../dev/CI_CD_GUIDE.md), [`../../../.github/ISSUE_TEMPLATE/review-request.yml`](../../../.github/ISSUE_TEMPLATE/review-request.yml) |
 | [`WORKFLOW_TEMPLATES.md`](WORKFLOW_TEMPLATES.md) | contributor workflow 정본과 중복된 템플릿 문서 | [`../../dev/CI_CD_GUIDE.md`](../../dev/CI_CD_GUIDE.md) |
+| [`langsmith_setup.md`](langsmith_setup.md) | LangSmith/비용 추적 standalone 가이드가 정본 문서와 중복 | [`../../technical/LLM_CONFIGURATION.md`](../../technical/LLM_CONFIGURATION.md), [`../../reference/environment-variables.md`](../../reference/environment-variables.md) |
 
 ## Rollback
 

--- a/docs/archive/2026-q1/langsmith_setup.md
+++ b/docs/archive/2026-q1/langsmith_setup.md
@@ -1,5 +1,9 @@
 # LangSmith 연동 및 비용 추적 가이드
 
+> Historical note (RR-08): active LangSmith and cost-tracking guidance moved to
+> `../../technical/LLM_CONFIGURATION.md` and
+> `../../reference/environment-variables.md`.
+
 이 문서는 뉴스레터 생성기에서 LangSmith 연동 및 Google Generative AI 비용 추적을 설정하는 방법을 안내합니다.
 
 ## `.env` 파일을 사용한 환경 변수 설정

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -48,8 +48,10 @@
 | 변수 | 필수 여부 | 용도 |
 |---|---|---|
 | `LANGCHAIN_API_KEY` | LangSmith 사용 시 선택 | LangSmith API key |
-| `LANGCHAIN_TRACING_V2` | LangSmith 사용 시 선택 | tracing 토글 |
+| `LANGCHAIN_TRACING_V2` | LangSmith 사용 시 선택 | tracing 토글 (`true`/`1`) |
 | `LANGCHAIN_PROJECT` | LangSmith 사용 시 선택 | tracing project name |
+| `ENABLE_COST_TRACKING` | 비용 추적 사용 시 선택 | provider cost callback 활성화 (`--track-cost` 와 동일 목적) |
+| `DEBUG_COST_TRACKING` | 로컬 디버깅 시 선택 | LangSmith/cost tracking 초기화 디버그 로그 |
 | `DATABASE_URL` | DB persistence 사용 시 선택 | 애플리케이션 DB 연결 문자열 |
 | `REDIS_URL` | worker/scheduler 사용 시 필수 | Redis 연결 |
 | `RQ_QUEUE` | 선택 | RQ 큐 이름 (`default`) |
@@ -114,6 +116,11 @@
 SERPER_API_KEY=...
 GEMINI_API_KEY=...
 APP_ENV=development
+LANGCHAIN_API_KEY=...
+LANGCHAIN_TRACING_V2=1
+LANGCHAIN_PROJECT=...
+ENABLE_COST_TRACKING=false
+DEBUG_COST_TRACKING=false
 
 # 이메일 발송 포함
 POSTMARK_SERVER_TOKEN=ps_xxx

--- a/docs/technical/LLM_CONFIGURATION.md
+++ b/docs/technical/LLM_CONFIGURATION.md
@@ -159,6 +159,40 @@ provider_models:
 3. 사용 불가능한 경우 사용 가능한 다른 제공자로 자동 전환
 4. 모든 제공자가 사용 불가능한 경우 오류 발생
 
+## Observability and Cost Tracking
+
+LangSmith tracing and provider cost tracking are optional features. The current
+runtime implementation lives in `newsletter/cost_tracking.py`, and CLI
+entrypoints can enable cost tracking per invocation.
+
+### Runtime contract
+
+- `LANGCHAIN_API_KEY`: LangSmith API key
+- `LANGCHAIN_TRACING_V2`: `true` or `1` when tracing should initialize
+- `LANGCHAIN_PROJECT`: optional project name, defaults to `default-project`
+- `ENABLE_COST_TRACKING`: `true` or `1` to add provider cost callbacks
+- `DEBUG_COST_TRACKING`: optional debug logging for tracing initialization
+
+Use `../reference/environment-variables.md` as the canonical variable list and
+`../../.env.example` as the default sample. `LANGCHAIN_ENDPOINT` is not part of
+the current runtime contract and should not be added to active samples unless
+the implementation starts reading it.
+
+### CLI behavior
+
+- `newsletter run --track-cost`
+- `newsletter test ... --track-cost`
+
+The `--track-cost` flag sets `ENABLE_COST_TRACKING=1` for the current process.
+If `LANGCHAIN_TRACING_V2` and `LANGCHAIN_API_KEY` are both set, LangSmith
+tracing initializes alongside provider cost callbacks.
+
+### Operational guidance
+
+- Use `DEBUG_COST_TRACKING=1` only for local debugging because it increases
+  tracing setup logs.
+- Keep end-user quick-start material in `../user/MULTI_LLM_GUIDE.md`.
+
 ## 비용 최적화 팁
 
 ### 1. 작업 특성에 맞는 모델 선택


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- archive `docs/dev/langsmith_setup.md` and keep LangSmith guidance in canonical runtime docs only
- add active cost-tracking variables to `docs/reference/environment-variables.md` and `.env.example`
- document current LangSmith/cost-tracking runtime behavior in `docs/technical/LLM_CONFIGURATION.md`

## Scope
### In Scope
- move the stale standalone LangSmith guide to `docs/archive/2026-q1/`
- align active docs and env samples with the variables the runtime actually reads
- update docs hub and inventory metadata

### Out of Scope
- runtime code changes
- LLM provider/model refactors
- CLI behavior changes

## Delivery Unit
- RR: #269
- Delivery Unit ID: DU-20260309-langsmith-docs
- Merge Boundary: RR-08 LangSmith/cost-tracking doc consolidation only
- Rollback Boundary: revert this PR and move `docs/archive/2026-q1/langsmith_setup.md` back to `docs/dev/langsmith_setup.md`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): `python3 scripts/check_markdown_links.py`, `python3 scripts/check_markdown_style.py`, `python3 scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy --strict`, `/Users/hojungjung/development/newsletter-generator/.venv/bin/python scripts/release_preflight.py`

### Commands and Results
```bash
python3 scripts/check_markdown_links.py
# PASS: Markdown link integrity check passed (0 broken internal links).

python3 scripts/check_markdown_style.py
# PASS: Markdown style check passed.

python3 scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy --strict
# PASS: top-level entries=44 warnings=0

/Users/hojungjung/development/newsletter-generator/.venv/bin/python scripts/release_preflight.py
# PASS: RESULT: PASSED (preflight)

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: low; docs/sample-only changes could misdescribe runtime variables if the contract is wrong
- Rollback: revert commit `50299946da24653fb63b844759ffc99d76c22c66`

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: not touched
- Outbox/send_key 중복 방지 결과: not touched
- import-time side effect 제거 여부: not touched

## Not Run (with reason)
- none
