### PR TITLE
chore(root): isolate local artifacts under .local

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -23,6 +23,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  DEBUG_DIR: .local/debug_files
+
 jobs:
   # ========================================
   # Generate Newsletter
@@ -49,7 +52,7 @@ jobs:
         run: |
           mkdir -p output
           mkdir -p config
-          mkdir -p debug_files
+          mkdir -p "${DEBUG_DIR}"
           mkdir -p templates
 
       - name: Configure environment
@@ -79,6 +82,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           PYTHONPATH: ${{ github.workspace }}
+          NEWSLETTER_DEBUG_DIR: ${{ env.DEBUG_DIR }}
         run: |
           echo "🚀 Generating newsletter with real APIs"
           python -m newsletter run --keywords "AI,기술뉴스,개발" --template-style compact

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -23,6 +23,10 @@ env:
   CACHE_VERSION: v1
   # Hard gate is enabled by default; allow temporary override only if needed.
   REPO_HYGIENE_STRICT: 'true'
+  REPO_AUDIT_DIR: .local/artifacts/repo-audit
+  COVERAGE_DIR: .local/coverage
+  DEBUG_DIR: .local/debug_files
+  WINDOWS_CI_BURNIN_REPORT: .local/artifacts/windows-ci-burnin.json
 
 jobs:
   # ========================================
@@ -159,17 +163,17 @@ jobs:
           fi
           python scripts/repo_audit.py \
             --policy scripts/repo_hygiene_policy.json \
-            --output-dir artifacts/repo-audit \
+            --output-dir "${REPO_AUDIT_DIR}" \
             --check-policy \
             "${STRICT_ARGS[@]}"
-          cat artifacts/repo-audit/policy_warnings.md >> "$GITHUB_STEP_SUMMARY"
+          cat "${REPO_AUDIT_DIR}/policy_warnings.md" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload repo audit artifact
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: repo-audit-${{ github.run_id }}
-          path: artifacts/repo-audit/
+          path: ${{ env.REPO_AUDIT_DIR }}/
 
       - name: Type checking (mypy)
         shell: bash
@@ -257,7 +261,8 @@ jobs:
         run: |
           mkdir -p output
           mkdir -p output/test_results
-          mkdir -p debug_files
+          mkdir -p "${DEBUG_DIR}"
+          mkdir -p "${COVERAGE_DIR}"
           mkdir -p templates
         shell: bash
 
@@ -266,6 +271,7 @@ jobs:
           MOCK_MODE: 'true'
           TESTING: '1'
           PYTHONPATH: ${{ github.workspace }}
+          NEWSLETTER_DEBUG_DIR: ${{ env.DEBUG_DIR }}
           # Dummy test environment variables
           OPENAI_API_KEY: test-key
           SERPER_API_KEY: test-key
@@ -274,7 +280,7 @@ jobs:
           POSTMARK_SERVER_TOKEN: dummy-token
           EMAIL_SENDER: test@example.com
         run: |
-          pytest -m unit --tb=short --junitxml=test-results-unit.xml --cov=newsletter --cov=newsletter_core --cov=web --cov-report=xml --cov-report=html
+          pytest -m unit --tb=short --junitxml=test-results-unit.xml
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -283,8 +289,8 @@ jobs:
           name: test-results-unit-${{ matrix.os }}-${{ matrix.python-version }}
           path: |
             test-results-*.xml
-            coverage.xml
-            htmlcov/
+            ${{ env.COVERAGE_DIR }}/coverage.xml
+            ${{ env.COVERAGE_DIR }}/htmlcov/
 
   # ========================================
   # Stage 3: Mock API Tests
@@ -312,7 +318,7 @@ jobs:
       - name: Create required directories
         run: |
           mkdir -p output
-          mkdir -p debug_files
+          mkdir -p "${DEBUG_DIR}"
           mkdir -p templates
 
       - name: Run mock API tests
@@ -320,6 +326,7 @@ jobs:
           MOCK_MODE: 'true'
           TESTING: '1'
           PYTHONPATH: ${{ github.workspace }}
+          NEWSLETTER_DEBUG_DIR: ${{ env.DEBUG_DIR }}
           OPENAI_API_KEY: test-key
           SERPER_API_KEY: test-key
           GEMINI_API_KEY: test-key
@@ -375,7 +382,7 @@ jobs:
       - name: Create required directories
         run: |
           mkdir -p output
-          mkdir -p debug_files
+          mkdir -p "${DEBUG_DIR}"
           mkdir -p templates
 
       - name: Run scheduler integration contracts (always)
@@ -383,6 +390,7 @@ jobs:
           RUN_INTEGRATION_TESTS: '1'
           TESTING: '1'
           PYTHONPATH: ${{ github.workspace }}
+          NEWSLETTER_DEBUG_DIR: ${{ env.DEBUG_DIR }}
           OPENAI_API_KEY: test-key
           SERPER_API_KEY: test-key
           GEMINI_API_KEY: test-key
@@ -398,6 +406,7 @@ jobs:
           RUN_INTEGRATION_TESTS: '1'
           TESTING: '1'
           PYTHONPATH: ${{ github.workspace }}
+          NEWSLETTER_DEBUG_DIR: ${{ env.DEBUG_DIR }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || '' }}
           SERPER_API_KEY: ${{ secrets.SERPER_API_KEY || '' }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY || '' }}
@@ -450,7 +459,7 @@ jobs:
         run: |
           echo "## 🧪 Test Results Summary" >> $GITHUB_STEP_SUMMARY
           echo "### Coverage Report" >> $GITHUB_STEP_SUMMARY
-          if [ -f coverage.xml ]; then
+          if [ -f "${COVERAGE_DIR}/coverage.xml" ]; then
             echo "✅ Coverage report generated successfully" >> $GITHUB_STEP_SUMMARY
           else
             echo "⚠️ Coverage report not found" >> $GITHUB_STEP_SUMMARY
@@ -678,12 +687,12 @@ jobs:
             --branch main \
             --limit 10 \
             --min-success-rate 95 \
-            --output artifacts/windows-ci-burnin.json
+            --output "${WINDOWS_CI_BURNIN_REPORT}"
 
       - name: Upload windows burn-in artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: windows-ci-burnin-${{ github.run_id }}
-          path: artifacts/windows-ci-burnin.json
+          path: ${{ env.WINDOWS_CI_BURNIN_REPORT }}
           if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ var/
 # Virtual environments
 .env
 .venv
+.local/
 env/
 venv/
 ENV/

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,18 @@
 # 실행 경로/인터프리터 설정
 EXPECTED_CWD ?= /Users/hojungjung/development/newsletter-generator
 PROJECT_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+LOCAL_DIR ?= $(PROJECT_ROOT)/.local
+ARTIFACTS_DIR ?= $(LOCAL_DIR)/artifacts
+REPO_AUDIT_DIR ?= $(ARTIFACTS_DIR)/repo-audit
+WINDOWS_CI_BURNIN_REPORT ?= $(ARTIFACTS_DIR)/windows-ci-burnin.json
+WINDOWS_RELEASE_CONTROLS_REPORT ?= $(ARTIFACTS_DIR)/windows-release-controls.json
+COVERAGE_DIR ?= $(LOCAL_DIR)/coverage
+DEBUG_DIR ?= $(LOCAL_DIR)/debug_files
+NEWSLETTER_DEBUG_DIR ?= $(DEBUG_DIR)
 VENV_PYTHON := $(PROJECT_ROOT)/.venv/bin/python
 PYTHON ?= $(if $(wildcard $(VENV_PYTHON)),$(VENV_PYTHON),python3)
 PIP := $(PYTHON) -m pip
+export NEWSLETTER_DEBUG_DIR
 
 # 디렉토리 설정
 SRC_DIRS := newsletter tests web scripts apps newsletter_core
@@ -139,11 +148,11 @@ windows-update-manifest: ## Generate update-manifest.json (WINDOWS_UPDATE_BASE_U
 
 windows-ci-burnin-report: ## Measure latest Windows CI burn-in success rate
 	@echo "📈 Windows CI burn-in 리포트 생성 중..."
-	$(PYTHON) scripts/devtools/windows_ci_burnin_report.py --workflow "Main CI Pipeline" --branch main --limit 10 --min-success-rate 95 --output artifacts/windows-ci-burnin.json
+	$(PYTHON) scripts/devtools/windows_ci_burnin_report.py --workflow "Main CI Pipeline" --branch main --limit 10 --min-success-rate 95 --output $(WINDOWS_CI_BURNIN_REPORT)
 
 github-windows-release-controls: ## Verify GitHub release controls (branch protection/vars/secrets)
 	@echo "🧭 GitHub Windows release control 점검 중..."
-	$(PYTHON) scripts/devtools/check_github_windows_release_controls.py --repo hjjung-katech/newsletter-generator --output artifacts/windows-release-controls.json
+	$(PYTHON) scripts/devtools/check_github_windows_release_controls.py --repo hjjung-katech/newsletter-generator --output $(WINDOWS_RELEASE_CONTROLS_REPORT)
 
 test-quick: preflight-release ## 빠른 게이트 (5분 이내 목표: 포맷/린트/핵심 단위)
 	@echo "⚡ Quick 게이트 실행 중..."
@@ -185,7 +194,7 @@ test-all: ## 모든 테스트 실행
 
 test-coverage: ## 커버리지 포함 테스트
 	@echo "📊 커버리지 측정 중..."
-	MOCK_MODE=true $(PYTHON) -m pytest -m unit --cov=newsletter --cov=newsletter_core --cov=web --cov-report=html --cov-report=term
+	MOCK_MODE=true $(PYTHON) -m pytest -m unit --cov=newsletter --cov=newsletter_core --cov=web --cov-report=html:$(COVERAGE_DIR)/htmlcov --cov-report=term
 
 ci-check: ## CI 검사 실행 (GitHub Actions와 동일)
 	@echo "🚀 CI 검사 실행 중..."
@@ -261,13 +270,13 @@ docs-check: ## Markdown 링크/스타일 무결성 검사
 
 repo-audit: ## 루트 인벤토리/Repo hygiene soft gate 리포트 생성
 	@echo "🧹 Repo audit 실행 중..."
-	$(PYTHON) scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy
-	@echo "✅ repo-audit 완료 (artifacts/repo-audit)"
+	$(PYTHON) scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir $(REPO_AUDIT_DIR) --check-policy
+	@echo "✅ repo-audit 완료 ($(REPO_AUDIT_DIR))"
 
 repo-audit-strict: ## 루트 인벤토리/Repo hygiene strict gate 리허설
 	@echo "🧱 Repo audit strict 실행 중..."
-	$(PYTHON) scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy --strict
-	@echo "✅ repo-audit-strict 완료 (artifacts/repo-audit)"
+	$(PYTHON) scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir $(REPO_AUDIT_DIR) --check-policy --strict
+	@echo "✅ repo-audit-strict 완료 ($(REPO_AUDIT_DIR))"
 
 runtime-ascii-guard: ## Ensure runtime print/logger literals stay ASCII-safe
 	@echo "🔡 Runtime ASCII 출력 가드 실행 중..."
@@ -302,7 +311,12 @@ clean: ## 캐시 및 임시 파일 정리
 	find . -type f -name "*.pyc" -delete 2>/dev/null || true
 	find . -type f -name "*.pyo" -delete 2>/dev/null || true
 	find . -type f -name ".coverage" -delete 2>/dev/null || true
+	rm -f coverage.xml 2>/dev/null || true
+	rm -rf artifacts/ 2>/dev/null || true
+	rm -rf coverage_html_report/ 2>/dev/null || true
 	rm -rf htmlcov/ 2>/dev/null || true
+	rm -rf $(ARTIFACTS_DIR)/ 2>/dev/null || true
+	rm -rf $(COVERAGE_DIR)/ 2>/dev/null || true
 	rm -rf .pytest_cache/ 2>/dev/null || true
 	rm -rf .mypy_cache/ 2>/dev/null || true
 	rm -rf dist/ build/ *.egg-info 2>/dev/null || true

--- a/docs/dev/CI_CD_GUIDE.md
+++ b/docs/dev/CI_CD_GUIDE.md
@@ -72,9 +72,10 @@ make repo-audit-strict
 
 ## Coverage Reporting
 
-- 커버리지는 `pytest-cov` 리포트(`coverage.xml`, `htmlcov/`)로 계속 수집합니다.
+- 커버리지는 `pytest-cov` 리포트(`.local/coverage/coverage.xml`, `.local/coverage/htmlcov/`)로 계속 수집합니다.
 - 현재 contributor gate는 "고정 퍼센트 임계치" 문서보다 `make check-full` 통과와 테스트 리포트 정합성을 우선 기준으로 사용합니다.
 - 커버리지 개선 작업은 별도 RR/PR 단위로 분리합니다.
+- repo audit, coverage, debug 같은 로컬 scratch 산출물은 기본적으로 루트 `.local/` 아래에 격리합니다.
 
 ## Repo Hygiene Gate
 
@@ -83,16 +84,16 @@ make repo-audit-strict
 ```bash
 python scripts/repo_audit.py \
   --policy scripts/repo_hygiene_policy.json \
-  --output-dir artifacts/repo-audit \
+  --output-dir .local/artifacts/repo-audit \
   --check-policy
 ```
 
 - 현재 기본 운영: `REPO_HYGIENE_STRICT=true` (hard gate)
 - 임시 예외 경로: `REPO_HYGIENE_STRICT=false`로 soft gate override 가능(권장하지 않음)
 - CI artifact:
-  - `artifacts/repo-audit/repo_audit_report.md`
-  - `artifacts/repo-audit/repo_audit_report.json`
-  - `artifacts/repo-audit/policy_warnings.md`
+  - `.local/artifacts/repo-audit/repo_audit_report.md`
+  - `.local/artifacts/repo-audit/repo_audit_report.json`
+  - `.local/artifacts/repo-audit/policy_warnings.md`
 
 ## PR Policy Check Gate
 

--- a/docs/dev/LONG_TERM_REPO_STRATEGY.md
+++ b/docs/dev/LONG_TERM_REPO_STRATEGY.md
@@ -260,7 +260,7 @@ Delivery KPI:
 - Week 12 실행 반영:
   - `packages/newsletter_core/src/newsletter_core`를 `newsletter_core/`로 평탄화
 - Week 13 실행 반영:
-  - `output/`, `debug_files/`를 local-only 생성 디렉터리로 전환(`.gitkeep` 추적 제거)
+  - `output/`은 사용자 생성 결과물로 루트 유지, 디버그/점검/coverage 산출물 기본 경로는 `.local/`로 숨김 정리
 - Week 14 실행 반영:
   - `.vscode/`를 local-only(추적 제외)로 전환
 - Week 15 실행 반영:

--- a/docs/dev/REPO_HYGIENE_POLICY.md
+++ b/docs/dev/REPO_HYGIENE_POLICY.md
@@ -9,6 +9,7 @@
 - Week 5 반영: CI hard gate(`REPO_HYGIENE_STRICT=true`) 기본 활성화
 - Week 10 반영: 루트 `.coveragerc`, `.python-version` 제거
 - Week 11 반영: 루트 `config.yml`을 `config/config.yml`로 이관
+- Week 18 반영: 로컬 scratch 산출물 기본 경로를 루트 `.local/`로 정규화
 
 ## Scope
 
@@ -31,9 +32,9 @@
 | `pyinstaller_hooks/` | 이관 완료 | `scripts/devtools/pyinstaller_hooks/` | 빌드 유틸 범주로 통합 |
 | `build_web_exe.py`, `build_web_exe_enhanced.py`, `cleanup_debug_files.py`, `fix_env_setup.py`, `run_tests.py` | 삭제 완료 | `scripts/devtools/`만 사용 | 루트 clutter 제거 및 단일 실행 경로 고정 |
 | `check_quality.py`, `setup_env.py`, `newsletter-test.sh`, `newsletter-test.bat` | 삭제 완료 | `scripts/devtools/`만 사용 | 루트 clutter 제거 및 단일 실행 경로 고정 |
-| `.coverage`, `coverage.xml`, `coverage_html_report/` | ignore | 로컬 산출물 | 재생성 가능 산출물 |
+| `.local/` | ignore | 로컬 scratch workspace (`artifacts/`, `coverage/`, `debug_files/`) | 재생성 가능 산출물과 디버그 출력은 숨김 경계로 격리 |
 | `.venv/`, `.pytest_cache/`, `.mypy_cache/`, `__pycache__/` | ignore | 로컬 캐시 | 개인/런타임 캐시 |
-| `output/`, `debug_files/` | ignore | 로컬 생성 디렉터리 (tracked 제외) | 실행 시 자동 생성, 루트 tracked 엔트리 축소 |
+| `output/` | ignore | 사용자 생성 결과물 디렉터리 (tracked 제외) | 실행 결과 확인용이므로 루트 유지 |
 | `config/config.yml` | 유지 | `config/` 내부 정본 | 런타임 설정 파일 위치 정규화 |
 | `config.example.yml` | 이관 완료 | `config/config.example.yml` | 템플릿 파일 위치 정규화 + 루트 엔트리 축소 |
 | `TODOs.md` | 이관 완료 | `docs/archive/2026-q1/F14_COMPLETION_REPORT.md` | 루트 문서 혼잡도 완화 및 문서 의미 정정 |
@@ -72,17 +73,18 @@
 
 - 위치: `.github/workflows/main-ci.yml`의 `quality-checks` stage
 - 실행 명령:
-  - `python scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir artifacts/repo-audit --check-policy`
+  - `python scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir .local/artifacts/repo-audit --check-policy`
 - strict 토글:
   - `REPO_HYGIENE_STRICT=true`(기본): `--strict` 활성화, warning 발견 시 CI 실패(hard gate)
   - `REPO_HYGIENE_STRICT=false`: 임시 soft gate override(경고만 출력)
 - 산출물(artifact):
-  - `artifacts/repo-audit/repo_audit_report.md`
-  - `artifacts/repo-audit/repo_audit_report.json`
-  - `artifacts/repo-audit/policy_warnings.md`
+  - `.local/artifacts/repo-audit/repo_audit_report.md`
+  - `.local/artifacts/repo-audit/repo_audit_report.json`
+  - `.local/artifacts/repo-audit/policy_warnings.md`
 - 운영 원칙:
   - Week 1~4: warning-only soft gate로 준비 단계 운영
   - Week 5+: hard gate 기본 운영, 예외 시에만 일시 override 검토
+  - root에서 ignore된 엔트리도 정책 allowlist(`.local/`, `output/`, 캐시 디렉터리) 밖이면 strict gate에서 경고합니다.
 
 ### Shim Policy (Week 4)
 
@@ -95,7 +97,7 @@
 ```bash
 python scripts/repo_audit.py \
   --policy scripts/repo_hygiene_policy.json \
-  --output-dir artifacts/repo-audit \
+  --output-dir .local/artifacts/repo-audit \
   --check-policy
 ```
 
@@ -104,7 +106,7 @@ strict 모드(CI 기본):
 ```bash
 python scripts/repo_audit.py \
   --policy scripts/repo_hygiene_policy.json \
-  --output-dir artifacts/repo-audit \
+  --output-dir .local/artifacts/repo-audit \
   --check-policy \
   --strict
 ```

--- a/docs/setup/LOCAL_SETUP.md
+++ b/docs/setup/LOCAL_SETUP.md
@@ -213,7 +213,10 @@ newsletter-generator/
 │   ├── intermediate_processing/  # 중간 처리 파일
 │   ├── email_tests/            # 이메일 테스트 결과
 │   └── test_results/           # 테스트 결과
-├── debug_files/                # 디버그 파일 (자동 생성)
+├── .local/                     # 로컬 scratch 산출물
+│   ├── coverage/               # coverage 리포트/데이터
+│   ├── artifacts/              # repo audit, Windows burn-in 등 점검 산출물
+│   └── debug_files/            # 디버그 파일 (자동 생성)
 └── web/
     ├── storage.db              # 웹앱 데이터베이스 (자동 생성)
     ├── app.py                  # 메인 웹 애플리케이션
@@ -258,6 +261,8 @@ sqlite3 storage.db "DELETE FROM history WHERE created_at < datetime('now', '-30 
 ```
 
 ## 12. 디버그 파일 정리
+
+기본 디버그 파일 경로는 `.local/debug_files/` 입니다.
 
 디버그 파일이 과도하게 쌓인 경우:
 

--- a/newsletter/utils/file_naming.py
+++ b/newsletter/utils/file_naming.py
@@ -5,6 +5,7 @@
 import os
 import re
 from datetime import datetime
+from pathlib import Path
 from typing import List, Optional
 
 
@@ -32,10 +33,10 @@ def get_safe_filename(topic: str) -> str:
 def generate_unified_newsletter_filename(
     topic: str,
     style: str = "detailed",
-    timestamp: str = None,
+    timestamp: Optional[str] = None,
     use_current_date: bool = True,
     generation_type: str = "original",  # "original", "regenerated", "test"
-    source_timestamp: str = None,  # 원본 파일의 타임스탬프 (재생성시 사용)
+    source_timestamp: Optional[str] = None,  # 원본 파일의 타임스탬프 (재생성시 사용)
 ) -> str:
     """
     통일된 뉴스레터 파일명 생성 함수
@@ -144,7 +145,7 @@ def _parse_and_standardize_timestamp(
     return date_part, time_part
 
 
-def generate_newsletter_filename(topic: str, timestamp: str = None) -> str:
+def generate_newsletter_filename(topic: str, timestamp: Optional[str] = None) -> str:
     """
     뉴스레터 HTML 파일의 경로를 생성 (기존 함수 - 호환성 유지)
 
@@ -270,16 +271,17 @@ def ensure_debug_directory() -> str:
     Returns:
         str: debug_files 디렉토리의 절대 경로
     """
-    # 프로젝트 루트를 기준으로 debug_files 디렉토리 경로 생성
-    project_root = os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    )
-    debug_dir = os.path.join(project_root, "debug_files")
+    configured_dir = os.getenv("NEWSLETTER_DEBUG_DIR")
+    if configured_dir:
+        debug_dir = Path(configured_dir).expanduser()
+    else:
+        project_root = Path(__file__).resolve().parents[2]
+        debug_dir = project_root / ".local" / "debug_files"
 
     # 디렉토리가 없으면 생성
     os.makedirs(debug_dir, exist_ok=True)
 
-    return debug_dir
+    return str(debug_dir.resolve())
 
 
 def generate_debug_filename(
@@ -344,9 +346,9 @@ def save_debug_file(
     except Exception as e:
         # 로깅이 가능한 경우 로그 남김
         try:
-            from ..utils.logger import logger
+            from ..utils.logger import get_logger
 
-            logger.error(f"Debug 파일 저장 중 오류: {e}")
+            get_logger().error(f"Debug 파일 저장 중 오류: {e}")
         except ImportError:
             print(f"Debug 파일 저장 중 오류: {e}")
         raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ ignore_errors = true
 
 [tool.coverage.run]
 source = ["newsletter", "newsletter_core", "web"]
+data_file = ".local/coverage/.coverage"
 omit = [
     "tests/*",
     "newsletter/__main__.py",
@@ -197,6 +198,7 @@ exclude_files = [
     ".*\\.lock$",
     ".*\\.log$",
     ".*\\.pyc$",
+    ".local/.*",
     ".*/__pycache__/.*",
     ".git/.*",
     ".pytest_cache/.*",
@@ -210,7 +212,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-norecursedirs = ["tests/_backup", ".venv", "venv", ".git"]
+norecursedirs = ["tests/_backup", ".local", ".venv", "venv", ".git"]
 minversion = "6.0"
 addopts = [
     "-ra",
@@ -221,8 +223,8 @@ addopts = [
     "--cov=newsletter_core",
     "--cov=web",
     "--cov-report=term-missing",
-    "--cov-report=html",
-    "--cov-report=xml",
+    "--cov-report=html:.local/coverage/htmlcov",
+    "--cov-report=xml:.local/coverage/coverage.xml",
     "--tb=short",
 ]
 markers = [

--- a/scripts/devtools/cleanup_debug_files.py
+++ b/scripts/devtools/cleanup_debug_files.py
@@ -11,6 +11,8 @@ from datetime import datetime
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DEBUG_DIR = PROJECT_ROOT / ".local" / "debug_files"
+DEFAULT_DEBUG_ARCHIVE_DIR = PROJECT_ROOT / ".local" / "debug_archives"
 
 
 def main():
@@ -23,8 +25,13 @@ def main():
     )
     parser.add_argument(
         "--target-dir",
-        default="debug_archives",
+        default=str(DEFAULT_DEBUG_ARCHIVE_DIR),
         help="Directory to move files to (when action is 'move')",
+    )
+    parser.add_argument(
+        "--source-dir",
+        default=os.getenv("NEWSLETTER_DEBUG_DIR", str(DEFAULT_DEBUG_DIR)),
+        help="Directory to scan for debug files",
     )
     parser.add_argument(
         "--pattern", default="template_debug_", help="File pattern to match for cleanup"
@@ -32,14 +39,15 @@ def main():
 
     args = parser.parse_args()
 
-    # 레거시와 동일하게 저장소 루트 기준에서 동작하도록 고정
-    os.chdir(PROJECT_ROOT)
+    source_dir = Path(args.source_dir)
+    if not source_dir.exists():
+        print(f"Source directory does not exist: {source_dir}")
+        return
 
-    # 현재 디렉토리 내의 모든 파일 가져오기
-    files = [f for f in os.listdir() if os.path.isfile(f)]
+    files = [path for path in source_dir.iterdir() if path.is_file()]
 
     # 패턴과 일치하는 파일 필터링
-    debug_files = [f for f in files if args.pattern in f]
+    debug_files = [path for path in files if args.pattern in path.name]
 
     if not debug_files:
         print(f"No files matching pattern '{args.pattern}' found.")
@@ -61,15 +69,14 @@ def main():
 
         # 파일 이동
         for file in debug_files:
-            src = Path(file)
-            dst = date_dir / src.name
-            shutil.move(str(src), str(dst))
+            dst = date_dir / file.name
+            shutil.move(str(file), str(dst))
 
         print(f"Moved {len(debug_files)} files to {date_dir}")
 
     else:  # delete
         for file in debug_files:
-            os.remove(file)
+            file.unlink()
         print(f"Deleted {len(debug_files)} files")
 
 

--- a/scripts/repo_audit.py
+++ b/scripts/repo_audit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -122,6 +123,18 @@ def allowed_root_entry(name: str, entry_type: str, root_policy: dict[str, Any]) 
     return False
 
 
+def allowed_ignored_root_entry(
+    name: str, entry_type: str, root_policy: dict[str, Any]
+) -> bool:
+    if entry_type == "file":
+        globs = root_policy.get("ignore_file_globs", [])
+        return match_any(name, globs)
+    if entry_type == "directory":
+        names = root_policy.get("ignore_directory_names", [])
+        return name in names
+    return False
+
+
 @dataclass(frozen=True)
 class RootEntry:
     name: str
@@ -228,6 +241,15 @@ def policy_warnings(
         if entry.action == "ignore_or_remove_local":
             continue
         warnings.append(f"[local-only] {entry.name} is untracked at repository root")
+
+    for entry in entries:
+        if entry.git_state != "ignored":
+            continue
+        if allowed_ignored_root_entry(entry.name, entry.entry_type, root_policy):
+            continue
+        warnings.append(
+            f"[ignored-root] {entry.name} is ignored at repository root but not policy-approved"
+        )
 
     warnings.extend(dot_scope_warnings(repo_root, policy))
     return warnings
@@ -364,7 +386,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--output-dir",
-        default="artifacts/repo-audit",
+        default="",
         help="Directory where reports are written",
     )
     parser.add_argument(
@@ -407,7 +429,10 @@ def main() -> int:
 
     entries = collect_root_entries(repo_root, policy)
     warnings = policy_warnings(entries, policy, repo_root) if args.check_policy else []
-    output_dir = (repo_root / args.output_dir).resolve()
+    output_dir_arg = args.output_dir or os.environ.get(
+        "REPO_AUDIT_OUTPUT_DIR", ".local/artifacts/repo-audit"
+    )
+    output_dir = (repo_root / output_dir_arg).resolve()
 
     markdown_path = output_dir / "repo_audit_report.md"
     json_path = output_dir / "repo_audit_report.json"

--- a/scripts/repo_hygiene_policy.json
+++ b/scripts/repo_hygiene_policy.json
@@ -53,20 +53,17 @@
     ],
     "shim_file_names": [],
     "ignore_file_globs": [
-      ".coverage",
-      "coverage.xml",
+      ".DS_Store",
       "*.zip"
     ],
     "ignore_directory_names": [
+      ".local",
       ".mypy_cache",
       ".pytest_cache",
       ".venv",
       ".vscode",
       ".githooks",
       "__pycache__",
-      "artifacts",
-      "coverage_html_report",
-      "debug_files",
       "output"
     ]
   },

--- a/tests/unit_tests/test_debug_file_paths.py
+++ b/tests/unit_tests/test_debug_file_paths.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from newsletter.utils import file_naming
+
+
+def test_ensure_debug_directory_defaults_to_hidden_local_dir(monkeypatch):
+    monkeypatch.delenv("NEWSLETTER_DEBUG_DIR", raising=False)
+
+    debug_dir = Path(file_naming.ensure_debug_directory())
+
+    assert debug_dir.name == "debug_files"
+    assert debug_dir.parent.name == ".local"
+    assert debug_dir.is_dir()
+
+
+def test_generate_debug_filename_uses_env_override(monkeypatch, tmp_path):
+    override_dir = tmp_path / "debug"
+    monkeypatch.setenv("NEWSLETTER_DEBUG_DIR", str(override_dir))
+
+    debug_file = Path(
+        file_naming.generate_debug_filename(
+            prefix="template_debug",
+            extension="log",
+            timestamp="20260309_120000",
+        )
+    )
+
+    assert debug_file == override_dir / "template_debug_20260309_120000.log"
+    assert override_dir.is_dir()


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- 루트 첫 레벨의 로컬 산출물 기본 경로를 숨김 작업 디렉터리 `.local/` 아래로 정리했습니다.
- repo audit, coverage, debug 파일, Windows release control/burn-in 리포트의 기본 경로를 루트 밖으로 옮겨 첫 레벨 가독성을 개선했습니다.
- root `artifacts/`, `debug_files/`, root coverage 출력이 다시 생기면 repo hygiene strict gate에서 감지되도록 정책을 강화했습니다.

## Scope
### In Scope
- `.local/` 기반 로컬 산출물 경계 도입
- `Makefile`, `scripts/repo_audit.py`, `pyproject.toml`, debug cleanup/file naming 경로 정리
- CI workflow와 canonical 문서 정합성 업데이트
- debug 파일 경로 regression test 추가

### Out of Scope
- `output/` 경로 변경
- `templates/`, `config/`, `apps/*` 구조 재배치
- `.venv/` 위치 변경

## Delivery Unit
- RR: #276
- Delivery Unit ID: DU-20260309-root-local-artifact-isolation
- Merge Boundary: `.local/` local-output isolation only
- Rollback Boundary: this PR revert restores previous root-local output defaults

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): `./.venv/bin/python -m pytest tests/unit_tests/test_debug_file_paths.py -q`

### Commands and Results
```bash
./.venv/bin/python scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir .local/artifacts/repo-audit --check-policy --strict
# PASS: top-level entries=38 warnings=0

./.venv/bin/python -m pytest tests/unit_tests/test_debug_file_paths.py -q
# PASS: 2 passed

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: 로컬/CI 스크립트가 기존 루트 `artifacts`, `debug_files`, coverage 출력 경로를 직접 참조하면 경로 불일치가 발생할 수 있습니다.
- Rollback: `git revert ab706ba79b862774c541a93d78cb80b8c7577135` 후 루트 경로 기반 산출물을 다시 생성하면 됩니다.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 해당 없음
- Outbox/send_key 중복 방지 결과: 해당 없음
- import-time side effect 제거 여부: 추가/변경 없음

## Not Run (with reason)
- 없음

Closes #276
