### PR TITLE
chore(web): move development db state under .local

### DIFF
--- a/docs/dev/REPO_HYGIENE_POLICY.md
+++ b/docs/dev/REPO_HYGIENE_POLICY.md
@@ -35,7 +35,7 @@
 | `pyinstaller_hooks/` | 이관 완료 | `scripts/devtools/pyinstaller_hooks/` | 빌드 유틸 범주로 통합 |
 | `build_web_exe.py`, `build_web_exe_enhanced.py`, `cleanup_debug_files.py`, `fix_env_setup.py`, `run_tests.py` | 삭제 완료 | `scripts/devtools/`만 사용 | 루트 clutter 제거 및 단일 실행 경로 고정 |
 | `check_quality.py`, `setup_env.py`, `newsletter-test.sh`, `newsletter-test.bat` | 삭제 완료 | `scripts/devtools/`만 사용 | 루트 clutter 제거 및 단일 실행 경로 고정 |
-| `.local/` | ignore | 로컬 scratch workspace (`artifacts/`, `coverage/`, `debug_files/`, `venv/`) | 재생성 가능 산출물과 로컬 런타임 환경을 숨김 경계로 격리 |
+| `.local/` | ignore | 로컬 workspace (`artifacts/`, `coverage/`, `debug_files/`, `state/`, `venv/`) | 재생성 가능 산출물, 로컬 런타임 환경, 개발 모드 웹 상태를 숨김 경계로 격리 |
 | `.venv/` | ignore(호환) | legacy local virtualenv | 기존 clone 호환용, 신규 bootstrap 정본은 `.local/venv/` |
 | `.pytest_cache/`, `.mypy_cache/`, `__pycache__/` | ignore | 로컬 캐시 | 재생성 가능 캐시 |
 | `output/` | ignore | 사용자 생성 결과물 디렉터리 (tracked 제외) | 실행 결과 확인용이므로 루트 유지 |
@@ -126,7 +126,7 @@ make repo-audit-strict
 
 ```bash
 make clean-caches   # 재생성 가능한 cache/coverage만 삭제
-make clean-local    # cache + .local scratch 삭제 (output/, venv 유지)
+make clean-local    # cache + .local scratch 삭제 (output/, state/, venv 유지)
 make clean-venv     # .local/venv 및 legacy .venv 삭제
 ```
 

--- a/docs/setup/LOCAL_SETUP.md
+++ b/docs/setup/LOCAL_SETUP.md
@@ -209,12 +209,14 @@ newsletter-generator/
 │   ├── intermediate_processing/  # 중간 처리 파일
 │   ├── email_tests/            # 이메일 테스트 결과
 │   └── test_results/           # 테스트 결과
-├── .local/                     # 로컬 scratch 산출물
+├── .local/                     # 로컬 scratch/state 산출물
 │   ├── coverage/               # coverage 리포트/데이터
 │   ├── artifacts/              # repo audit, Windows burn-in 등 점검 산출물
-│   └── debug_files/            # 디버그 파일 (자동 생성)
+│   ├── debug_files/            # 디버그 파일 (자동 생성)
+│   └── state/
+│       └── web/
+│           └── storage.db      # 개발 모드 웹 데이터베이스 (자동 생성)
 └── web/
-    ├── storage.db              # 웹앱 데이터베이스 (자동 생성)
     ├── app.py                  # 메인 웹 애플리케이션
     ├── worker.py               # 백그라운드 워커 (선택사항)
     ├── schedule_runner.py      # 스케줄러 (선택사항)
@@ -239,7 +241,7 @@ python apps/web/main.py
 
 ### 데이터베이스 백업
 ```bash
-cp web/storage.db web/storage.db.backup_$(date +%Y%m%d_%H%M%S)
+cp .local/state/web/storage.db .local/state/web/storage.db.backup_$(date +%Y%m%d_%H%M%S)
 ```
 
 ### 데이터베이스 재설정
@@ -250,7 +252,7 @@ python web/init_database.py --force
 ### 히스토리 정리 (선택사항)
 ```bash
 # SQLite 명령어로 직접 정리
-sqlite3 storage.db "DELETE FROM history WHERE created_at < datetime('now', '-30 days');"
+sqlite3 .local/state/web/storage.db "DELETE FROM history WHERE created_at < datetime('now', '-30 days');"
 ```
 
 ## 12. 디버그 파일 정리
@@ -280,7 +282,7 @@ make clean-venv     # .local/venv 및 legacy .venv 제거
 ### 데이터베이스 관련 오류
 ```bash
 # 데이터베이스 재생성
-rm -f web/storage.db
+rm -f .local/state/web/storage.db
 python web/init_database.py
 ```
 

--- a/docs/setup/RAILWAY_DEPLOYMENT.md
+++ b/docs/setup/RAILWAY_DEPLOYMENT.md
@@ -139,6 +139,10 @@ services:
 ## 파일 구조
 ```
 project/
+├── .local/
+│   └── state/
+│       └── web/
+│           └── storage.db      # SQLite 데이터베이스
 ├── web/
 │   ├── app.py              # Flask 메인 애플리케이션
 │   ├── worker.py           # RQ 워커 (프로덕션용)
@@ -146,7 +150,6 @@ project/
 │   ├── tasks.py            # 백그라운드 작업 정의
 │   ├── mail.py             # 이메일 발송 모듈
 │   ├── init_database.py    # DB 초기화
-│   ├── storage.db          # SQLite 데이터베이스
 │   └── requirements.txt    # Python 의존성
 ├── nixpacks.toml           # Nixpacks 빌드 설정
 ├── railway.yml             # Railway 서비스 정의

--- a/tests/unit_tests/test_db_core.py
+++ b/tests/unit_tests/test_db_core.py
@@ -45,6 +45,17 @@ def test_ensure_database_schema_creates_runtime_tables(tmp_path: Path) -> None:
     }.issubset(tables)
 
 
+def test_ensure_database_schema_creates_missing_parent_directories(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / ".local" / "state" / "web" / "storage.db"
+
+    ensure_database_schema(str(db_path))
+
+    assert db_path.parent.is_dir()
+    assert db_path.is_file()
+
+
 def test_connect_db_applies_additive_history_and_schedule_columns(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/web/test_runtime_paths.py
+++ b/tests/unit_tests/web/test_runtime_paths.py
@@ -15,7 +15,9 @@ def test_runtime_paths_development_mode(monkeypatch, tmp_path):
 
     assert runtime_paths.resolve_template_dir() == str(web_dir / "templates")
     assert runtime_paths.resolve_static_dir() == str(web_dir / "static")
-    assert runtime_paths.resolve_database_path() == str(web_dir / "storage.db")
+    assert runtime_paths.resolve_database_path() == str(
+        project_root / ".local" / "state" / "web" / "storage.db"
+    )
     assert runtime_paths.resolve_project_root() == str(project_root)
     assert runtime_paths.resolve_env_file_path() == str(project_root / ".env")
 

--- a/web/db_core.py
+++ b/web/db_core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from pathlib import Path
 
 _APPROVAL_STATUS_NOT_REQUESTED = "not_requested"
 _DELIVERY_STATUS_DRAFT = "draft"
@@ -196,8 +197,20 @@ def _ensure_database_schema(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def _ensure_database_parent_dir(db_path: str) -> None:
+    if db_path in {"", ":memory:"} or db_path.startswith("file:"):
+        return
+
+    parent_dir = Path(db_path).expanduser().parent
+    if str(parent_dir) in {"", "."}:
+        return
+
+    parent_dir.mkdir(parents=True, exist_ok=True)
+
+
 def ensure_database_schema(db_path: str) -> None:
     """Run additive DB migrations and ensure runtime schema is complete."""
+    _ensure_database_parent_dir(db_path)
     conn = sqlite3.connect(db_path)
     try:
         _ensure_database_schema(conn)
@@ -207,6 +220,7 @@ def ensure_database_schema(db_path: str) -> None:
 
 def connect_db(db_path: str) -> sqlite3.Connection:
     """Return a connection after ensuring the additive runtime schema."""
+    _ensure_database_parent_dir(db_path)
     conn = sqlite3.connect(db_path)
     _ensure_database_schema(conn)
     return conn

--- a/web/init_database.py
+++ b/web/init_database.py
@@ -2,7 +2,8 @@
 """
 웹 애플리케이션 데이터베이스 초기화 스크립트
 
-이 스크립트는 storage.db가 없거나 손상된 경우 새로운 데이터베이스를 생성합니다.
+이 스크립트는 기본 웹 런타임 데이터베이스 경로 또는 지정한 경로에
+SQLite 데이터베이스를 생성합니다.
 개발 환경 설정이나 프로덕션 배포 시 사용할 수 있습니다.
 """
 
@@ -13,11 +14,16 @@ from datetime import datetime
 
 try:
     from db_state import ensure_database_schema
+    from runtime_paths import resolve_database_path
 except ImportError:
     from web.db_state import ensure_database_schema  # pragma: no cover
+    from web.runtime_paths import resolve_database_path  # pragma: no cover
 
 
-def create_database(db_path: str = "storage.db") -> bool:
+DEFAULT_DATABASE_PATH = resolve_database_path()
+
+
+def create_database(db_path: str = DEFAULT_DATABASE_PATH) -> bool:
     """
     SQLite 데이터베이스와 필요한 테이블들을 생성합니다.
 
@@ -40,7 +46,7 @@ def create_database(db_path: str = "storage.db") -> bool:
     return True
 
 
-def verify_database(db_path: str = "storage.db") -> bool:
+def verify_database(db_path: str = DEFAULT_DATABASE_PATH) -> bool:
     """
     데이터베이스가 올바르게 생성되었는지 확인합니다.
 
@@ -86,7 +92,11 @@ def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(description="웹 애플리케이션 데이터베이스 초기화")
-    parser.add_argument("--db-path", default="storage.db", help="데이터베이스 파일 경로")
+    parser.add_argument(
+        "--db-path",
+        default=DEFAULT_DATABASE_PATH,
+        help="데이터베이스 파일 경로",
+    )
     parser.add_argument("--verify-only", action="store_true", help="검증만 수행 (생성하지 않음)")
     parser.add_argument("--force", action="store_true", help="기존 데이터베이스 강제 재생성")
 

--- a/web/runtime_paths.py
+++ b/web/runtime_paths.py
@@ -26,6 +26,12 @@ def _web_dir() -> Path:
     return Path(__file__).resolve().parent
 
 
+def _project_root() -> Path:
+    if _is_frozen():
+        return _bundle_root()
+    return _web_dir().parent
+
+
 def _first_existing_dir(candidates: Iterable[Path]) -> Path:
     candidate_list = list(candidates)
     for candidate in candidate_list:
@@ -73,13 +79,11 @@ def resolve_static_dir() -> str:
 def resolve_database_path() -> str:
     if _is_frozen():
         return str(Path(sys.executable).resolve().parent / "storage.db")
-    return str(_web_dir() / "storage.db")
+    return str(_project_root() / ".local" / "state" / "web" / "storage.db")
 
 
 def resolve_project_root() -> str:
-    if _is_frozen():
-        return str(_bundle_root())
-    return str(_web_dir().parent)
+    return str(_project_root())
 
 
 def resolve_env_file_path() -> str:

--- a/web/schedule_runner.py
+++ b/web/schedule_runner.py
@@ -75,19 +75,25 @@ except ImportError:
         run_sync_fallback,
     )
 
+try:
+    from runtime_paths import resolve_database_path
+except ImportError:
+    from web.runtime_paths import resolve_database_path  # pragma: no cover
+
 # Configure logging
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO").upper(),
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+DEFAULT_DATABASE_PATH = resolve_database_path()
 
 
 class ScheduleRunner:
     """RRULE 기반 스케줄 실행기"""
 
-    def __init__(self, db_path: str = "storage.db", redis_url: str | None = None):
-        self.db_path = db_path
+    def __init__(self, db_path: str | None = None, redis_url: str | None = None):
+        self.db_path = db_path or DEFAULT_DATABASE_PATH
         ensure_database_schema(self.db_path)
         self.redis_url = redis_url or os.environ.get(
             "REDIS_URL", "redis://localhost:6379/0"
@@ -305,7 +311,11 @@ def main() -> None:
     import argparse
 
     parser = argparse.ArgumentParser(description="Newsletter Schedule Runner")
-    parser.add_argument("--db-path", default="storage.db", help="Database file path")
+    parser.add_argument(
+        "--db-path",
+        default=DEFAULT_DATABASE_PATH,
+        help="Database file path",
+    )
     parser.add_argument("--redis-url", help="Redis URL (default: from REDIS_URL env)")
     parser.add_argument("--once", action="store_true", help="Run once and exit")
     parser.add_argument(

--- a/web/tasks.py
+++ b/web/tasks.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import sqlite3
 import traceback
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any, Dict
 
 from newsletter_core.public.generation import (
@@ -70,10 +70,12 @@ except ImportError:
 
 try:
     from archive import inject_archive_references
+    from runtime_paths import resolve_database_path
 except ImportError:
     from web.archive import inject_archive_references  # pragma: no cover
+    from web.runtime_paths import resolve_database_path  # pragma: no cover
 
-DATABASE_PATH = os.path.join(os.path.dirname(__file__), "storage.db")
+DATABASE_PATH = resolve_database_path()
 logger = logging.getLogger("web.tasks")
 
 
@@ -340,6 +342,7 @@ def generate_newsletter_task(
 
 def create_schedule_entry(params: Dict[str, Any], job_id: str) -> str:
     """Create a scheduled newsletter entry."""
+    Path(DATABASE_PATH).expanduser().parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(DATABASE_PATH)
     cursor = conn.cursor()
 


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- move the default development-mode web database out of `web/storage.db` and under `.local/state/web/storage.db`
- keep frozen/PyInstaller runtime behavior unchanged so Windows artifacts still create `storage.db` next to the executable
- align docs and schema/bootstrap code with the new hidden local state boundary

## Scope
### In Scope
- web runtime path resolution for development DB state
- web DB bootstrap callers and parent directory creation
- local/deployment docs for the new DB location
- regression tests for runtime paths and nested DB parent creation

### Out of Scope
- changing frozen executable DB placement
- changing the output directory policy
- broader entrypoint or package-boundary refactors

## Delivery Unit
- RR: #286
- Delivery Unit ID: DU-20260310-rr-f-web-runtime-state
- Merge Boundary: development-mode web state path only
- Rollback Boundary: revert this PR to restore `web/storage.db` as the development default

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed):

### Commands and Results
```bash
./.local/venv/bin/python -m pytest tests/unit_tests/web/test_runtime_paths.py tests/unit_tests/test_db_core.py -q
./.local/venv/bin/python web/init_database.py --db-path .local/artifacts/rr-f-db-verify/storage.db --force
./.local/venv/bin/python scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir .local/artifacts/repo-audit --check-policy --strict
make check
make check-full
make clean-local
./.local/venv/bin/python scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json --output-dir .local/artifacts/repo-audit --check-policy --strict
```

Results:
- targeted tests passed (`6 passed`)
- `web/init_database.py` created and verified a DB under `.local/artifacts/rr-f-db-verify/storage.db`
- strict repo audit passed before and after cleanup; final result `top-level entries=33 warnings=0`
- `make check` passed
- `make check-full` passed

## Risk & Rollback
- Risk: medium-low; the default development DB path changes for non-frozen web runtime callers
- Rollback: revert this PR and, if needed, move `.local/state/web/storage.db` back to `web/storage.db`

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 변경 없음
- Outbox/send_key 중복 방지 결과: 변경 없음
- import-time side effect 제거 여부: 변경 없음

## Not Run (with reason)
- No additional manual Windows runtime test was run locally because frozen runtime path behavior was preserved rather than changed

Closes #286
