### PR TITLE
docs: archive remaining historical logs and QA summary

### DIFF
--- a/docs/DOCUMENT_INVENTORY.md
+++ b/docs/DOCUMENT_INVENTORY.md
@@ -2,7 +2,7 @@
 
 문서 정합성 전수조사 기준일: 2026-03-09
 
-이 문서는 현재 추적 중인 Markdown 문서 55개를 대상으로 `canonical`, `supporting`, `historical`, `obsolete` 상태를 지정한 인벤토리입니다.
+이 문서는 현재 추적 중인 Markdown 문서 56개를 대상으로 `canonical`, `supporting`, `historical`, `obsolete` 상태를 지정한 인벤토리입니다.
 owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 
 ## Status Definitions
@@ -71,7 +71,7 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 | [`setup/WINDOWS_EXE_OPERATIONS.md`](setup/WINDOWS_EXE_OPERATIONS.md) | canonical | Setup/Deploy | - | keep |
 | [`setup/WINDOWS_EXE_SMOKE_PLAYBOOK.md`](setup/WINDOWS_EXE_SMOKE_PLAYBOOK.md) | supporting | Setup/Deploy | [`setup/WINDOWS_EXE_OPERATIONS.md`](setup/WINDOWS_EXE_OPERATIONS.md) | keep |
 | [`setup/WINDOWS_EXE_UPDATE_CHANNEL.md`](setup/WINDOWS_EXE_UPDATE_CHANNEL.md) | supporting | Setup/Deploy | [`setup/WINDOWS_EXE_OPERATIONS.md`](setup/WINDOWS_EXE_OPERATIONS.md) | keep |
-| [`setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md`](setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md) | historical | Setup/Deploy | [`setup/WINDOWS_EXE_OPERATIONS.md`](setup/WINDOWS_EXE_OPERATIONS.md) | keep |
+| [`archive/2026-q1/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md`](archive/2026-q1/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md) | historical | Setup/Deploy | [`setup/WINDOWS_EXE_OPERATIONS.md`](setup/WINDOWS_EXE_OPERATIONS.md) | archive |
 | [`user/USER_GUIDE.md`](user/USER_GUIDE.md) | canonical | User Docs | - | keep |
 | [`user/CLI_REFERENCE.md`](user/CLI_REFERENCE.md) | canonical | User Docs | - | keep |
 | [`user/MULTI_LLM_GUIDE.md`](user/MULTI_LLM_GUIDE.md) | supporting | User Docs | [`technical/LLM_CONFIGURATION.md`](technical/LLM_CONFIGURATION.md) | keep |
@@ -93,10 +93,11 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 | Path | Status | Owner | Canonical Replacement | Disposition |
 |---|---|---|---|---|
 | [`../tests/README.md`](../tests/README.md) | supporting | QA | [`dev/LOCAL_CI_GUIDE.md`](dev/LOCAL_CI_GUIDE.md) | keep |
+| [`../tests/archive/README.md`](../tests/archive/README.md) | supporting | QA | [`../tests/README.md`](../tests/README.md) | keep |
 | [`../tests/TEST_EXECUTION_GUIDE.md`](../tests/TEST_EXECUTION_GUIDE.md) | supporting | QA | [`../tests/README.md`](../tests/README.md) | keep |
 | [`../tests/TEST_REPORT_COMPACT_DEFINITIONS.md`](../tests/TEST_REPORT_COMPACT_DEFINITIONS.md) | supporting | QA | [`../tests/README.md`](../tests/README.md) | keep |
 | [`../tests/TEST_CLASSIFICATION_SUMMARY.md`](../tests/TEST_CLASSIFICATION_SUMMARY.md) | supporting | QA | [`../tests/README.md`](../tests/README.md) | keep |
-| [`../tests/RESULTS_SUMMARY.md`](../tests/RESULTS_SUMMARY.md) | historical | QA | [`../tests/README.md`](../tests/README.md) | keep |
+| [`../tests/archive/RESULTS_SUMMARY.md`](../tests/archive/RESULTS_SUMMARY.md) | historical | QA | [`../tests/README.md`](../tests/README.md) | archive |
 
 ## Immediate Actions Applied in This RR
 
@@ -112,3 +113,6 @@ owner는 개인 이름이 아니라 기능 영역 기준 관리 책임입니다.
 10. contributor workflow 중복 문서는 [`dev/CI_CD_GUIDE.md`](dev/CI_CD_GUIDE.md) 정본으로 통합하고, `WORKFLOW_TEMPLATES` 및 `RR_REQUEST_TEMPLATE` 는 archive 로 이관했습니다.
 11. LangSmith/cost-tracking standalone 문서는 [`technical/LLM_CONFIGURATION.md`](technical/LLM_CONFIGURATION.md) 와 [`reference/environment-variables.md`](reference/environment-variables.md) 로 흡수하고 archive-first 로 이관했습니다.
 12. 날짜가 박힌 architecture baseline snapshot 은 [`archive/2026-q1/architecture-baseline-2026-02-22.md`](archive/2026-q1/architecture-baseline-2026-02-22.md) 로 이관하고, active 구조 기준은 ADR + migration log 조합으로 유지했습니다.
+13. 날짜가 고정된 Windows release admin log 는 [`archive/2026-q1/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md`](archive/2026-q1/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md) 로 이관하고, active 운영 기준은 [`setup/WINDOWS_EXE_OPERATIONS.md`](setup/WINDOWS_EXE_OPERATIONS.md) 로 유지했습니다.
+14. historical QA summary 는 `tests/archive/` 규칙을 만들고 [`../tests/archive/RESULTS_SUMMARY.md`](../tests/archive/RESULTS_SUMMARY.md) 로 이관했습니다.
+15. [`technical/architecture-migration-log.md`](technical/architecture-migration-log.md) 는 shim 제거 일정이 아직 열려 있으므로 active 참고 문서로 유지합니다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,6 @@
   - [`setup/RAILWAY_DEPLOYMENT.md`](setup/RAILWAY_DEPLOYMENT.md)
   - [`setup/WINDOWS_EXE_OPERATIONS.md`](setup/WINDOWS_EXE_OPERATIONS.md)
   - [`setup/WINDOWS_EXE_UPDATE_CHANNEL.md`](setup/WINDOWS_EXE_UPDATE_CHANNEL.md)
-  - [`setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md`](setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md)
   - [`reference/web-api.md`](reference/web-api.md)
   - [`reference/environment-variables.md`](reference/environment-variables.md)
 
@@ -52,6 +51,7 @@
   - [`technical/architecture-migration-log.md`](technical/architecture-migration-log.md)
   - [`technical/shim-deprecation-schedule.md`](technical/shim-deprecation-schedule.md)
   - [`PRD.md`](PRD.md)
+  - `technical/architecture-migration-log.md` 는 shim 제거가 완료될 때까지 active 참고 문서로 유지합니다.
 
 ## Governance
 
@@ -84,5 +84,6 @@
   - [`archive/2026-q1/WORKFLOW_TEMPLATES.md`](archive/2026-q1/WORKFLOW_TEMPLATES.md)
   - [`archive/2026-q1/langsmith_setup.md`](archive/2026-q1/langsmith_setup.md)
   - [`archive/2026-q1/architecture-baseline-2026-02-22.md`](archive/2026-q1/architecture-baseline-2026-02-22.md)
+  - [`archive/2026-q1/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md`](archive/2026-q1/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md)
   - [`archive/2026-q1/MULTI_LLM_IMPLEMENTATION_SUMMARY.md`](archive/2026-q1/MULTI_LLM_IMPLEMENTATION_SUMMARY.md)
   - [`archive/webservice-prd.md`](archive/webservice-prd.md)

--- a/docs/archive/2026-q1/README.md
+++ b/docs/archive/2026-q1/README.md
@@ -21,6 +21,7 @@
 | [`WORKFLOW_TEMPLATES.md`](WORKFLOW_TEMPLATES.md) | contributor workflow 정본과 중복된 템플릿 문서 | [`../../dev/CI_CD_GUIDE.md`](../../dev/CI_CD_GUIDE.md) |
 | [`langsmith_setup.md`](langsmith_setup.md) | LangSmith/비용 추적 standalone 가이드가 정본 문서와 중복 | [`../../technical/LLM_CONFIGURATION.md`](../../technical/LLM_CONFIGURATION.md), [`../../reference/environment-variables.md`](../../reference/environment-variables.md) |
 | [`architecture-baseline-2026-02-22.md`](architecture-baseline-2026-02-22.md) | 날짜가 고정된 구조 기준선 스냅샷 | [`../../technical/adr-0001-architecture-boundaries.md`](../../technical/adr-0001-architecture-boundaries.md), [`../../technical/architecture-migration-log.md`](../../technical/architecture-migration-log.md) |
+| [`WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md`](WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md) | 날짜가 고정된 Windows release 운영 로그 | [`../../setup/WINDOWS_EXE_OPERATIONS.md`](../../setup/WINDOWS_EXE_OPERATIONS.md) |
 
 ## Rollback
 

--- a/docs/archive/2026-q1/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md
+++ b/docs/archive/2026-q1/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md
@@ -1,5 +1,8 @@
 # Windows Release Admin Log (2026-02-24)
 
+> Historical note (RR-10): active Windows release guidance remains in
+> `../../setup/WINDOWS_EXE_OPERATIONS.md`.
+
 ## 목적
 
 - Windows EXE release 제어 항목을 운영 환경에 적용한 이력을 남깁니다.

--- a/docs/setup/WINDOWS_EXE_OPERATIONS.md
+++ b/docs/setup/WINDOWS_EXE_OPERATIONS.md
@@ -126,4 +126,4 @@ make github-windows-release-controls
 
 ## 8) 실행 로그
 
-- 2026-02-24 실행 로그: `docs/setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md`
+- 2026-02-24 실행 로그(archive): [`docs/archive/2026-q1/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md`](../archive/2026-q1/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md)

--- a/tests/README.md
+++ b/tests/README.md
@@ -105,6 +105,11 @@ python scripts/devtools/run_tests.py integration
 python tests/deployment/smoke_test.py --railway
 ```
 
+## Historical Reports
+
+- archived QA summary: [`archive/RESULTS_SUMMARY.md`](archive/RESULTS_SUMMARY.md)
+- historical reports are not the current execution standard; use this guide and [`TEST_EXECUTION_GUIDE.md`](TEST_EXECUTION_GUIDE.md) first.
+
 ## 🏷️ 테스트 마커 시스템
 
 프로젝트에서 사용하는 pytest 마커:

--- a/tests/archive/README.md
+++ b/tests/archive/README.md
@@ -1,0 +1,10 @@
+# Test Archive Index
+
+이 디렉터리는 현재 실행 기준이 아닌 historical QA 산출물을 보관합니다.
+운영/개발 시에는 먼저 `../README.md` 와 `../TEST_EXECUTION_GUIDE.md` 를 사용합니다.
+
+## Archived Reports
+
+| Archived Document | Reason | Active Replacement |
+|---|---|---|
+| [`RESULTS_SUMMARY.md`](RESULTS_SUMMARY.md) | 과거 필터링 구현 요약 보고서이며 현재 테스트 실행 기준이 아님 | [`../README.md`](../README.md), [`../TEST_EXECUTION_GUIDE.md`](../TEST_EXECUTION_GUIDE.md) |

--- a/tests/archive/RESULTS_SUMMARY.md
+++ b/tests/archive/RESULTS_SUMMARY.md
@@ -1,5 +1,8 @@
 # Newsletter Generator Filtering Implementation Results
 
+> Historical note (RR-10): current QA execution guidance remains in
+> `../README.md`.
+
 ## What We Implemented
 
 1. **Article Filtering Module (`article_filter.py`)**


### PR DESCRIPTION
## Summary (what / why)
- archive the remaining dated Windows release admin log and historical QA summary
- add a small `tests/archive/` index so historical QA docs have a stable archive location
- keep `docs/technical/architecture-migration-log.md` active and document why it is not archived yet

## Scope
### In Scope
- move `docs/setup/WINDOWS_RELEASE_ADMIN_LOG_2026-02-24.md` to `docs/archive/2026-q1/`
- move `tests/RESULTS_SUMMARY.md` to `tests/archive/`
- update docs hubs, archive indexes, and document inventory
- document the current keep-rationale for `docs/technical/architecture-migration-log.md`

### Out of Scope
- any runtime/code/config changes
- archiving `docs/technical/architecture-migration-log.md` before shim retirement completes

## Delivery Unit
- RR: #273
- Delivery Unit ID: DU-20260309-archive-historical-logs
- Merge Boundary: docs archive cleanup for remaining historical logs and QA summary only
- Rollback Boundary: revert commit `b56f83f20cc04991afc33864c21a8d9ddca72651`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): `python3 scripts/check_markdown_links.py`, `python3 scripts/check_markdown_style.py`, `python3 scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy --strict`, `/Users/hojungjung/development/newsletter-generator/.venv/bin/python scripts/release_preflight.py`

### Commands and Results
```bash
python3 scripts/check_markdown_links.py
# Markdown link integrity check passed (0 broken internal links).

python3 scripts/check_markdown_style.py
# Markdown style check passed.

python3 scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy --strict
# repo_audit: top-level entries=44 warnings=0

/Users/hojungjung/development/newsletter-generator/.venv/bin/python scripts/release_preflight.py
# RESULT: PASSED (preflight)

make check
# ✅ check 완료

make check-full
# ✅ check-full 완료
```

## Risk & Rollback
- Risk: stale links if archive paths are referenced outside the updated hubs/indexes
- Rollback: revert commit `b56f83f20cc04991afc33864c21a8d9ddca72651` and restore the two moved files to their original paths

## Ops-Safety Addendum (if touching protected paths)
- Not applicable. This PR changes documentation/archive locations only and does not touch ops-safety-sensitive runtime paths.

## Not Run (with reason)
- 없음
