### PR TITLE
chore(repo): standardize local env and cache hygiene

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Newsletter Generator - Makefile
 # 개발 워크플로우 자동화를 위한 Makefile
 
-.PHONY: help bootstrap doctor check check-full format format-check lint architecture-check architecture-baseline test test-quick test-full test-nightly preflight-release validate-ci-manifest validate-scheduler-manifest validate-runtime-bootstrap-manifest apply-pr-metadata ci-check ci-fix clean install pre-commit pre-commit-run skill-ci-gate skill-docs-and-config-consistency skill-newsletter-smoke skill-web-smoke skill-scheduler-debug skill-release-integration skills-check docs-check repo-audit repo-audit-strict runtime-ascii-guard legacy-web-types-guard ops-safety-check ops-safety-smoke ops-safety-report build-web-exe windows-release-artifacts verify-windows-artifact-checksum support-bundle windows-sign-exe validate-windows-release-artifacts windows-update-manifest windows-ci-burnin-report github-windows-release-controls
+.PHONY: help bootstrap doctor print-python print-venv check check-full format format-check lint architecture-check architecture-baseline test test-quick test-full test-nightly preflight-release validate-ci-manifest validate-scheduler-manifest validate-runtime-bootstrap-manifest apply-pr-metadata ci-check ci-fix clean clean-caches clean-local clean-venv install pre-commit pre-commit-run skill-ci-gate skill-docs-and-config-consistency skill-newsletter-smoke skill-web-smoke skill-scheduler-debug skill-release-integration skills-check docs-check repo-audit repo-audit-strict runtime-ascii-guard legacy-web-types-guard ops-safety-check ops-safety-smoke ops-safety-report build-web-exe windows-release-artifacts verify-windows-artifact-checksum support-bundle windows-sign-exe validate-windows-release-artifacts windows-update-manifest windows-ci-burnin-report github-windows-release-controls
 
 # 실행 경로/인터프리터 설정
 EXPECTED_CWD ?= /Users/hojungjung/development/newsletter-generator
@@ -14,7 +14,19 @@ WINDOWS_RELEASE_CONTROLS_REPORT ?= $(ARTIFACTS_DIR)/windows-release-controls.jso
 COVERAGE_DIR ?= $(LOCAL_DIR)/coverage
 DEBUG_DIR ?= $(LOCAL_DIR)/debug_files
 NEWSLETTER_DEBUG_DIR ?= $(DEBUG_DIR)
-VENV_PYTHON := $(PROJECT_ROOT)/.venv/bin/python
+DEFAULT_VENV_DIR ?= $(LOCAL_DIR)/venv
+LEGACY_VENV_DIR ?= $(PROJECT_ROOT)/.venv
+BOOTSTRAP_VENV_DIR ?= $(DEFAULT_VENV_DIR)
+VENV_DIR ?= $(DEFAULT_VENV_DIR)
+ifeq ($(origin VENV_DIR), file)
+  ifeq ($(wildcard $(DEFAULT_VENV_DIR)/bin/python)$(wildcard $(DEFAULT_VENV_DIR)/Scripts/python.exe),)
+    ifneq ($(wildcard $(LEGACY_VENV_DIR)/bin/python)$(wildcard $(LEGACY_VENV_DIR)/Scripts/python.exe),)
+      VENV_DIR := $(LEGACY_VENV_DIR)
+    endif
+  endif
+endif
+BOOTSTRAP_VENV_PYTHON := $(if $(wildcard $(BOOTSTRAP_VENV_DIR)/Scripts/python.exe),$(BOOTSTRAP_VENV_DIR)/Scripts/python.exe,$(BOOTSTRAP_VENV_DIR)/bin/python)
+VENV_PYTHON := $(if $(wildcard $(VENV_DIR)/Scripts/python.exe),$(VENV_DIR)/Scripts/python.exe,$(VENV_DIR)/bin/python)
 PYTHON ?= $(if $(wildcard $(VENV_PYTHON)),$(VENV_PYTHON),python3)
 PIP := $(PYTHON) -m pip
 export NEWSLETTER_DEBUG_DIR
@@ -38,11 +50,11 @@ help: ## 도움말 표시
 
 bootstrap: ## 로컬 가상환경/의존성/훅 설치
 	@echo "🧱 로컬 개발 환경 bootstrap 중..."
-	python3 -m venv .venv
-	$(VENV_PYTHON) -m pip install --upgrade pip
-	$(VENV_PYTHON) -m pip install -r requirements.txt
-	$(VENV_PYTHON) -m pip install -r requirements-dev.txt
-	$(VENV_PYTHON) -m pre_commit install
+	python3 -m venv $(BOOTSTRAP_VENV_DIR)
+	$(BOOTSTRAP_VENV_PYTHON) -m pip install --upgrade pip
+	$(BOOTSTRAP_VENV_PYTHON) -m pip install -r requirements.txt
+	$(BOOTSTRAP_VENV_PYTHON) -m pip install -r requirements-dev.txt
+	$(BOOTSTRAP_VENV_PYTHON) -m pre_commit install
 	@echo "✅ bootstrap 완료"
 
 doctor: ## 작업 경로/인터프리터 전제 조건 검증
@@ -61,10 +73,16 @@ doctor: ## 작업 경로/인터프리터 전제 조건 검증
 	fi
 	@if [ ! -x "$(VENV_PYTHON)" ]; then \
 		echo "❌ 가상환경 Python 없음: $(VENV_PYTHON)"; \
-		echo "   먼저 'make bootstrap'을 실행하세요."; \
+		echo "   기본 경로는 $(DEFAULT_VENV_DIR) 입니다. 먼저 'make bootstrap'을 실행하세요."; \
 		exit 1; \
 	fi
-	@echo "✅ 환경 점검 통과 (PYTHON=$(PYTHON))"
+	@echo "✅ 환경 점검 통과 (PYTHON=$(PYTHON), VENV_DIR=$(VENV_DIR))"
+
+print-python: ## 현재 선택된 Python 인터프리터 경로 출력
+	@echo "$(PYTHON)"
+
+print-venv: ## 현재 선택된 가상환경 디렉터리 경로 출력
+	@echo "$(VENV_DIR)"
 
 check: doctor test-quick docs-check skills-check ## 표준 로컬 게이트
 	@echo "✅ check 완료"
@@ -305,9 +323,10 @@ pre-commit-run: ## Pre-commit 수동 실행
 	@echo "🔍 Pre-commit 검사 실행 중..."
 	pre-commit run --all-files
 
-clean: ## 캐시 및 임시 파일 정리
-	@echo "🧹 정리 중..."
+clean-caches: ## 재생성 가능한 캐시/coverage 정리
+	@echo "🧽 캐시 정리 중..."
 	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d \( -name ".pytest_cache" -o -name ".mypy_cache" -o -name ".ruff_cache" -o -name ".hypothesis" -o -name ".tox" -o -name ".nox" -o -name ".pytype" \) -prune -exec rm -rf {} + 2>/dev/null || true
 	find . -type f -name "*.pyc" -delete 2>/dev/null || true
 	find . -type f -name "*.pyo" -delete 2>/dev/null || true
 	find . -type f -name ".coverage" -delete 2>/dev/null || true
@@ -317,8 +336,21 @@ clean: ## 캐시 및 임시 파일 정리
 	rm -rf htmlcov/ 2>/dev/null || true
 	rm -rf $(ARTIFACTS_DIR)/ 2>/dev/null || true
 	rm -rf $(COVERAGE_DIR)/ 2>/dev/null || true
-	rm -rf .pytest_cache/ 2>/dev/null || true
-	rm -rf .mypy_cache/ 2>/dev/null || true
+	@echo "✅ 캐시 정리 완료!"
+
+clean-local: clean-caches ## .local scratch 산출물 정리 (output/과 venv 제외)
+	@echo "🧹 로컬 scratch 정리 중..."
+	rm -rf $(DEBUG_DIR)/ 2>/dev/null || true
+	@echo "✅ 로컬 scratch 정리 완료!"
+
+clean-venv: ## 로컬 가상환경 정리 (.local/venv + legacy .venv)
+	@echo "🗑️ 가상환경 정리 중..."
+	rm -rf $(DEFAULT_VENV_DIR) 2>/dev/null || true
+	rm -rf $(LEGACY_VENV_DIR) 2>/dev/null || true
+	@echo "✅ 가상환경 정리 완료!"
+
+clean: clean-local ## 캐시 및 임시 파일 정리
+	@echo "🧹 추가 빌드 산출물 정리 중..."
 	rm -rf dist/ build/ *.egg-info 2>/dev/null || true
 	@echo "✅ 정리 완료!"
 

--- a/docs/dev/DEVELOPMENT_GUIDE.md
+++ b/docs/dev/DEVELOPMENT_GUIDE.md
@@ -33,9 +33,9 @@ cd newsletter-generator
 git remote add upstream https://github.com/original-org/newsletter-generator.git
 
 # 3. 가상환경 생성 및 활성화
-python -m venv .venv
-source .venv/bin/activate  # Linux/macOS
-.venv\Scripts\activate     # Windows
+python -m venv .local/venv
+source .local/venv/bin/activate  # Linux/macOS
+.local\venv\Scripts\activate     # Windows
 
 # 4. 개발 의존성 설치
 pip install --upgrade pip
@@ -54,7 +54,7 @@ pre-commit install
 
 ```json
 {
-    "python.defaultInterpreterPath": "./.venv/bin/python",
+    "python.defaultInterpreterPath": "./.local/venv/bin/python",
     "python.linting.enabled": true,
     "python.linting.flake8Enabled": true,
     "python.linting.mypyEnabled": true,
@@ -589,7 +589,7 @@ echo "Release $VERSION completed"
 
 ```bash
 # 개발 환경 활성화
-source .venv/bin/activate
+source .local/venv/bin/activate
 
 # 코드 품질 검사
 python run_ci_checks.py --quick

--- a/docs/dev/LOCAL_CI_GUIDE.md
+++ b/docs/dev/LOCAL_CI_GUIDE.md
@@ -11,6 +11,8 @@ make doctor
 make check
 ```
 
+기본 로컬 가상환경 경로는 `.local/venv/` 입니다. 기존 clone의 루트 `.venv/` 는 호환 fallback으로만 지원합니다.
+
 PR 전 최종 검증:
 
 ```bash
@@ -26,6 +28,8 @@ make check-full
 | `make check-full` | 전체 PR 게이트 (`test-full + docs-check + skills-check`) | 푸시/PR 전 |
 | `make ci-fix` | 포맷 자동 수정 포함 CI 스크립트 실행 | 코드 정리 필요 시 |
 | `make docs-check` | Markdown 링크/스타일 검증 | 문서 변경 시 |
+| `make clean-caches` | 재생성 가능한 cache/coverage 삭제 | gate 전후 root 정리 |
+| `make clean-local` | cache + `.local` scratch 삭제 | 산출물 정리 |
 
 ## Strict Gate Policy
 
@@ -60,7 +64,7 @@ make doctor
 ### 2) Virtualenv/interpreter mismatch
 
 현상:
-- `.venv/bin/python` 없음
+- `.local/venv/bin/python` 없음
 - 도구(black/isort/flake8/mypy/bandit/pytest) import 실패
 
 해결:
@@ -81,8 +85,8 @@ make check
 
 진단:
 ```bash
-.venv/bin/python scripts/architecture/check_import_boundaries.py --mode ratchet
-.venv/bin/python scripts/architecture/check_import_cycles.py
+$(make print-python) scripts/architecture/check_import_boundaries.py --mode ratchet
+$(make print-python) scripts/architecture/check_import_cycles.py
 ```
 
 ## Recommended Local Workflow

--- a/docs/dev/REPO_HYGIENE_POLICY.md
+++ b/docs/dev/REPO_HYGIENE_POLICY.md
@@ -10,6 +10,7 @@
 - Week 10 반영: 루트 `.coveragerc`, `.python-version` 제거
 - Week 11 반영: 루트 `config.yml`을 `config/config.yml`로 이관
 - Week 18 반영: 로컬 scratch 산출물 기본 경로를 루트 `.local/`로 정규화
+- Week 19 반영: 로컬 가상환경 canonical 경로를 `.local/venv/`로 정규화, cache cleanup target 분리
 
 ## Scope
 
@@ -34,8 +35,9 @@
 | `pyinstaller_hooks/` | 이관 완료 | `scripts/devtools/pyinstaller_hooks/` | 빌드 유틸 범주로 통합 |
 | `build_web_exe.py`, `build_web_exe_enhanced.py`, `cleanup_debug_files.py`, `fix_env_setup.py`, `run_tests.py` | 삭제 완료 | `scripts/devtools/`만 사용 | 루트 clutter 제거 및 단일 실행 경로 고정 |
 | `check_quality.py`, `setup_env.py`, `newsletter-test.sh`, `newsletter-test.bat` | 삭제 완료 | `scripts/devtools/`만 사용 | 루트 clutter 제거 및 단일 실행 경로 고정 |
-| `.local/` | ignore | 로컬 scratch workspace (`artifacts/`, `coverage/`, `debug_files/`) | 재생성 가능 산출물과 디버그 출력은 숨김 경계로 격리 |
-| `.venv/`, `.pytest_cache/`, `.mypy_cache/`, `__pycache__/` | ignore | 로컬 캐시 | 개인/런타임 캐시 |
+| `.local/` | ignore | 로컬 scratch workspace (`artifacts/`, `coverage/`, `debug_files/`, `venv/`) | 재생성 가능 산출물과 로컬 런타임 환경을 숨김 경계로 격리 |
+| `.venv/` | ignore(호환) | legacy local virtualenv | 기존 clone 호환용, 신규 bootstrap 정본은 `.local/venv/` |
+| `.pytest_cache/`, `.mypy_cache/`, `__pycache__/` | ignore | 로컬 캐시 | 재생성 가능 캐시 |
 | `output/` | ignore | 사용자 생성 결과물 디렉터리 (tracked 제외) | 실행 결과 확인용이므로 루트 유지 |
 | `config/config.yml` | 유지 | `config/` 내부 정본 | 런타임 설정 파일 위치 정규화 |
 | `config.example.yml` | 이관 완료 | `config/config.example.yml` | 템플릿 파일 위치 정규화 + 루트 엔트리 축소 |
@@ -118,6 +120,14 @@ Makefile 단축 명령:
 ```bash
 make repo-audit
 make repo-audit-strict
+```
+
+로컬 환경 위생 정리:
+
+```bash
+make clean-caches   # 재생성 가능한 cache/coverage만 삭제
+make clean-local    # cache + .local scratch 삭제 (output/, venv 유지)
+make clean-venv     # .local/venv 및 legacy .venv 삭제
 ```
 
 ## Governance Notes

--- a/docs/setup/INSTALLATION.md
+++ b/docs/setup/INSTALLATION.md
@@ -50,14 +50,14 @@ git clone https://github.com/username/newsletter-generator.git
 cd newsletter-generator
 
 # 2. 가상환경 생성
-python -m venv .venv
+python -m venv .local/venv
 
 # 3. 가상환경 활성화
 # Windows
-.venv\Scripts\activate
+.local\venv\Scripts\activate
 
 # macOS/Linux
-source .venv/bin/activate
+source .local/venv/bin/activate
 
 # 4. 의존성 설치
 pip install --upgrade pip
@@ -117,6 +117,8 @@ notepad .env  # Windows
 newsletter-generator/
 ├── .env                    # 환경 변수 설정
 ├── .env.example           # 환경 변수 예제
+├── .local/
+│   └── venv/              # 로컬 가상환경 (canonical)
 ├── newsletter/            # 메인 패키지
 │   └── templates/         # 패키지 내부 HTML 템플릿
 ├── output/               # 생성된 파일들
@@ -327,9 +329,9 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 
 # 가상환경 재생성
 deactivate
-rm -rf .venv  # Linux/macOS
-rmdir /s .venv  # Windows
-python -m venv .venv
+rm -rf .local/venv  # Linux/macOS
+rmdir /s .local\venv  # Windows
+python -m venv .local/venv
 ```
 
 #### 4. 권한 문제

--- a/docs/setup/LOCAL_SETUP.md
+++ b/docs/setup/LOCAL_SETUP.md
@@ -14,13 +14,13 @@ cd newsletter-generator
 ## 2. 가상환경 설정
 
 ```bash
-python -m venv .venv
+python -m venv .local/venv
 
 # Windows
-.venv\Scripts\activate
+.local\venv\Scripts\activate
 
 # macOS/Linux
-source .venv/bin/activate
+source .local/venv/bin/activate
 ```
 
 ## 3. 의존성 설치
@@ -32,6 +32,8 @@ pip install -r requirements.txt
 # 웹 애플리케이션 의존성 추가 설치
 pip install -r web/requirements.txt
 ```
+
+기본 로컬 가상환경 경로는 `.local/venv/` 입니다. 기존 루트 `.venv/` 가 있는 clone도 호환되지만 신규 생성은 권장하지 않습니다.
 
 ## 4. 환경 변수 설정
 
@@ -263,6 +265,14 @@ python scripts/devtools/cleanup_debug_files.py --action move
 
 # 디버그 파일 완전 삭제
 python scripts/devtools/cleanup_debug_files.py --action delete
+```
+
+## 13. 로컬 캐시/가상환경 정리
+
+```bash
+make clean-caches   # __pycache__, .pytest_cache, .mypy_cache, coverage 정리
+make clean-local    # cache + .local/artifacts, .local/coverage, .local/debug_files 정리
+make clean-venv     # .local/venv 및 legacy .venv 제거
 ```
 
 ## 문제 해결

--- a/docs/setup/PYINSTALLER_WINDOWS.md
+++ b/docs/setup/PYINSTALLER_WINDOWS.md
@@ -16,8 +16,8 @@ git clone https://github.com/hjjung-katech/newsletter-generator.git
 cd newsletter-generator
 
 # 가상환경 생성 및 활성화
-python -m venv .venv
-.\.venv\Scripts\activate
+python -m venv .local\venv
+.\.local\venv\Scripts\activate
 
 # 필요한 패키지 설치
 pip install -r requirements.txt

--- a/docs/setup/QUICK_START_GUIDE.md
+++ b/docs/setup/QUICK_START_GUIDE.md
@@ -8,8 +8,8 @@
 ```bash
 git clone https://github.com/hjjung-katech/newsletter-generator.git
 cd newsletter-generator
-python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+python -m venv .local/venv
+source .local/venv/bin/activate  # Windows: .local\\venv\\Scripts\\activate
 ```
 
 ## 2. 의존성 설치


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- standardize the canonical local virtualenv under `.local/venv` and keep root `.venv` as a compatibility fallback
- add explicit cache/scratch cleanup targets so root-level clutter can be cleared without deleting user outputs
- align developer/setup docs with the new local environment boundary

## Scope
### In Scope
- Makefile local virtualenv resolution and cleanup targets
- repo hygiene and local setup documentation updates
- canonical local development path migration from `.venv` to `.local/venv`

### Out of Scope
- CI runner virtualenv layout changes outside the existing Makefile/runtime resolution
- removing the legacy `.venv` fallback from existing clones
- any runtime or production config changes

## Delivery Unit
- RR: #284
- Delivery Unit ID: DU-20260310-local-env-hygiene
- Merge Boundary: this PR only changes local environment bootstrap/cleanup behavior and related docs
- Rollback Boundary: revert this PR to restore root `.venv` as the documented default and remove the new cleanup targets

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed):

### Commands and Results
```bash
make doctor
./.local/venv/bin/python scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir .local/artifacts/repo-audit --check-policy --strict
make check
make check-full
make clean-local
./.local/venv/bin/python scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir .local/artifacts/repo-audit --check-policy --strict
```

Results:
- `make doctor` passed and reported `VENV_DIR=/Users/hojungjung/development/newsletter-generator/.local/venv`
- strict repo audit passed before and after cleanup; final result `top-level entries=33 warnings=0`
- `make check` passed
- `make check-full` passed
- `make clean-local` removed root caches/scratch outputs while keeping `.local/venv`

## Risk & Rollback
- Risk: low; existing clones still resolve a legacy root `.venv` when `.local/venv` does not exist
- Rollback: revert this PR and recreate/move the virtualenv back to `/Users/hojungjung/development/newsletter-generator/.venv` if a local workflow depends on the old path

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 해당 없음
- Outbox/send_key 중복 방지 결과: 해당 없음
- import-time side effect 제거 여부: 해당 없음

## Not Run (with reason)
- GitHub-hosted checks are not locally runnable; they will validate the pushed branch after PR creation

Closes #284
