### PR TITLE
Close required-check operations alignment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,8 +8,12 @@
 - 목적: 코드 품질, 테스트, 빌드 검증의 메인 CI 파이프라인
 - 트리거: `push`(main/develop/release/**), `pull_request`(main/develop)
 - 참고: PR 정책 검증은 `pr-policy-check.yml`에서 수행
-- 주요 PR gate: `Release Preflight`, `Source Smoke (macos-latest)`, `Source Smoke (windows-latest)`, `Container Smoke (ubuntu-latest)`, `Build Check (windows-latest)`
-- 참고: branch protection required check 구성 자체는 별도 관리자 설정 범위이며, 이 문서는 workflow truth만 설명합니다.
+- 현재 `main` branch protection required checks:
+  - `policy-check`, `docs-quality`, `Code Quality & Security`, `Release Preflight`
+  - `Unit Tests - ubuntu-latest-py3.11`, `Unit Tests - ubuntu-latest-py3.12`
+  - `Source Smoke (ubuntu-latest)`, `Source Smoke (macos-latest)`, `Source Smoke (windows-latest)`
+  - `Build Check (ubuntu-latest)`, `Build Check (windows-latest)`, `Container Smoke (ubuntu-latest)`
+- 추가 PR validation: `Mock API Tests`
 
 2. `deployment.yml`
 - 목적: 배포 파이프라인 (Railway + Pages 병행)

--- a/docs/dev/CI_CD_GUIDE.md
+++ b/docs/dev/CI_CD_GUIDE.md
@@ -102,6 +102,10 @@ make repo-audit-strict
 
 ### PR Gate
 
+아래 12개 check는 `main` branch protection required check 기준이다.
+
+- `policy-check`
+- `docs-quality`
 - `Code Quality & Security`
 - `Unit Tests - ubuntu-latest-py3.11`
 - `Unit Tests - ubuntu-latest-py3.12`
@@ -109,10 +113,13 @@ make repo-audit-strict
 - `Source Smoke (ubuntu-latest)`
 - `Source Smoke (macos-latest)`
 - `Source Smoke (windows-latest)`
-- `Mock API Tests`
 - `Build Check (ubuntu-latest)`
 - `Build Check (windows-latest)`
 - `Container Smoke (ubuntu-latest)`
+
+추가 PR validation:
+- `Mock API Tests`
+  - PR에서 계속 실행하지만 현재 branch protection required check에는 포함하지 않는다.
 
 ### Long Gate
 

--- a/docs/reference/support-policy.md
+++ b/docs/reference/support-policy.md
@@ -15,6 +15,7 @@
 - contributor-facing canonical entrypoint는 `python -m scripts.devtools.dev_entrypoint`다.
 - Makefile과 shell script는 현재 contributor automation wrapper로 남아 있지만, 아키텍처 계약의 정본은 아니다.
 - CI gate는 이 문서의 지원 계약을 비대칭적으로 집행한다. Linux는 full unit/package/container 검증, Windows는 source smoke + EXE release surface, macOS는 source smoke + runtime subset을 기준으로 유지한다.
+- `main` branch protection required check 목록은 `docs/dev/CI_CD_GUIDE.md`와 `.github/workflows/README.md`에 verbatim으로 유지한다.
 
 ## OS Support Contract
 

--- a/tests/contract/test_ci_workflow_truth.py
+++ b/tests/contract/test_ci_workflow_truth.py
@@ -51,14 +51,25 @@ def test_active_docs_describe_ci_gate_split_truthfully() -> None:
     workflow_readme = _read_text(".github/workflows/README.md")
 
     for text in (ci_guide, workflow_readme):
+        assert "policy-check" in text
+        assert "docs-quality" in text
+        assert "Code Quality & Security" in text
+        assert "Unit Tests - ubuntu-latest-py3.11" in text
+        assert "Unit Tests - ubuntu-latest-py3.12" in text
         assert "Release Preflight" in text
+        assert "Source Smoke (ubuntu-latest)" in text
         assert "Source Smoke (macos-latest)" in text
         assert "Source Smoke (windows-latest)" in text
+        assert "Build Check (ubuntu-latest)" in text
+        assert "Build Check (windows-latest)" in text
         assert "Container Smoke (ubuntu-latest)" in text
 
     assert "macOS source smoke + runtime subset" in ci_guide
     assert "Windows source smoke + runtime subset" in ci_guide
     assert "Linux container smoke" in ci_guide
+    assert "Mock API Tests" in ci_guide
+    assert "branch protection required check" in ci_guide
+    assert "branch protection required check" in support_policy
     assert (
         "macOS | 2차 지원 | source/smoke 중심 | source smoke + runtime subset"
         in support_policy


### PR DESCRIPTION
## Summary (what / why)
- align required-check documentation with the `main` branch protection state set after PR 5
- distinguish branch-protection required checks from additional PR validation so docs and 운영 설정 describe the same contract
- confirm the local PR body scratch artifact is not kept in the workspace

## Scope
- branch protection required check close-out
- support-policy / CI guide / workflow README wording alignment
- local scratch artifact hygiene confirmation

## Delivery Unit
- RR: #304
- Delivery Unit ID: DU-20260310-close-required-check-ops-alignment
- Merge boundary: operations close-out cleanup only
- Rollback boundary: revert commit `80f3ad6`

## Test & Evidence
- `.local/venv/bin/python -m pytest tests/contract/test_ci_workflow_truth.py tests/contract/test_support_policy_consistency.py -q`
- `.local/venv/bin/python scripts/release_preflight.py`
- `.local/venv/bin/python scripts/validate_release_manifest.py`
- `gh api repos/hjjung-katech/newsletter-generator/branches/main/protection/required_status_checks`
- local scratch artifact check: `.local/pr_body_pr5.md` -> removed from workspace

## Risk & Rollback
- risk is limited to documentation/test drift and branch protection metadata; runtime and packaging policy are unchanged
- rollback for repo changes is `git revert 80f3ad6`
- rollback for branch protection is restoring the previous required status check set via GitHub branch protection API/admin UI

## Ops-Safety Addendum (if touching protected paths)
- touched protected CI/docs contract paths only: `.github/workflows/README.md`, `docs/dev/CI_CD_GUIDE.md`, `docs/reference/support-policy.md`, `tests/contract/test_ci_workflow_truth.py`
- no runtime path, packaging policy, or workflow topology changes

## Not Run (with reason)
- no new workflow or runtime code was introduced, so no additional matrix expansion or packaging lane redesign was run in this cleanup PR
