### PR TITLE
Harden runtime boundaries and remove import-time side effects

### DIFF
--- a/newsletter_core/public/generation.py
+++ b/newsletter_core/public/generation.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import re
 from contextlib import nullcontext
 from dataclasses import dataclass
+from importlib import import_module
 from typing import Any, Dict, List, Optional, TypedDict, Union
 from unittest.mock import patch
 
 from langchain.tools import tool
 
-from newsletter import graph, tools
 from newsletter_core.public.source_policies import filter_articles_by_source_policies
 
 
@@ -43,6 +43,35 @@ class GenerateNewsletterRequest:
     suggest_count: int = 10
     source_allowlist: Optional[List[str]] = None
     source_blocklist: Optional[List[str]] = None
+
+
+class _LazyModuleProxy:
+    def __init__(self, module_name: str) -> None:
+        object.__setattr__(self, "_module_name", module_name)
+        object.__setattr__(self, "_module", None)
+
+    def _resolve(self) -> Any:
+        module = object.__getattribute__(self, "_module")
+        if module is None:
+            module = import_module(object.__getattribute__(self, "_module_name"))
+            object.__setattr__(self, "_module", module)
+        return module
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._resolve(), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(self._resolve(), name, value)
+
+    def __delattr__(self, name: str) -> None:
+        delattr(self._resolve(), name)
+
+    def __repr__(self) -> str:
+        return f"<LazyModuleProxy {object.__getattribute__(self, '_module_name')}>"
+
+
+graph = _LazyModuleProxy("newsletter.graph")
+tools = _LazyModuleProxy("newsletter.tools")
 
 
 def _normalize_keywords(raw: Optional[Union[str, List[str]]]) -> List[str]:

--- a/tests/unit_tests/test_web_import_side_effects.py
+++ b/tests/unit_tests/test_web_import_side_effects.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+
+import pytest
+from flask import Flask
+
+
+def _pop_module(name: str) -> ModuleType | None:
+    module = sys.modules.get(name)
+    if module is not None:
+        del sys.modules[name]
+    return module
+
+
+def _restore_module(name: str, module: ModuleType | None) -> None:
+    sys.modules.pop(name, None)
+    if module is not None:
+        sys.modules[name] = module
+
+
+@pytest.mark.unit
+def test_web_app_import_does_not_bootstrap_runtime_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_state_module = importlib.import_module("web.db_state")
+    newsletter_clients_module = importlib.import_module("web.newsletter_clients")
+    sentry_module = importlib.import_module("web.sentry_integration")
+    redis_module = importlib.import_module("redis")
+
+    calls = {"db": 0, "cli": 0, "sentry": 0, "redis": 0}
+
+    monkeypatch.setattr(
+        db_state_module,
+        "ensure_database_schema",
+        lambda *_args, **_kwargs: calls.__setitem__("db", calls["db"] + 1),
+    )
+    monkeypatch.setattr(
+        newsletter_clients_module,
+        "create_newsletter_cli",
+        lambda: calls.__setitem__("cli", calls["cli"] + 1),
+    )
+    monkeypatch.setattr(
+        sentry_module,
+        "setup_sentry",
+        lambda: calls.__setitem__("sentry", calls["sentry"] + 1),
+    )
+    monkeypatch.setattr(
+        redis_module,
+        "from_url",
+        lambda *_args, **_kwargs: calls.__setitem__("redis", calls["redis"] + 1),
+    )
+
+    previous = _pop_module("web.app")
+    try:
+        web_app = importlib.import_module("web.app")
+
+        assert calls == {"db": 0, "cli": 0, "sentry": 0, "redis": 0}
+        assert web_app.newsletter_cli is None
+        assert web_app.redis_conn is None
+        assert web_app.task_queue is None
+    finally:
+        _restore_module("web.app", previous)
+
+
+@pytest.mark.unit
+def test_create_app_registers_routes_without_eager_runtime_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    previous = _pop_module("web.app")
+    try:
+        web_app = importlib.import_module("web.app")
+        calls = {"cli": 0, "queue": 0, "sentry": 0}
+
+        def fake_create_newsletter_cli() -> object:
+            calls["cli"] += 1
+            return object()
+
+        def fake_create_task_queue(_app: Flask) -> tuple[object, object]:
+            calls["queue"] += 1
+            return object(), object()
+
+        def fake_setup_sentry() -> tuple[object, object]:
+            calls["sentry"] += 1
+            return object(), object()
+
+        monkeypatch.setattr(
+            web_app, "create_newsletter_cli", fake_create_newsletter_cli
+        )
+        monkeypatch.setattr(web_app, "_create_task_queue", fake_create_task_queue)
+        monkeypatch.setattr(web_app, "setup_sentry", fake_setup_sentry)
+
+        app = web_app.create_app()
+        app.config["TESTING"] = True
+
+        assert isinstance(app, Flask)
+        assert "/api/generate" in {rule.rule for rule in app.url_map.iter_rules()}
+        assert calls == {"cli": 0, "queue": 0, "sentry": 1}
+
+        with app.test_client() as client:
+            response = client.get("/health")
+
+        assert response.status_code == 200
+        assert calls == {"cli": 1, "queue": 0, "sentry": 1}
+    finally:
+        _restore_module("web.app", previous)
+
+
+@pytest.mark.unit
+def test_generation_facade_import_is_lazy_for_legacy_modules() -> None:
+    previous_generation = _pop_module("newsletter_core.public.generation")
+    previous_graph = _pop_module("newsletter.graph")
+    previous_tools = _pop_module("newsletter.tools")
+
+    try:
+        importlib.import_module("newsletter_core.public.generation")
+
+        assert "newsletter.graph" not in sys.modules
+        assert "newsletter.tools" not in sys.modules
+    finally:
+        _restore_module("newsletter_core.public.generation", previous_generation)
+        _restore_module("newsletter.graph", previous_graph)
+        _restore_module("newsletter.tools", previous_tools)

--- a/web/app.py
+++ b/web/app.py
@@ -1,7 +1,10 @@
 # flake8: noqa
-"""
-Newsletter Generator Web Service
-Flask application that provides web interface for the CLI newsletter generator
+"""Newsletter Generator web runtime entrypoint.
+
+This module keeps import-time behavior side-effect free. Heavy runtime setup
+such as DB schema creation, Sentry initialization, Redis queue wiring, and CLI
+adapter creation is deferred until the Flask app is created or lazily resolved
+by request handlers.
 """
 
 from __future__ import annotations
@@ -9,26 +12,15 @@ from __future__ import annotations
 import logging
 import os
 import platform
-import sys
-from pathlib import Path
+from collections.abc import Callable
 from typing import Any, cast
 
 import redis
 from flask import Flask, render_template
 
-WEB_DIR = Path(__file__).resolve().parent
-if str(WEB_DIR) not in sys.path:
-    sys.path.insert(0, str(WEB_DIR))
-
-if __package__ in {None, ""}:
-    REPO_ROOT = Path(__file__).resolve().parents[1]
-    if str(REPO_ROOT) not in sys.path:
-        sys.path.insert(0, str(REPO_ROOT))
-
 from newsletter_core.public.settings import get_setting_value
 from web.access_control import configure_access_control
 from web.cors_config import configure_cors
-from web.db_state import ensure_database_schema
 from web.newsletter_clients import create_newsletter_cli
 from web.ops_logging import log_exception, log_info, log_warning
 from web.routes_analytics import register_analytics_routes
@@ -50,15 +42,15 @@ from web.runtime_paths import (
 from web.sentry_integration import setup_sentry
 from web.suggest import bp as suggest_bp
 
-_set_sentry_user_context, _set_sentry_tags = setup_sentry()
-
 QUEUE_NAME = str(get_setting_value("RQ_QUEUE", "default"))
 DATABASE_PATH = resolve_database_path()
-newsletter_cli = create_newsletter_cli()
+
+newsletter_cli: Any = None
 redis_conn: Any = None
 task_queue: Any = None
 in_memory_tasks: dict[str, dict[str, Any]] = {}
 logger = logging.getLogger("web.app")
+_cached_app: Flask | None = None
 
 
 def _configure_logging() -> logging.Logger:
@@ -95,14 +87,38 @@ def _create_task_queue(app: Flask) -> tuple[Any, Any]:
             redis_url=redis_url,
         )
         return connected_redis, queue
-    except Exception as e:
+    except Exception as exc:
         log_exception(
             logger,
             "app.redis.connection_failed",
-            e,
+            exc,
             redis_url=redis_url,
         )
         return None, None
+
+
+def _resolve_newsletter_cli() -> Any:
+    global newsletter_cli
+    if newsletter_cli is None:
+        newsletter_cli = create_newsletter_cli()
+    return newsletter_cli
+
+
+def _resolve_queue_dependencies(app: Flask) -> tuple[Any, Any]:
+    global redis_conn, task_queue
+    if app.config.get("TESTING", False):
+        return redis_conn, task_queue
+    if redis_conn is None and task_queue is None:
+        redis_conn, task_queue = _create_task_queue(app)
+    return redis_conn, task_queue
+
+
+def _resolve_redis_conn(app: Flask) -> Any:
+    return _resolve_queue_dependencies(app)[0]
+
+
+def _resolve_task_queue(app: Flask) -> Any:
+    return _resolve_queue_dependencies(app)[1]
 
 
 def _register_index_route(app: Flask) -> None:
@@ -111,17 +127,18 @@ def _register_index_route(app: Flask) -> None:
         """Main dashboard page."""
         try:
             return cast(str, render_template("index.html"))
-        except Exception as e:
-            template_path = os.path.join(app.template_folder, "index.html")
+        except Exception as exc:
+            template_folder = app.template_folder or ""
+            template_path = os.path.join(template_folder, "index.html")
             log_exception(
                 logger,
                 "app.template.render_failed",
-                e,
+                exc,
                 template_folder=app.template_folder,
                 template_path=template_path,
                 template_exists=os.path.exists(template_path),
             )
-            return f"Template error: {str(e)}", 500
+            return f"Template error: {str(exc)}", 500
 
 
 def _register_routes(app: Flask) -> None:
@@ -132,13 +149,17 @@ def _register_routes(app: Flask) -> None:
         in_memory_tasks=in_memory_tasks,
         task_queue=task_queue,
         redis_conn=redis_conn,
-        get_newsletter_cli=lambda: newsletter_cli,
+        get_newsletter_cli=_resolve_newsletter_cli,
+        get_task_queue=lambda: _resolve_task_queue(app),
+        get_redis_conn=lambda: _resolve_redis_conn(app),
     )
     register_health_route(
         app=app,
         database_path=DATABASE_PATH,
         redis_conn=redis_conn,
         newsletter_cli=newsletter_cli,
+        get_redis_conn=lambda: _resolve_redis_conn(app),
+        get_newsletter_cli=_resolve_newsletter_cli,
     )
     register_ops_routes(app, DATABASE_PATH)
     register_send_email_route(app, DATABASE_PATH)
@@ -153,9 +174,10 @@ def _register_routes(app: Flask) -> None:
 
 
 def create_app() -> Flask:
-    global logger, redis_conn, task_queue
+    global logger
 
     logger = _configure_logging()
+    setup_sentry()
 
     app = Flask(
         __name__,
@@ -178,14 +200,40 @@ def create_app() -> Flask:
         database_path=DATABASE_PATH,
     )
 
-    ensure_database_schema(DATABASE_PATH)
-    redis_conn, task_queue = _create_task_queue(app)
     _register_index_route(app)
     _register_routes(app)
     return app
 
 
-app = create_app()
+def get_app() -> Flask:
+    global _cached_app
+    if _cached_app is None:
+        _cached_app = create_app()
+    return _cached_app
+
+
+class _LazyFlaskApp:
+    def __init__(self, app_getter: Callable[[], Flask]) -> None:
+        object.__setattr__(self, "_app_getter", app_getter)
+
+    def _app(self) -> Flask:
+        getter = object.__getattribute__(self, "_app_getter")
+        return getter()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._app(), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(self._app(), name, value)
+
+    def __call__(self, environ: Any, start_response: Any) -> Any:
+        return self._app()(environ, start_response)
+
+    def __repr__(self) -> str:
+        return "<LazyFlaskApp proxy for web.app.get_app()>"
+
+
+app = _LazyFlaskApp(get_app)
 
 
 def _resolve_app_env() -> str:
@@ -196,8 +244,9 @@ def main() -> None:
     host = os.getenv("HOST", "0.0.0.0")
     port = int(os.getenv("PORT", "8000"))
     debug = _resolve_app_env() == "development"
+    flask_app = get_app()
     log_info(logger, "app.starting", host=host, port=port, debug=debug)
-    app.run(host=host, port=port, debug=debug)
+    flask_app.run(host=host, port=port, debug=debug)
 
 
 if __name__ == "__main__":

--- a/web/routes_generation.py
+++ b/web/routes_generation.py
@@ -12,7 +12,11 @@ from datetime import datetime
 from typing import Any, Callable
 
 from flask import Flask, jsonify, request
-from tasks import generate_newsletter_task
+
+try:
+    from tasks import generate_newsletter_task
+except ImportError:
+    from web.tasks import generate_newsletter_task  # pragma: no cover
 
 try:
     from db_state import (
@@ -203,6 +207,8 @@ def register_generation_routes(
     real_cli_class: type = RealNewsletterCLI,
     mock_cli_class: type = MockNewsletterCLI,
     get_newsletter_cli: Callable[[], Any] | None = None,
+    get_task_queue: Callable[[], Any] | None = None,
+    get_redis_conn: Callable[[], Any] | None = None,
 ) -> None:
     """Register generation, status, history, and scheduling routes."""
 
@@ -216,6 +222,18 @@ def register_generation_routes(
             return newsletter_cli
         resolved = get_newsletter_cli()
         return resolved if resolved is not None else newsletter_cli
+
+    def resolve_task_queue() -> Any:
+        if get_task_queue is None:
+            return task_queue
+        resolved = get_task_queue()
+        return resolved if resolved is not None else task_queue
+
+    def resolve_redis_conn() -> Any:
+        if get_redis_conn is None:
+            return redis_conn
+        resolved = get_redis_conn()
+        return resolved if resolved is not None else redis_conn
 
     def _serialize_schedule_timestamp(value: str | None) -> str | None:
         if not value:
@@ -310,7 +328,7 @@ def register_generation_routes(
                 send_email=send_email,
                 database_path=DATABASE_PATH,
                 in_memory_tasks=in_memory_tasks,
-                task_queue=task_queue,
+                task_queue=resolve_task_queue(),
                 run_in_memory_job=run_in_memory_job,
             )
             return (
@@ -859,8 +877,11 @@ def register_generation_routes(
         )
 
     def _dispatch_schedule_run(resolution: ScheduleRunResolution) -> dict[str, Any]:
-        if redis_conn and task_queue:
-            job = task_queue.enqueue(
+        active_redis_conn = resolve_redis_conn()
+        active_task_queue = resolve_task_queue()
+
+        if active_redis_conn and active_task_queue:
+            job = active_task_queue.enqueue(
                 generate_newsletter_task,
                 resolution.params,
                 resolution.immediate_job_id,

--- a/web/routes_health.py
+++ b/web/routes_health.py
@@ -2,6 +2,7 @@
 
 import os
 import sqlite3
+from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 
@@ -16,8 +17,22 @@ def register_health_route(
     database_path: str,
     redis_conn: Any,
     newsletter_cli: Any,
+    get_redis_conn: Callable[[], Any] | None = None,
+    get_newsletter_cli: Callable[[], Any] | None = None,
 ) -> None:
     """Register health route on the given Flask app."""
+
+    def resolve_redis_conn() -> Any:
+        if get_redis_conn is None:
+            return redis_conn
+        resolved = get_redis_conn()
+        return resolved if resolved is not None else redis_conn
+
+    def resolve_newsletter_cli() -> Any:
+        if get_newsletter_cli is None:
+            return newsletter_cli
+        resolved = get_newsletter_cli()
+        return resolved if resolved is not None else newsletter_cli
 
     @app.route("/health")  # type: ignore[untyped-decorator]
     def health_check() -> ResponseReturnValue:
@@ -33,8 +48,9 @@ def register_health_route(
         overall_status = "healthy"
 
         try:
-            if redis_conn:
-                redis_conn.ping()
+            active_redis_conn = resolve_redis_conn()
+            if active_redis_conn:
+                active_redis_conn.ping()
                 deps["redis"] = {"status": "connected", "message": "Redis is healthy"}
             else:
                 deps["redis"] = {
@@ -102,7 +118,7 @@ def register_health_route(
         }
 
         try:
-            cli_type = type(newsletter_cli).__name__
+            cli_type = type(resolve_newsletter_cli()).__name__
             deps["newsletter_cli"] = {
                 "status": "healthy",
                 "type": cli_type,


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Remove `web.app` import-time DB/Redis/queue/bootstrap side effects and make the app factory importable without eager runtime initialization.
- Narrow the core-to-legacy boundary by replacing eager legacy imports in `newsletter_core.public.generation` with lazy proxies.
- Keep API response shapes unchanged while pushing runtime/bootstrap responsibility into approved edge-layer lazy resolvers.

## Scope
### In Scope
- `web.app` lazy app creation and runtime dependency resolution
- Lazy queue/CLI resolution in web routes
- Lazy legacy-module access in `newsletter_core.public.generation`
- Regression tests for import-time side effects and lazy facade loading

### Out of Scope
- Docker or release-lane redesign
- CI matrix expansion
- Packaging scope changes
- API response schema changes

## Delivery Unit
- RR: #298
- Delivery Unit ID: DU-20260310-harden-runtime-boundaries
- Merge Boundary: PR 3 only (`Harden runtime boundaries and remove import-time side effects`)
- Rollback Boundary: Revert the squash merge commit for this PR

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): runtime-side-effect, web API, schedule, contract, and runtime path coverage

### Commands and Results
```bash
cd /Users/hojungjung/development/newsletter-generator && .local/venv/bin/python -m pytest tests/unit_tests/test_web_import_side_effects.py tests/unit_tests/test_web_app_main.py tests/unit_tests/web/test_runtime_paths.py tests/unit_tests/web/test_runtime_hook_bootstrap.py tests/contract/test_generation_facade.py tests/contract/test_web_runtime_contract.py -q
# 17 passed in 2.80s

cd /Users/hojungjung/development/newsletter-generator && .local/venv/bin/python -m pytest tests/test_api.py tests/test_web_api.py tests/contract/test_web_email_routes_contract.py tests/unit_tests/test_web_schedule_routes.py tests/unit_tests/test_web_preview_and_run_now_routes.py -q
# 49 passed, 1 skipped in 2.86s

cd /Users/hojungjung/development/newsletter-generator && .local/venv/bin/python -m pytest tests/unit_tests/test_config_import_side_effects.py -q
# 8 passed in 3.96s

cd /Users/hojungjung/development/newsletter-generator && .local/venv/bin/python -m pytest tests/integration/test_schedule_execution.py -q
# 8 skipped in 2.59s

cd /Users/hojungjung/development/newsletter-generator && .local/venv/bin/python -m pytest tests/unit_tests/test_schedule_time_sync.py -q
# 4 passed in 2.95s

cd /Users/hojungjung/development/newsletter-generator && .local/venv/bin/python -m pytest tests/contract/test_web_email_routes_contract.py -q
# 8 passed in 3.06s

cd /Users/hojungjung/development/newsletter-generator && make check
# PASS

cd /Users/hojungjung/development/newsletter-generator && make check-full
# PASS
```

## Risk & Rollback
- Risk: Lazy resolution now controls app/queue/CLI initialization, so regressions would concentrate around route registration and request-time dependency resolution.
- Rollback: Revert the squash merge commit if health/generation route bootstrap regresses.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 해당 없음
- Outbox/send_key 중복 방지 결과: 해당 없음
- import-time side effect 제거 여부: `web.app` import 시 DB schema, Redis queue, newsletter CLI, Sentry bootstrap이 더 이상 발생하지 않음

## Not Run (with reason)
- GitHub Actions checks are not local commands; they will run on the PR after creation.
