### PR TITLE
chore: package newsletter template assets

### DIFF
--- a/docs/dev/DEVELOPMENT_GUIDE.md
+++ b/docs/dev/DEVELOPMENT_GUIDE.md
@@ -98,7 +98,6 @@ newsletter-generator/
 │   ├── tools.py               # 유틸리티 도구
 │   ├── cost_tracking.py       # 비용 추적
 │   └── utils/                 # 유틸리티 모듈
-├── templates/                  # HTML 템플릿
 ├── tests/                      # 테스트 파일
 │   ├── unit_tests/            # 단위 테스트
 │   ├── api_tests/             # API 테스트
@@ -308,7 +307,7 @@ class TestComposeNewsletter:
             "articles": [{"title": "Test", "content": "Content"}],
             "keywords": ["AI"]
         }
-        template_dir = "templates"
+        template_dir = get_newsletter_template_dir()
 
         # When
         result = compose_newsletter(mock_data, template_dir, "detailed")

--- a/docs/dev/LONG_TERM_REPO_STRATEGY.md
+++ b/docs/dev/LONG_TERM_REPO_STRATEGY.md
@@ -272,6 +272,9 @@ Delivery KPI:
 - Week 19 실행 반영:
   - `config/template_config.json` 제거, 템플릿 메타데이터를 `config/config.yml`의 `newsletter_settings`로 통합
   - `config/`를 런타임 설정 전용 디렉터리로 고정
+- Week 20 실행 반영:
+  - 루트 `templates/`를 `newsletter/templates/`로 이관하고 패키지 상대 경로 helper로 통일
+  - repo hygiene policy에서 루트 `templates/` 허용을 제거
 
 ## 10) 요청 표준(Agent/Skill + PR 중심)
 

--- a/docs/dev/REPO_HYGIENE_POLICY.md
+++ b/docs/dev/REPO_HYGIENE_POLICY.md
@@ -28,7 +28,8 @@
 | `setup.cfg`, `setup.py` | 제거 완료 | `pyproject.toml` 단일 경로 | 패키징 설정 중복 제거 |
 | `run_ci_checks.py` | 유지 | 루트 유지 | 정책상 루트 진입 스크립트 |
 | `.github/`, `.release/`, `docs/`, `scripts/`, `newsletter/`, `newsletter_core/`, `web/`, `tests/` | 유지 | 루트 유지 | 핵심 운영/도메인 디렉터리 |
-| `apps/`, `templates/` | 유지(과도기) | 루트 유지 | 엔트리포인트/템플릿 경로 정리 전까지 호환 유지 |
+| `apps/` | 유지(과도기) | 루트 유지 | 엔트리포인트 경로 정리 전까지 호환 유지 |
+| `templates/` | 이관 완료 | `newsletter/templates/` | 패키지 상대 경로 템플릿 자산으로 정규화 |
 | `config/` | 유지 | 런타임 설정 전용 디렉터리 | `config/config.yml`, `config/config.example.yml` 단일 정본 유지 |
 | `pyinstaller_hooks/` | 이관 완료 | `scripts/devtools/pyinstaller_hooks/` | 빌드 유틸 범주로 통합 |
 | `build_web_exe.py`, `build_web_exe_enhanced.py`, `cleanup_debug_files.py`, `fix_env_setup.py`, `run_tests.py` | 삭제 완료 | `scripts/devtools/`만 사용 | 루트 clutter 제거 및 단일 실행 경로 고정 |

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -118,7 +118,7 @@ newsletter-generator/
 ├── .env                    # 환경 변수 설정
 ├── .env.example           # 환경 변수 예제
 ├── newsletter/            # 메인 패키지
-├── templates/             # HTML 템플릿
+│   └── templates/         # 패키지 내부 HTML 템플릿
 ├── output/               # 생성된 파일들
 ├── docs/                 # 문서
 ├── tests/                # 테스트 파일

--- a/newsletter/chains_compact_flow.py
+++ b/newsletter/chains_compact_flow.py
@@ -3,7 +3,6 @@ Compact-mode newsletter flow helpers.
 """
 
 import datetime
-import os
 from typing import Any
 
 from langchain_core.messages import HumanMessage
@@ -11,6 +10,7 @@ from langchain_core.messages import HumanMessage
 from .chains_llm_utils import get_llm
 from .compose import NewsletterConfig, compose_newsletter, create_grouped_sections
 from .template_manager import TemplateManager
+from .template_paths import get_newsletter_template_dir
 from .utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -228,7 +228,7 @@ def build_compact_newsletter_result(
     logger.step("HTML 템플릿 렌더링", "rendering")
     logger.info("Composing compact newsletter for topic: %s", newsletter_topic)
 
-    template_dir = os.path.join(os.path.dirname(__file__), "..", "templates")
+    template_dir = get_newsletter_template_dir()
     result_data["email_compatible"] = data.get("email_compatible", False)
     result_data["template_style"] = data.get("template_style", "compact")
 

--- a/newsletter/chains_no_articles.py
+++ b/newsletter/chains_no_articles.py
@@ -3,7 +3,6 @@ Fallback generation flow when no articles were collected.
 """
 
 import datetime
-import os
 from typing import Any
 
 from langchain_core.messages import HumanMessage
@@ -11,6 +10,7 @@ from langchain_core.messages import HumanMessage
 from .chains_llm_utils import get_llm
 from .compose import compose_newsletter
 from .template_manager import TemplateManager
+from .template_paths import get_newsletter_template_dir
 from .utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -175,7 +175,7 @@ R&D 전략기획단 전문위원들을 대상으로, 해당 주제 분야의 전
     }
 
     logger.info("키워드 기반 뉴스레터 생성: %s", newsletter_topic)
-    template_dir = os.path.join(os.path.dirname(__file__), "..", "templates")
+    template_dir = get_newsletter_template_dir()
 
     if email_compatible:
         logger.info("Email-compatible 템플릿 사용")

--- a/newsletter/chains_prompts.py
+++ b/newsletter/chains_prompts.py
@@ -1,9 +1,6 @@
-"""
-Newsletter Generator prompt and template constants.
-"""
+"""Newsletter Generator prompt and template constants."""
 
-import os
-
+from .template_paths import get_newsletter_template_path
 from .utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -11,9 +8,7 @@ logger = get_logger(__name__)
 
 def load_html_template() -> str:
     """HTML 템플릿 파일을 로드합니다."""
-    template_path = os.path.join(
-        os.path.dirname(__file__), "..", "templates", "newsletter_template.html"
-    )
+    template_path = get_newsletter_template_path("newsletter_template.html")
     try:
         with open(template_path, "r", encoding="utf-8") as f:
             return f.read()

--- a/newsletter/chains_rendering.py
+++ b/newsletter/chains_rendering.py
@@ -13,6 +13,7 @@ from newsletter.article_filter import select_top_articles
 from .chains_prompts import HTML_TEMPLATE
 from .compose import compose_newsletter
 from .template_manager import TemplateManager
+from .template_paths import get_newsletter_template_dir
 from .utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -163,7 +164,7 @@ def _render_with_template(
             "편집자 드림",
         )
 
-        template_dir = os.path.join(os.path.dirname(__file__), "..", "templates")
+        template_dir = get_newsletter_template_dir()
         rendered_html = compose_newsletter(
             combined_data, template_dir, "email_compatible"
         )

--- a/newsletter/cli_test.py
+++ b/newsletter/cli_test.py
@@ -78,8 +78,9 @@ def test(
 
             # 템플릿 스타일에 따른 compose_newsletter 함수 사용
             from .compose import compose_newsletter
+            from .template_paths import get_newsletter_template_dir
 
-            template_dir = os.path.join(os.path.dirname(__file__), "..", "templates")
+            template_dir = get_newsletter_template_dir()
 
             # email_compatible인 경우 데이터에 template_style 정보 추가
             if email_compatible:

--- a/newsletter/template_paths.py
+++ b/newsletter/template_paths.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+_TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
+
+
+def get_newsletter_template_dir() -> str:
+    return str(_TEMPLATE_DIR)
+
+
+def get_newsletter_template_path(template_name: str) -> str:
+    return str(_TEMPLATE_DIR / template_name)

--- a/newsletter/templates/newsletter_template.html
+++ b/newsletter/templates/newsletter_template.html
@@ -10,34 +10,34 @@
             --secondary-color: {{ secondary_color | default('#2c3e50') }};
             --font-family: {{ font_family | default('Malgun Gothic, sans-serif') }};
         }
-        
-        body { 
-            font-family: var(--font-family); 
-            margin: 20px; 
-            background-color: #f4f4f4; 
-            color: #333; 
-            line-height: 1.6; 
+
+        body {
+            font-family: var(--font-family);
+            margin: 20px;
+            background-color: #f4f4f4;
+            color: #333;
+            line-height: 1.6;
         }
-        .container { 
-            background-color: #fff; 
-            padding: 30px; 
-            border-radius: 8px; 
-            box-shadow: 0 4px 15px rgba(0,0,0,0.1); 
-            max-width: 800px; 
-            margin: 20px auto; 
+        .container {
+            background-color: #fff;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+            max-width: 800px;
+            margin: 20px auto;
         }
-        
+
         .header-section {
             text-align: center;
             padding-bottom: 25px;
             border-bottom: 1px solid #ecf0f1;
             margin-bottom: 25px;
         }
-        .header-title { 
-            color: var(--secondary-color); 
-            font-size: 28px; 
-            font-weight: bold; 
-            margin-bottom: 15px; 
+        .header-title {
+            color: var(--secondary-color);
+            font-size: 28px;
+            font-weight: bold;
+            margin-bottom: 15px;
         }
         .topic-badge {
             margin: 0 auto 15px auto;
@@ -51,161 +51,161 @@
             display: inline-block;
             max-width: 400px;
         }
-        .meta-info { 
-            color: #666; 
-            font-size: 14px; 
-            margin-bottom: 8px; 
+        .meta-info {
+            color: #666;
+            font-size: 14px;
+            margin-bottom: 8px;
         }
-        .search-keywords { 
-            color: #888; 
-            font-size: 12px; 
+        .search-keywords {
+            color: #888;
+            font-size: 12px;
             margin-bottom: 0;
             font-style: italic;
         }
 
-        .greeting { 
-            margin-bottom: 20px; 
-            font-size: 16px; 
+        .greeting {
+            margin-bottom: 20px;
+            font-size: 16px;
         }
-        .introduction { 
-            margin-bottom: 30px; 
-            font-size: 16px; 
-            border-bottom: 1px solid #ecf0f1; 
-            padding-bottom: 20px; 
-        }
-
-        .section { 
-            margin-bottom: 30px; 
-            padding-bottom: 20px; 
-            border-bottom: 1px solid #ecf0f1; 
-        }
-        .section h2 { 
-            font-size: 22px; 
-            font-weight: bold; 
-            color: var(--primary-color); 
-            margin-bottom: 15px; 
-        }
-        .summary { 
-            margin-bottom: 15px; 
-        }
-        .news-links { 
-            margin-bottom: 15px; 
-        }
-        .news-links h3 { 
-            font-size: 18px; 
-            font-weight: bold; 
-            color: var(--secondary-color); 
-            margin-bottom: 10px; 
-        }
-        .news-links ul { 
-            padding-left: 20px; 
-        }
-        .news-links li { 
-            margin-bottom: 8px; 
-            font-size: 14px; 
-        }
-        .news-links a { 
-            color: var(--primary-color); 
-            text-decoration: none; 
-        }
-        .news-links a:hover { 
-            text-decoration: underline; 
-        }
-        .source-date { 
-            color: #777; 
-            font-size: 12px; 
-            margin-left: 10px; 
+        .introduction {
+            margin-bottom: 30px;
+            font-size: 16px;
+            border-bottom: 1px solid #ecf0f1;
+            padding-bottom: 20px;
         }
 
-        .definition-section { 
-            margin-top: 30px; 
-            padding: 20px; 
-            background-color: #f8f9fa; 
-            border-left: 4px solid var(--primary-color); 
-            border-radius: 8px; 
+        .section {
+            margin-bottom: 30px;
+            padding-bottom: 20px;
+            border-bottom: 1px solid #ecf0f1;
         }
-        .definition-section h3 { 
-            font-size: 20px; 
-            font-weight: bold; 
-            color: var(--secondary-color); 
-            margin-bottom: 15px; 
+        .section h2 {
+            font-size: 22px;
+            font-weight: bold;
+            color: var(--primary-color);
+            margin-bottom: 15px;
         }
-        .definition-list { 
-            list-style: none; 
-            padding-left: 0; 
+        .summary {
+            margin-bottom: 15px;
         }
-        .definition-list li { 
-            margin-bottom: 10px; 
+        .news-links {
+            margin-bottom: 15px;
         }
-        .definition-term { 
-            font-weight: bold; 
-            color: var(--primary-color); 
+        .news-links h3 {
+            font-size: 18px;
+            font-weight: bold;
+            color: var(--secondary-color);
+            margin-bottom: 10px;
         }
-        .definition-explanation { 
-            color: #333; 
-            margin-left: 10px; 
+        .news-links ul {
+            padding-left: 20px;
+        }
+        .news-links li {
+            margin-bottom: 8px;
+            font-size: 14px;
+        }
+        .news-links a {
+            color: var(--primary-color);
+            text-decoration: none;
+        }
+        .news-links a:hover {
+            text-decoration: underline;
+        }
+        .source-date {
+            color: #777;
+            font-size: 12px;
+            margin-left: 10px;
         }
 
-        .food-for-thought-section { 
-            margin-top: 30px; 
-            padding-top: 20px; 
-            border-top: 1px solid #ecf0f1; 
+        .definition-section {
+            margin-top: 30px;
+            padding: 20px;
+            background-color: #f8f9fa;
+            border-left: 4px solid var(--primary-color);
+            border-radius: 8px;
         }
-        .food-for-thought-section h3 { 
-            font-size: 20px; 
-            font-weight: bold; 
-            color: var(--secondary-color); 
-            margin-bottom: 15px; 
+        .definition-section h3 {
+            font-size: 20px;
+            font-weight: bold;
+            color: var(--secondary-color);
+            margin-bottom: 15px;
         }
-        .food-for-thought .quote { 
-            font-style: italic; 
-            color: var(--secondary-color); 
-            font-size: 18px; 
-            margin-bottom: 10px; 
+        .definition-list {
+            list-style: none;
+            padding-left: 0;
+        }
+        .definition-list li {
+            margin-bottom: 10px;
+        }
+        .definition-term {
+            font-weight: bold;
+            color: var(--primary-color);
+        }
+        .definition-explanation {
+            color: #333;
+            margin-left: 10px;
+        }
+
+        .food-for-thought-section {
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #ecf0f1;
+        }
+        .food-for-thought-section h3 {
+            font-size: 20px;
+            font-weight: bold;
+            color: var(--secondary-color);
+            margin-bottom: 15px;
+        }
+        .food-for-thought .quote {
+            font-style: italic;
+            color: var(--secondary-color);
+            font-size: 18px;
+            margin-bottom: 10px;
             text-align: center;
         }
-        .food-for-thought .author { 
-            color: #555; 
-            font-size: 14px; 
-            margin-bottom: 15px; 
-            text-align: center; 
+        .food-for-thought .author {
+            color: #555;
+            font-size: 14px;
+            margin-bottom: 15px;
+            text-align: center;
         }
-        .food-for-thought .message { 
-            color: #333; 
-            font-size: 16px; 
-        }
-
-        .closing-section { 
-            margin-top: 30px; 
-            padding-top: 20px; 
-            border-top: 1px solid #ecf0f1; 
-        }
-        .closing-section p { 
-            margin-bottom: 10px; 
-            font-size: 16px; 
-        }
-        .editor-signature { 
-            margin-top: 20px; 
-            font-style: italic; 
-            color: #555; 
-            text-align: right; 
+        .food-for-thought .message {
+            color: #333;
+            font-size: 16px;
         }
 
-        .footer { 
-            text-align: center; 
-            margin-top: 40px; 
-            font-size: 0.9em; 
-            color: #aaa; 
+        .closing-section {
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #ecf0f1;
         }
-        .footer p { 
-            margin-bottom: 5px; 
+        .closing-section p {
+            margin-bottom: 10px;
+            font-size: 16px;
         }
-        .company-tagline { 
-            margin-top: 10px; 
-            font-style: italic; 
+        .editor-signature {
+            margin-top: 20px;
+            font-style: italic;
+            color: #555;
+            text-align: right;
         }
-        .footer-contact { 
-            margin-top: 8px; 
+
+        .footer {
+            text-align: center;
+            margin-top: 40px;
+            font-size: 0.9em;
+            color: #aaa;
+        }
+        .footer p {
+            margin-bottom: 5px;
+        }
+        .company-tagline {
+            margin-top: 10px;
+            font-style: italic;
+        }
+        .footer-contact {
+            margin-top: 8px;
         }
 
         .hero {
@@ -318,7 +318,7 @@
         {% for section in sections %}
         <div class="section">
             <h2>{{ section.title }}</h2>
-            
+
             {% if section.summary_paragraphs %}
             <div class="summary">
                 {% for paragraph in section.summary_paragraphs %}

--- a/newsletter/templates/newsletter_template_compact.html
+++ b/newsletter/templates/newsletter_template_compact.html
@@ -9,13 +9,13 @@ body{font-family:Arial, sans-serif; line-height:1.6; margin:0; padding:0; backgr
 header{text-align:center; padding:15px 0 20px 0;}
 .main-title{font-size:1.8em; font-weight:bold; color:#2c3e50; margin-bottom:12px;}
 .topic-badge{
-  margin:0 auto 12px auto; 
-  padding:6px 14px; 
-  background:#e8f4f8; 
-  color:#2c3e50; 
-  text-align:center; 
-  font-size:0.9em; 
-  border:1px solid #b8dce8; 
+  margin:0 auto 12px auto;
+  padding:6px 14px;
+  background:#e8f4f8;
+  color:#2c3e50;
+  text-align:center;
+  font-size:0.9em;
+  border:1px solid #b8dce8;
   border-radius:20px;
   display:inline-block;
   font-weight:500;
@@ -134,4 +134,4 @@ footer{font-size:0.8em; color:#888; text-align:center; margin-top:40px;}
 </footer>
 </div>
 </body>
-</html> 
+</html>

--- a/newsletter/templates/newsletter_template_email_compatible.html
+++ b/newsletter/templates/newsletter_template_email_compatible.html
@@ -123,7 +123,7 @@
 
                     <!-- Main Sections -->
                     {% set is_compact_style = template_style == 'compact' %}
-                    
+
                     {% if is_compact_style and grouped_sections %}
                     <!-- Compact style: use grouped_sections -->
                     {% for group in grouped_sections %}
@@ -132,7 +132,7 @@
                             <h2 style="margin: 0 0 15px 0; color: #0d47a1; font-size: 18px; font-weight: bold;">
                                 {{ group.heading }}
                             </h2>
-                            
+
                             {% if group.intro %}
                             <p style="margin: 0 0 10px 0; color: #333333; font-size: 14px; line-height: 1.6;">
                                 {{ group.intro }}
@@ -169,7 +169,7 @@
                         </td>
                     </tr>
                     {% endfor %}
-                    
+
                     {% else %}
                     <!-- Detailed style: use sections -->
                     {% for section in sections %}
@@ -178,7 +178,7 @@
                             <h2 style="margin: 0 0 15px 0; color: #0d47a1; font-size: 18px; font-weight: bold;">
                                 {{ section.title }}
                             </h2>
-                            
+
                             {% if section.summary_paragraphs %}
                             {% for paragraph in section.summary_paragraphs %}
                             <p style="margin: 0 0 10px 0; color: #333333; font-size: 14px; line-height: 1.6;">
@@ -335,4 +335,4 @@
         </tr>
     </table>
 </body>
-</html> 
+</html>

--- a/newsletter/utils/test_mode.py
+++ b/newsletter/utils/test_mode.py
@@ -5,8 +5,6 @@ Utilities for running the newsletter generator in test mode.
 import json
 import logging
 import os
-import sys
-from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -25,6 +23,10 @@ def load_intermediate_data(file_path: str) -> Dict[str, Any]:
     try:
         with open(file_path, "r", encoding="utf-8") as f:
             data = json.load(f)
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Intermediate data file must contain a JSON object: {file_path}"
+            )
         logger.info(f"Successfully loaded intermediate data from {file_path}")
         return data
     except Exception as e:
@@ -173,9 +175,8 @@ def run_in_test_mode(data_file: str, output_html_path: Optional[str] = None) -> 
         logger.info(f"Using timestamp from config: {timestamp}")
 
     # 3. 콘텐츠 데이터에서 타임스탬프 확인
-    generation_timestamp = None
-    if not timestamp and content_data.get("generation_timestamp"):
-        generation_timestamp = content_data.get("generation_timestamp")
+    generation_timestamp = content_data.get("generation_timestamp")
+    if not timestamp and isinstance(generation_timestamp, str):
         # HH:MM:SS 형식을 HHMMSS로 변환
         if ":" in generation_timestamp:
             hour, minute, second = generation_timestamp.split(":")
@@ -185,7 +186,7 @@ def run_in_test_mode(data_file: str, output_html_path: Optional[str] = None) -> 
                 "generation_date", datetime.datetime.now().strftime("%Y-%m-%d")
             )
             # 2025-05-16 형식을 20250516으로 변환
-            if "-" in generation_date:
+            if isinstance(generation_date, str) and "-" in generation_date:
                 year, month, day = generation_date.split("-")
                 timestamp_date = f"{year}{month}{day}"
                 timestamp = f"{timestamp_date}_{timestamp_time}"
@@ -202,9 +203,9 @@ def run_in_test_mode(data_file: str, output_html_path: Optional[str] = None) -> 
         if timestamp and len(timestamp) >= 8:
             date_part = timestamp.split("_")[0] if "_" in timestamp else timestamp[:8]
             if len(date_part) == 8:
-                content_data["generation_date"] = (
-                    f"{date_part[:4]}-{date_part[4:6]}-{date_part[6:8]}"
-                )
+                content_data[
+                    "generation_date"
+                ] = f"{date_part[:4]}-{date_part[4:6]}-{date_part[6:8]}"
 
         if "generation_date" not in content_data:
             content_data["generation_date"] = datetime.datetime.now().strftime(
@@ -216,9 +217,9 @@ def run_in_test_mode(data_file: str, output_html_path: Optional[str] = None) -> 
         if timestamp and "_" in timestamp:
             time_part = timestamp.split("_")[1]
             if len(time_part) >= 6:
-                content_data["generation_timestamp"] = (
-                    f"{time_part[:2]}:{time_part[2:4]}:{time_part[4:6]}"
-                )
+                content_data[
+                    "generation_timestamp"
+                ] = f"{time_part[:2]}:{time_part[2:4]}:{time_part[4:6]}"
 
         if "generation_timestamp" not in content_data:
             content_data["generation_timestamp"] = datetime.datetime.now().strftime(
@@ -256,10 +257,12 @@ def run_in_test_mode(data_file: str, output_html_path: Optional[str] = None) -> 
         )
 
     # 템플릿 디렉토리 설정
-    current_dir = os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    from ..template_paths import (
+        get_newsletter_template_dir,
+        get_newsletter_template_path,
     )
-    template_dir = os.path.join(current_dir, "templates")
+
+    template_dir = get_newsletter_template_dir()
     template_name = "newsletter_template.html"
 
     # 템플릿 디렉토리 존재 확인
@@ -268,7 +271,7 @@ def run_in_test_mode(data_file: str, output_html_path: Optional[str] = None) -> 
         os.makedirs(template_dir, exist_ok=True)
 
     # 템플릿 파일 존재 확인
-    template_path = os.path.join(template_dir, template_name)
+    template_path = get_newsletter_template_path(template_name)
     if not os.path.exists(template_path):
         logger.warning(f"Template file not found: {template_path}")
         # 기본 템플릿 생성

--- a/scripts/repo_hygiene_policy.json
+++ b/scripts/repo_hygiene_policy.json
@@ -37,7 +37,6 @@
       "newsletter",
       "newsletter_core",
       "scripts",
-      "templates",
       "tests",
       "web"
     ],

--- a/tests/test_compact_newsletter.py
+++ b/tests/test_compact_newsletter.py
@@ -7,7 +7,6 @@ Compact 뉴스레터 단위 테스트
 
 import os
 import sys
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -15,11 +14,14 @@ import pytest
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, project_root)
 
-from newsletter.chains import get_newsletter_chain
-from newsletter.compose import (
+from newsletter.chains import get_newsletter_chain  # noqa: E402
+from newsletter.compose import (  # noqa: E402
     compose_compact_newsletter_html,
     extract_key_definitions_for_compact,
 )
+from newsletter.template_paths import get_newsletter_template_dir  # noqa: E402
+
+TEMPLATE_DIR = get_newsletter_template_dir()
 
 
 class TestCompactNewsletterUnit:
@@ -138,29 +140,22 @@ class TestCompactNewsletterUnit:
                     "articles": [],
                 }
             ],
-            "definitions": [
-                {"term": "테스트용어", "explanation": "테스트를 위한 용어입니다."}
-            ],
+            "definitions": [{"term": "테스트용어", "explanation": "테스트를 위한 용어입니다."}],
             "food_for_thought": "테스트 질문입니다.",
             "company_name": "Test Company",
         }
 
-        template_dir = os.path.join(project_root, "templates")
         html = compose_compact_newsletter_html(
-            test_data, template_dir, "newsletter_template_compact.html"
+            test_data, TEMPLATE_DIR, "newsletter_template_compact.html"
         )
 
         # 검증 - 실제 렌더링되는 제목으로 수정
         assert html is not None and len(html) > 0, "HTML이 생성되지 않았습니다"
-        assert (
-            "자율주행 주간 산업 동향 뉴스 클리핑" in html
-        ), "제목이 렌더링되지 않았습니다"
+        assert "자율주행 주간 산업 동향 뉴스 클리핑" in html, "제목이 렌더링되지 않았습니다"
         assert "📖 이런 뜻이에요" in html, "정의 섹션이 렌더링되지 않았습니다"
         assert "테스트용어" in html, "용어가 렌더링되지 않았습니다"
         assert "테스트를 위한 용어입니다" in html, "용어 설명이 렌더링되지 않았습니다"
-        assert (
-            "이번 주, 주요 산업 동향을 미리 만나보세요" in html
-        ), "태그라인이 렌더링되지 않았습니다"
+        assert "이번 주, 주요 산업 동향을 미리 만나보세요" in html, "태그라인이 렌더링되지 않았습니다"
 
         print("✅ Compact 템플릿 렌더링 테스트 통과!")
 
@@ -176,9 +171,7 @@ class TestCompactNewsletterUnit:
         # definitions 필드가 없는 섹션 테스트
         no_definitions_sections = [{"title": "테스트 섹션", "articles": []}]
         definitions = extract_key_definitions_for_compact(no_definitions_sections)
-        assert (
-            definitions == []
-        ), "definitions 필드가 없는 섹션에서 정의가 생성되었습니다"
+        assert definitions == [], "definitions 필드가 없는 섹션에서 정의가 생성되었습니다"
 
         # 빈 definitions 필드가 있는 섹션 테스트
         empty_definitions_sections = [{"title": "테스트 섹션", "definitions": []}]
@@ -198,23 +191,17 @@ class TestCompactNewsletterUnit:
             "definitions": [],
         }
 
-        template_dir = os.path.join(project_root, "templates")
-
         try:
             html = compose_compact_newsletter_html(
-                minimal_data, template_dir, "newsletter_template_compact.html"
+                minimal_data, TEMPLATE_DIR, "newsletter_template_compact.html"
             )
 
             # 기본 HTML 구조는 생성되어야 함
-            assert (
-                html is not None and len(html) > 0
-            ), "최소 데이터로 HTML이 생성되지 않았습니다"
+            assert html is not None and len(html) > 0, "최소 데이터로 HTML이 생성되지 않았습니다"
             assert "<!DOCTYPE html>" in html, "유효한 HTML 형식이 아닙니다"
             # compose_compact_newsletter_html은 newsletter_topic을 newsletter_title로 매핑함
             assert "테스트 뉴스 클리핑" in html, "제목이 렌더링되지 않았습니다"
-            assert (
-                "이번 주, 주요 산업 동향을 미리 만나보세요" in html
-            ), "태그라인이 렌더링되지 않았습니다"
+            assert "이번 주, 주요 산업 동향을 미리 만나보세요" in html, "태그라인이 렌더링되지 않았습니다"
 
             print("✅ 템플릿 데이터 검증 테스트 통과!")
 
@@ -232,13 +219,11 @@ class TestCompactNewsletterUnit:
             "definitions": [],
         }
 
-        template_dir = os.path.join(project_root, "templates")
-
         try:
             # 존재하지 않는 템플릿 파일 - 이제 예외가 발생해야 함
             with pytest.raises(Exception):  # Jinja2 TemplateNotFound 예외 예상
-                html = compose_compact_newsletter_html(
-                    test_data, template_dir, "non_existent_template.html"
+                compose_compact_newsletter_html(
+                    test_data, TEMPLATE_DIR, "non_existent_template.html"
                 )
             print("✅ 에러 처리 테스트 통과!")
 
@@ -282,9 +267,7 @@ class TestCompactNewsletterUnit:
             assert term.strip() == term, "용어에 불필요한 공백이 있습니다"
             assert explanation.strip() == explanation, "설명에 불필요한 공백이 있습니다"
 
-        print(
-            f"✅ Definitions 내용 검증 테스트 통과! 선택된 정의: {[d['term'] for d in definitions]}"
-        )
+        print(f"✅ Definitions 내용 검증 테스트 통과! 선택된 정의: {[d['term'] for d in definitions]}")
 
 
 def test_compact_newsletter_unit_standalone():
@@ -311,9 +294,7 @@ if __name__ == "__main__":
         assert chain is not None, "체인 생성 실패"
 
         print("\n🎉 모든 독립 단위 테스트가 통과했습니다!")
-        print(
-            "전체 단위 테스트를 실행하려면: python -m pytest tests/test_compact_newsletter.py -v"
-        )
+        print("전체 단위 테스트를 실행하려면: python -m pytest tests/test_compact_newsletter.py -v")
     except Exception as e:
         print(f"\n❌ 일부 단위 테스트가 실패했습니다: {e}")
         sys.exit(1)

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,10 +1,10 @@
 import os
 import sys
 import unittest
-from pathlib import Path
 from unittest.mock import patch
 
 from newsletter.compose import compose_newsletter_html
+from newsletter.template_paths import get_newsletter_template_dir
 
 # 프로젝트 루트 디렉토리를 sys.path에 추가
 # 현재 파일의 디렉토리(tests)의 부모 디렉토리(프로젝트 루트)를 경로에 추가
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 
 class TestCompose(unittest.TestCase):
-    template_dir = str(Path(__file__).resolve().parents[1] / "templates")
+    template_dir = get_newsletter_template_dir()
 
     def test_compose_newsletter_html_success(self):
         summaries = [

--- a/tests/test_email_compatibility.py
+++ b/tests/test_email_compatibility.py
@@ -11,7 +11,6 @@ Email Compatibility 테스트 모듈
 """
 
 import os
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,8 +18,9 @@ from bs4 import BeautifulSoup
 
 from newsletter.chains import get_newsletter_chain
 from newsletter.compose import compose_newsletter
+from newsletter.template_paths import get_newsletter_template_dir
 
-project_root = str(Path(__file__).resolve().parents[1])
+TEMPLATE_DIR = get_newsletter_template_dir()
 
 
 class TestEmailCompatibilityCore:
@@ -97,7 +97,7 @@ class TestEmailCompatibilityCore:
 
     def test_email_compatible_template_selection(self, sample_data):
         """Email-compatible 템플릿이 올바르게 선택되는지 테스트"""
-        template_dir = os.path.join(project_root, "templates")
+        template_dir = TEMPLATE_DIR
 
         # email_compatible = True인 경우
         html_content = compose_newsletter(sample_data, template_dir, "email_compatible")
@@ -119,7 +119,7 @@ class TestEmailCompatibilityCore:
 
     def test_inline_css_processing(self, sample_data):
         """CSS가 인라인으로 처리되는지 테스트"""
-        template_dir = os.path.join(project_root, "templates")
+        template_dir = TEMPLATE_DIR
         html_content = compose_newsletter(sample_data, template_dir, "email_compatible")
 
         soup = BeautifulSoup(html_content, "html.parser")
@@ -134,7 +134,7 @@ class TestEmailCompatibilityCore:
 
     def test_template_style_handling(self, sample_data):
         """template_style에 따른 다른 콘텐츠 처리 테스트"""
-        template_dir = os.path.join(project_root, "templates")
+        template_dir = TEMPLATE_DIR
 
         # Detailed style 테스트
         sample_data["template_style"] = "detailed"
@@ -156,7 +156,7 @@ class TestEmailCompatibilityCore:
 
     def test_required_email_fields(self, sample_data):
         """Email-compatible 템플릿에 필요한 필드들이 포함되는지 테스트"""
-        template_dir = os.path.join(project_root, "templates")
+        template_dir = TEMPLATE_DIR
         html_content = compose_newsletter(sample_data, template_dir, "email_compatible")
 
         # 필수 필드들이 포함되었는지 확인
@@ -175,7 +175,7 @@ class TestEmailCompatibilityCore:
 
     def test_content_integrity(self, sample_data):
         """콘텐츠 무결성 테스트 - 모든 데이터가 손실 없이 포함되는지"""
-        template_dir = os.path.join(project_root, "templates")
+        template_dir = TEMPLATE_DIR
         html_content = compose_newsletter(sample_data, template_dir, "email_compatible")
 
         # 기사 제목들이 포함되었는지 확인
@@ -198,7 +198,7 @@ class TestEmailCompatibilityCore:
 
     def test_mobile_responsiveness(self, sample_data):
         """모바일 반응형 디자인 테스트"""
-        template_dir = os.path.join(project_root, "templates")
+        template_dir = TEMPLATE_DIR
         html_content = compose_newsletter(sample_data, template_dir, "email_compatible")
 
         soup = BeautifulSoup(html_content, "html.parser")
@@ -406,7 +406,7 @@ class TestEmailCompatibilityValidation:
             "top_articles": [],
         }
 
-        template_dir = os.path.join(project_root, "templates")
+        template_dir = TEMPLATE_DIR
         html_content = compose_newsletter(sample_data, template_dir, "email_compatible")
 
         soup = BeautifulSoup(html_content, "html.parser")
@@ -432,7 +432,7 @@ class TestEmailCompatibilityValidation:
             "top_articles": [],
         }
 
-        template_dir = os.path.join(project_root, "templates")
+        template_dir = TEMPLATE_DIR
         html_content = compose_newsletter(sample_data, template_dir, "email_compatible")
 
         # 지원되지 않는 CSS 속성 확인
@@ -468,7 +468,7 @@ class TestEmailCompatibilityValidation:
             "top_articles": [],
         }
 
-        template_dir = os.path.join(project_root, "templates")
+        template_dir = TEMPLATE_DIR
         html_content = compose_newsletter(sample_data, template_dir, "email_compatible")
 
         soup = BeautifulSoup(html_content, "html.parser")

--- a/tests/test_unified_architecture.py
+++ b/tests/test_unified_architecture.py
@@ -20,7 +20,7 @@ import pytest
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, project_root)
 
-from newsletter.compose import (
+from newsletter.compose import (  # noqa: E402
     NewsletterConfig,
     compose_newsletter,
     create_grouped_sections,
@@ -28,6 +28,7 @@ from newsletter.compose import (
     extract_definitions,
     extract_food_for_thought,
 )
+from newsletter.template_paths import get_newsletter_template_dir  # noqa: E402
 
 
 def create_test_data() -> Dict[str, Any]:
@@ -199,7 +200,7 @@ class TestUnifiedArchitecture:
         print("Step 9: Food for thought 생성 ✅")
 
         # Step 10: 최종 생성 (템플릿 테스트는 선택적)
-        template_dir = os.path.join(project_root, "templates")
+        template_dir = get_newsletter_template_dir()
         if os.path.exists(template_dir):
             try:
                 final_html = compose_newsletter(self.test_data, template_dir, "compact")
@@ -253,9 +254,7 @@ class TestUnifiedArchitecture:
         )
         assert len(detailed_groups) <= detailed_config["max_groups"]
 
-        print(
-            f"✅ Compact: {len(compact_definitions)}개 정의, {len(compact_groups)}개 그룹"
-        )
+        print(f"✅ Compact: {len(compact_definitions)}개 정의, {len(compact_groups)}개 그룹")
         print(
             f"✅ Detailed: {len(detailed_definitions)}개 정의, {len(detailed_groups)}개 그룹"
         )

--- a/tests/unit_tests/test_new_newsletter.py
+++ b/tests/unit_tests/test_new_newsletter.py
@@ -1,8 +1,10 @@
 import os
+import re
 from datetime import datetime, timedelta
 
 from newsletter.compose import compose_newsletter_html
 from newsletter.date_utils import standardize_date
+from newsletter.template_paths import get_newsletter_template_dir
 
 # Create test data that includes various date formats
 test_articles = [
@@ -56,7 +58,7 @@ tests_dir = os.path.dirname(current_dir)  # tests 디렉토리
 project_root = os.path.dirname(tests_dir)  # 프로젝트 루트 디렉토리
 
 # 템플릿 디렉토리 및 파일 경로 설정
-template_directory = os.path.join(project_root, "templates")
+template_directory = get_newsletter_template_dir()
 template_file = "newsletter_template.html"
 
 print(f"템플릿 디렉토리 경로: {template_directory}")
@@ -79,17 +81,12 @@ with open(output_filename, "w", encoding="utf-8") as f:
 
 print(f"테스트 뉴스레터 저장 경로: {output_filename}")
 
-# 뉴스레터 HTML에서 중요한 부분만 출력
-import re
-
 # 날짜 정보가 있는 부분 추출
 source_date_pattern = r'<span class="source">\((.*?)\)</span>'
 source_dates = re.findall(source_date_pattern, html_output)
 
 print("\n== 뉴스 기사 소스 및 날짜 정보 ==")
 for idx, source_date in enumerate(source_dates):
-    print(f"기사 {idx+1}: {source_date}")
+    print(f"기사 {idx + 1}: {source_date}")
 
-print(
-    "\n테스트 완료: 뉴스레터의 날짜 형식이 모두 YYYY-MM-DD 형식으로 표준화되었습니다."
-)
+print("\n테스트 완료: 뉴스레터의 날짜 형식이 모두 YYYY-MM-DD 형식으로 표준화되었습니다.")

--- a/tests/unit_tests/test_new_newsletter_with_weeks.py
+++ b/tests/unit_tests/test_new_newsletter_with_weeks.py
@@ -1,8 +1,10 @@
 import os
+import re
 from datetime import datetime, timedelta
 
 from newsletter.compose import compose_newsletter_html
 from newsletter.date_utils import standardize_date
+from newsletter.template_paths import get_newsletter_template_dir
 
 # Create test data that includes various date formats including "weeks ago"
 test_articles = [
@@ -57,7 +59,7 @@ tests_dir = os.path.dirname(current_dir)  # tests 디렉토리
 project_root = os.path.dirname(tests_dir)  # 프로젝트 루트 디렉토리
 
 # 템플릿 디렉토리 및 파일 경로 설정
-template_directory = os.path.join(project_root, "templates")
+template_directory = get_newsletter_template_dir()
 template_file = "newsletter_template.html"
 
 print(f"템플릿 디렉토리 경로: {template_directory}")
@@ -80,17 +82,12 @@ with open(output_filename, "w", encoding="utf-8") as f:
 
 print(f"테스트 뉴스레터 저장 경로: {output_filename}")
 
-# 뉴스레터 HTML에서 중요한 부분만 출력
-import re
-
 # 날짜 정보가 있는 부분 추출
 source_date_pattern = r'<span class="source">\((.*?)\)</span>'
 source_dates = re.findall(source_date_pattern, html_output)
 
 print("\n== 뉴스 기사 소스 및 날짜 정보 ==")
 for idx, source_date in enumerate(source_dates):
-    print(f"기사 {idx+1}: {source_date}")
+    print(f"기사 {idx + 1}: {source_date}")
 
-print(
-    "\n테스트 완료: 뉴스레터의 날짜 형식이 모두 YYYY-MM-DD 형식으로 표준화되었습니다."
-)
+print("\n테스트 완료: 뉴스레터의 날짜 형식이 모두 YYYY-MM-DD 형식으로 표준화되었습니다.")

--- a/tests/unit_tests/test_search_keywords.py
+++ b/tests/unit_tests/test_search_keywords.py
@@ -1,11 +1,7 @@
-import json
-import os
 from datetime import datetime
-from pathlib import Path
-
-import pytest
 
 from newsletter.compose import compose_newsletter_html
+from newsletter.template_paths import get_newsletter_template_dir
 
 
 def test_search_keywords_in_template():
@@ -20,9 +16,7 @@ def test_search_keywords_in_template():
         "sections": [
             {
                 "title": "생성형 AI 발전",
-                "summary_paragraphs": [
-                    "최근 생성형 AI 기술이 빠르게 발전하고 있습니다."
-                ],
+                "summary_paragraphs": ["최근 생성형 AI 기술이 빠르게 발전하고 있습니다."],
                 "news_links": [
                     {
                         "title": "ChatGPT 4.0 출시",
@@ -37,12 +31,7 @@ def test_search_keywords_in_template():
         "company_name": "Tech News Co.",
     }
 
-    # Get the template directory
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    project_root = os.path.dirname(
-        os.path.dirname(current_dir)
-    )  # Go up two levels to the project root
-    template_dir = os.path.join(project_root, "templates")
+    template_dir = get_newsletter_template_dir()
     template_file = "newsletter_template.html"
 
     # Create the newsletter HTML
@@ -73,19 +62,12 @@ def test_search_keywords_rendering_with_multiple_formats():
         "sections": [
             {
                 "title": "생성형 AI 발전",
-                "summary_paragraphs": [
-                    "최근 생성형 AI 기술이 빠르게 발전하고 있습니다."
-                ],
+                "summary_paragraphs": ["최근 생성형 AI 기술이 빠르게 발전하고 있습니다."],
             }
         ],
     }
 
-    # Get the template directory
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    project_root = os.path.dirname(
-        os.path.dirname(current_dir)
-    )  # Go up two levels to the project root
-    template_dir = os.path.join(project_root, "templates")
+    template_dir = get_newsletter_template_dir()
     template_file = "newsletter_template.html"
 
     # Test case 1: String keywords


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- move the newsletter HTML templates into `newsletter/templates` so the package owns its runtime assets and the repo root stays lighter
- replace root-relative template lookups with package-relative helpers in runtime paths and tests
- update hygiene policy and docs to remove the top-level `templates/` directory from the active root layout

## Scope
### In Scope
- template asset relocation into the `newsletter` package
- package-relative path helpers and call-site updates
- tests and docs needed to preserve the new canonical path

### Out of Scope
- archived docs that intentionally preserve historical root layout references
- broader entrypoint consolidation planned for RR-D

## Delivery Unit
- RR: #280
- Delivery Unit ID: DU-20260310-package-template-assets
- Merge Boundary: RR-C package-owned template assets
- Rollback Boundary: revert this PR to restore the previous root-level `templates/` layout

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): compact newsletter path coverage and strict repo audit

### Commands and Results
```bash
MOCK_MODE=true TESTING=1 GEMINI_API_KEY=test-key OPENAI_API_KEY=test-key ANTHROPIC_API_KEY=test-key SERPER_API_KEY=test-key ./.venv/bin/python -m pytest tests/test_compact_newsletter.py -q
# PASS (8 passed)

./.venv/bin/python -m pytest tests/test_compose.py -q
# PASS

./.venv/bin/python -m pytest tests/test_email_compatibility.py -q
# PASS (with expected skips)

./.venv/bin/python -m pytest tests/test_unified_architecture.py tests/unit_tests/test_search_keywords.py -q
# PASS

./.venv/bin/python scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir .local/artifacts/repo-audit --check-policy --strict
# PASS (top-level entries=36, warnings=0)

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: legacy callers that still assume a root-level `templates/` path could fail if they bypass the updated helpers
- Rollback: `git revert 84e596ee7f0e10812554554507bedeee54d988d3`

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: not touched
- Outbox/send_key 중복 방지 결과: not touched
- import-time side effect 제거 여부: not touched

## Not Run (with reason)
- no additional real-API runs; local validation stayed in `MOCK_MODE` per repo policy
