### PR TITLE
Extract provider wiring and env access from legacy llm_factory into newsletter_core adapters

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,7 +48,8 @@ class LLMFactory:
         # 자동 fallback 지원
 ```
 
-- 현재 provider/model 선택, 설정 정규화, provider info shaping 같은 순수 결정 로직은 `newsletter_core/application/llm_factory.py` 로 이관되었고, `newsletter/llm_factory.py` 는 provider SDK wiring, env access, fallback execution, legacy import path 호환을 담당하는 compatibility boundary로 유지됩니다.
+- 현재 provider/model 선택, 설정 정규화, provider info shaping 같은 순수 결정 로직은 `newsletter_core/application/llm_factory.py` 로 이관되었고, provider SDK 생성, env/API key 접근, provider 초기화 입력 조립 같은 runtime adapter 책임은 `newsletter_core/infrastructure/llm_factory_runtime.py` 로 이동했습니다.
+- `newsletter/llm_factory.py` 는 fallback execution, lazy singleton/proxy, legacy import path 호환을 담당하는 compatibility boundary로 유지됩니다.
 
 ### 0.3. 자동 Fallback 시스템
 

--- a/newsletter/llm_factory.py
+++ b/newsletter/llm_factory.py
@@ -8,15 +8,17 @@ F-14: 중앙화된 설정을 활용한 성능 최적화
 """
 
 import logging
-import os
 import time
-from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterator, List, Optional, cast
 
 from newsletter_core.application.llm_factory import (
     build_provider_info,
     get_default_model,
     resolve_provider_selection,
+)
+from newsletter_core.infrastructure.llm_factory_runtime import (
+    build_provider_callbacks,
+    build_runtime_provider_registry,
 )
 from newsletter_core.public.settings import get_llm_config
 
@@ -36,21 +38,6 @@ except ImportError:
 # 로거 초기화
 logger = get_logger()
 
-try:
-    from langchain_google_genai import ChatGoogleGenerativeAI
-except ImportError:
-    ChatGoogleGenerativeAI = None
-
-try:
-    from langchain_openai import ChatOpenAI
-except ImportError:
-    ChatOpenAI = None
-
-try:
-    from langchain_anthropic import ChatAnthropic
-except ImportError:
-    ChatAnthropic = None
-
 # LangChain Runnable 관련 imports 추가
 try:
     from langchain_core.runnables import Runnable
@@ -64,61 +51,10 @@ except ImportError:
     Output = Any
 
 
-def _get_runtime_settings() -> Any | None:
+def _load_runtime_settings() -> Any | None:
     if not CENTRALIZED_SETTINGS_AVAILABLE or get_settings is None:
         return None
-    try:
-        return get_settings()
-    except Exception as exc:
-        logger.warning(f"중앙화된 설정 로드 실패, 환경변수 fallback 사용: {exc}")
-        return None
-
-
-def _get_secret_value(value: Any) -> str | None:
-    if value is None:
-        return None
-    if hasattr(value, "get_secret_value"):
-        secret_value = value.get_secret_value()
-        return str(secret_value) if secret_value is not None else None
-    return str(value)
-
-
-def _get_provider_api_key(provider_name: str) -> str | None:
-    settings = _get_runtime_settings()
-    if settings is not None:
-        secret_map = {
-            "gemini": settings.gemini_api_key,
-            "openai": settings.openai_api_key,
-            "anthropic": settings.anthropic_api_key,
-        }
-        secret_value = _get_secret_value(secret_map.get(provider_name))
-        if secret_value:
-            return secret_value
-
-    env_keys = {
-        "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
-        "openai": ("OPENAI_API_KEY",),
-        "anthropic": ("ANTHROPIC_API_KEY",),
-    }
-    for env_key in env_keys.get(provider_name, ()):
-        env_value = os.getenv(env_key)
-        if env_value:
-            return env_value
-    return None
-
-
-def _prepare_google_runtime_environment() -> None:
-    google_creds_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
-    if google_creds_path and not os.path.exists(google_creds_path):
-        logger.warning(
-            f"GOOGLE_APPLICATION_CREDENTIALS이 존재하지 않는 파일을 가리킵니다: {google_creds_path}"
-        )
-        logger.info("Google Cloud 인증을 비활성화하고 API 키만 사용합니다.")
-
-    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = ""
-    os.environ["GOOGLE_CLOUD_PROJECT"] = ""
-    os.environ.pop("CLOUDSDK_CONFIG", None)
-    os.environ.pop("GCLOUD_PROJECT", None)
+    return get_settings()
 
 
 class QuotaExceededError(Exception):
@@ -504,182 +440,16 @@ class LLMWithFallback(Runnable):
         )
 
 
-class LLMProvider(ABC):
-    """LLM 제공자 추상 클래스"""
-
-    @abstractmethod
-    def create_model(
-        self, model_config: Dict[str, Any], callbacks: Optional[List[Any]] = None
-    ) -> Any:
-        """LLM 모델 인스턴스를 생성합니다."""
-        pass
-
-    @abstractmethod
-    def is_available(self) -> bool:
-        """제공자가 사용 가능한지 확인합니다."""
-        pass
-
-
-class GeminiProvider(LLMProvider):
-    """Google Gemini LLM 제공자"""
-
-    def create_model(
-        self, model_config: Dict[str, Any], callbacks: Optional[List[Any]] = None
-    ) -> Any:
-        """Gemini 모델 생성 - F-14 중앙화된 설정 시스템 적용"""
-        logger.debug("Creating Gemini model")
-
-        if not ChatGoogleGenerativeAI:
-            raise ImportError("langchain_google_genai 패키지가 설치되지 않았습니다")
-
-        _prepare_google_runtime_environment()
-        api_key = _get_provider_api_key("gemini")
-        if not api_key:
-            raise ValueError("GEMINI_API_KEY 환경변수가 설정되지 않았습니다")
-
-        # F-14: 중앙화된 설정에서 파라미터 가져오기
-        model_params = model_config.copy()
-        settings = _get_runtime_settings()
-        if settings is not None:
-            model_params.setdefault("timeout", settings.llm_request_timeout)
-            if settings.enable_fast_mode and "gemini-1.5-pro" in model_params.get(
-                "model", ""
-            ):
-                model_params["model"] = "gemini-1.5-flash"
-                logger.info("빠른 모드: Gemini Pro를 Flash로 변경")
-        else:
-            model_params.setdefault("timeout", 120)
-
-        model_params.setdefault("temperature", 0.3)
-        model_params.setdefault("max_tokens", 4000)
-        model_params.setdefault("model", "gemini-1.5-pro")
-
-        cost_callback = get_cost_callback_for_provider("gemini")
-        all_callbacks = (callbacks or []) + ([cost_callback] if cost_callback else [])
-
-        logger.debug(f"Gemini 모델 생성: {model_params}")
-
-        return ChatGoogleGenerativeAI(
-            google_api_key=api_key,
-            model=model_params["model"],
-            temperature=model_params["temperature"],
-            max_output_tokens=model_params["max_tokens"],
-            timeout=model_params.get("timeout", 120),
-            callbacks=all_callbacks,
-        )
-
-    def is_available(self) -> bool:
-        return ChatGoogleGenerativeAI is not None and bool(
-            _get_provider_api_key("gemini")
-        )
-
-
-class OpenAIProvider(LLMProvider):
-    """OpenAI LLM 제공자"""
-
-    def create_model(
-        self, model_config: Dict[str, Any], callbacks: Optional[List[Any]] = None
-    ) -> Any:
-        """OpenAI 모델 생성 - F-14 중앙화된 설정 시스템 적용"""
-        logger.debug("Creating OpenAI model")
-
-        if not ChatOpenAI:
-            raise ImportError("langchain_openai 패키지가 설치되지 않았습니다")
-
-        api_key = _get_provider_api_key("openai")
-        if not api_key:
-            raise ValueError("OPENAI_API_KEY 환경변수가 설정되지 않았습니다")
-
-        # F-14: 중앙화된 설정에서 파라미터 가져오기
-        model_params = model_config.copy()
-        settings = _get_runtime_settings()
-        if settings is not None:
-            model_params.setdefault("timeout", settings.llm_request_timeout)
-            if settings.enable_fast_mode and "gpt-4" in model_params.get("model", ""):
-                model_params["model"] = "gpt-3.5-turbo"
-                logger.info("빠른 모드: GPT-4를 GPT-3.5-turbo로 변경")
-        else:
-            model_params.setdefault("timeout", 120)
-
-        model_params.setdefault("temperature", 0.3)
-        model_params.setdefault("max_tokens", 4000)
-        model_params.setdefault("model", "gpt-4o-mini")
-
-        cost_callback = get_cost_callback_for_provider("openai")
-        all_callbacks = (callbacks or []) + ([cost_callback] if cost_callback else [])
-
-        logger.debug(f"OpenAI 모델 생성: {model_params}")
-
-        return ChatOpenAI(
-            api_key=api_key,
-            model=model_params["model"],
-            temperature=model_params["temperature"],
-            max_tokens=model_params["max_tokens"],
-            timeout=model_params.get("timeout", 120),
-            callbacks=all_callbacks,
-        )
-
-    def is_available(self) -> bool:
-        return ChatOpenAI is not None and bool(_get_provider_api_key("openai"))
-
-
-class AnthropicProvider(LLMProvider):
-    """Anthropic Claude LLM 제공자"""
-
-    def create_model(
-        self, model_config: Dict[str, Any], callbacks: Optional[List[Any]] = None
-    ) -> Any:
-        if not ChatAnthropic:
-            raise ImportError("langchain_anthropic 패키지가 설치되지 않았습니다")
-
-        api_key = _get_provider_api_key("anthropic")
-        if not api_key:
-            raise ValueError("ANTHROPIC_API_KEY 환경변수가 설정되지 않았습니다")
-
-        # F-14: 중앙화된 설정에서 타임아웃 적용
-        model_params = model_config.copy()
-        settings = _get_runtime_settings()
-        if settings is not None:
-            model_params.setdefault("timeout", settings.llm_request_timeout)
-            if settings.enable_fast_mode and "claude-3-opus" in model_params.get(
-                "model", ""
-            ):
-                model_params["model"] = "claude-3-haiku-20240307"
-                logger.info("빠른 모드: Claude Opus를 Haiku로 변경")
-        else:
-            model_params.setdefault("timeout", 120)
-
-        model_params.setdefault("temperature", 0.1)
-        model_params.setdefault("max_tokens", 4000)
-        model_params.setdefault("model", "claude-3-haiku-20240307")
-
-        cost_callback = get_cost_callback_for_provider("anthropic")
-        all_callbacks = (callbacks or []) + ([cost_callback] if cost_callback else [])
-
-        logger.debug(f"Anthropic 모델 생성: {model_params}")
-
-        return ChatAnthropic(
-            anthropic_api_key=api_key,
-            model=model_params["model"],
-            temperature=model_params["temperature"],
-            max_tokens=model_params["max_tokens"],
-            timeout=model_params.get("timeout", 120),
-            callbacks=all_callbacks,
-        )
-
-    def is_available(self) -> bool:
-        return ChatAnthropic is not None and bool(_get_provider_api_key("anthropic"))
-
-
 class LLMFactory:
     """LLM 팩토리 클래스"""
 
     def __init__(self) -> None:
-        self.providers = {
-            "gemini": GeminiProvider(),
-            "openai": OpenAIProvider(),
-            "anthropic": AnthropicProvider(),
-        }
+        self.providers = build_runtime_provider_registry(
+            runtime_settings_loader=_load_runtime_settings,
+            cost_callback_factory=get_cost_callback_for_provider,
+            exception_handler=handle_exception,
+            logger=logger,
+        )
 
     @property
     def llm_config(self) -> Dict[str, Any]:
@@ -692,17 +462,14 @@ class LLMFactory:
         *,
         fallback_path: bool = False,
     ) -> List[Any]:
-        final_callbacks = list(callbacks) if callbacks else []
-        try:
-            cost_callback = get_cost_callback_for_provider(provider_name)
-            final_callbacks.append(cost_callback)
-        except Exception as e:
-            message = (
-                f"비용 추적 추가 ({provider_name})"
-                if fallback_path
-                else f"Warning: Failed to add cost tracking for {provider_name}"
-            )
-            handle_exception(e, message, log_level=logging.INFO)
+        final_callbacks: List[Any] = build_provider_callbacks(
+            provider_name,
+            callbacks,
+            cost_callback_factory=get_cost_callback_for_provider,
+            exception_handler=handle_exception,
+            logger=logger,
+            fallback_path=fallback_path,
+        )
         return final_callbacks
 
     def get_llm_for_task(

--- a/newsletter_core/infrastructure/llm_factory_runtime.py
+++ b/newsletter_core/infrastructure/llm_factory_runtime.py
@@ -1,0 +1,365 @@
+"""Runtime adapter helpers for the legacy llm_factory compatibility layer."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+from collections.abc import Callable, Mapping, MutableMapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ProviderRuntimeSpec:
+    settings_attr: str
+    env_keys: tuple[str, ...]
+    import_module: str
+    class_name: str
+    missing_package_message: str
+    missing_api_key_message: str
+    default_model: str
+    default_temperature: float
+    api_key_argument: str
+    max_tokens_argument: str
+    fast_mode_match: str | None = None
+    fast_mode_replacement: str | None = None
+    fast_mode_message: str | None = None
+
+
+_PROVIDER_SPECS: dict[str, ProviderRuntimeSpec] = {
+    "gemini": ProviderRuntimeSpec(
+        settings_attr="gemini_api_key",
+        env_keys=("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+        import_module="langchain_google_genai",
+        class_name="ChatGoogleGenerativeAI",
+        missing_package_message="langchain_google_genai 패키지가 설치되지 않았습니다",
+        missing_api_key_message="GEMINI_API_KEY 환경변수가 설정되지 않았습니다",
+        default_model="gemini-1.5-pro",
+        default_temperature=0.3,
+        api_key_argument="google_api_key",
+        max_tokens_argument="max_output_tokens",
+        fast_mode_match="gemini-1.5-pro",
+        fast_mode_replacement="gemini-1.5-flash",
+        fast_mode_message="빠른 모드: Gemini Pro를 Flash로 변경",
+    ),
+    "openai": ProviderRuntimeSpec(
+        settings_attr="openai_api_key",
+        env_keys=("OPENAI_API_KEY",),
+        import_module="langchain_openai",
+        class_name="ChatOpenAI",
+        missing_package_message="langchain_openai 패키지가 설치되지 않았습니다",
+        missing_api_key_message="OPENAI_API_KEY 환경변수가 설정되지 않았습니다",
+        default_model="gpt-4o-mini",
+        default_temperature=0.3,
+        api_key_argument="api_key",
+        max_tokens_argument="max_tokens",
+        fast_mode_match="gpt-4",
+        fast_mode_replacement="gpt-3.5-turbo",
+        fast_mode_message="빠른 모드: GPT-4를 GPT-3.5-turbo로 변경",
+    ),
+    "anthropic": ProviderRuntimeSpec(
+        settings_attr="anthropic_api_key",
+        env_keys=("ANTHROPIC_API_KEY",),
+        import_module="langchain_anthropic",
+        class_name="ChatAnthropic",
+        missing_package_message="langchain_anthropic 패키지가 설치되지 않았습니다",
+        missing_api_key_message="ANTHROPIC_API_KEY 환경변수가 설정되지 않았습니다",
+        default_model="claude-3-haiku-20240307",
+        default_temperature=0.1,
+        api_key_argument="anthropic_api_key",
+        max_tokens_argument="max_tokens",
+        fast_mode_match="claude-3-opus",
+        fast_mode_replacement="claude-3-haiku-20240307",
+        fast_mode_message="빠른 모드: Claude Opus를 Haiku로 변경",
+    ),
+}
+
+
+def _get_provider_spec(provider_name: str) -> ProviderRuntimeSpec:
+    try:
+        return _PROVIDER_SPECS[provider_name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown provider: {provider_name}") from exc
+
+
+def resolve_runtime_settings(
+    runtime_settings_loader: Callable[[], Any | None] | None,
+    logger: Any,
+) -> Any | None:
+    if runtime_settings_loader is None:
+        return None
+    try:
+        return runtime_settings_loader()
+    except Exception as exc:
+        logger.warning(f"중앙화된 설정 로드 실패, 환경변수 fallback 사용: {exc}")
+        return None
+
+
+def _get_secret_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    if hasattr(value, "get_secret_value"):
+        secret_value = value.get_secret_value()
+        return str(secret_value) if secret_value is not None else None
+    return str(value)
+
+
+def resolve_provider_api_key(
+    provider_name: str,
+    *,
+    settings: Any | None = None,
+    getenv: Callable[[str], str | None] = os.getenv,
+) -> str | None:
+    spec = _get_provider_spec(provider_name)
+
+    if settings is not None:
+        secret_value = _get_secret_value(getattr(settings, spec.settings_attr, None))
+        if secret_value:
+            return secret_value
+
+    for env_key in spec.env_keys:
+        env_value = getenv(env_key)
+        if env_value:
+            return env_value
+    return None
+
+
+def prepare_google_runtime_environment(
+    logger: Any,
+    *,
+    environ: MutableMapping[str, str] | None = None,
+    path_exists: Callable[[str], bool] = os.path.exists,
+) -> None:
+    runtime_env = environ if environ is not None else os.environ
+    google_creds_path = runtime_env.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+    if google_creds_path and not path_exists(google_creds_path):
+        logger.warning(
+            "GOOGLE_APPLICATION_CREDENTIALS이 존재하지 않는 파일을 가리킵니다: " f"{google_creds_path}"
+        )
+        logger.info("Google Cloud 인증을 비활성화하고 API 키만 사용합니다.")
+
+    runtime_env["GOOGLE_APPLICATION_CREDENTIALS"] = ""
+    runtime_env["GOOGLE_CLOUD_PROJECT"] = ""
+    runtime_env.pop("CLOUDSDK_CONFIG", None)
+    runtime_env.pop("GCLOUD_PROJECT", None)
+
+
+def build_provider_model_params(
+    provider_name: str,
+    model_config: Mapping[str, Any],
+    *,
+    settings: Any | None = None,
+    logger: Any,
+) -> dict[str, Any]:
+    spec = _get_provider_spec(provider_name)
+    model_params = dict(model_config)
+
+    if settings is not None:
+        model_params.setdefault(
+            "timeout",
+            getattr(settings, "llm_request_timeout", 120),
+        )
+        if getattr(settings, "enable_fast_mode", False):
+            fast_mode_match = spec.fast_mode_match
+            model_name = str(model_params.get("model", ""))
+            if (
+                fast_mode_match
+                and fast_mode_match in model_name
+                and spec.fast_mode_replacement is not None
+            ):
+                model_params["model"] = spec.fast_mode_replacement
+                if spec.fast_mode_message:
+                    logger.info(spec.fast_mode_message)
+    else:
+        model_params.setdefault("timeout", 120)
+
+    model_params.setdefault("temperature", spec.default_temperature)
+    model_params.setdefault("max_tokens", 4000)
+    model_params.setdefault("model", spec.default_model)
+    return model_params
+
+
+def build_provider_callbacks(
+    provider_name: str,
+    callbacks: list[Any] | None,
+    *,
+    cost_callback_factory: Callable[[str], Any],
+    exception_handler: Callable[..., Any],
+    logger: Any,
+    fallback_path: bool = False,
+    error_message: str | None = None,
+) -> list[Any]:
+    final_callbacks = list(callbacks) if callbacks else []
+    try:
+        cost_callback = cost_callback_factory(provider_name)
+        if cost_callback is not None:
+            final_callbacks.append(cost_callback)
+    except Exception as exc:
+        message = error_message
+        if message is None:
+            message = (
+                f"비용 추적 추가 ({provider_name})"
+                if fallback_path
+                else f"Warning: Failed to add cost tracking for {provider_name}"
+            )
+        exception_handler(exc, message, log_level=logging.INFO)
+    return final_callbacks
+
+
+def _load_chat_class(provider_name: str) -> Any:
+    spec = _get_provider_spec(provider_name)
+    try:
+        module = importlib.import_module(spec.import_module)
+    except ImportError as exc:
+        raise ImportError(spec.missing_package_message) from exc
+
+    try:
+        return getattr(module, spec.class_name)
+    except AttributeError as exc:
+        raise ImportError(spec.missing_package_message) from exc
+
+
+def _build_chat_kwargs(
+    provider_name: str,
+    api_key: str,
+    model_params: Mapping[str, Any],
+    callbacks: list[Any],
+) -> dict[str, Any]:
+    spec = _get_provider_spec(provider_name)
+    kwargs = {
+        spec.api_key_argument: api_key,
+        "model": model_params["model"],
+        "temperature": model_params["temperature"],
+        spec.max_tokens_argument: model_params["max_tokens"],
+        "timeout": model_params.get("timeout", 120),
+        "callbacks": callbacks,
+    }
+    return kwargs
+
+
+def create_provider_model_instance(
+    provider_name: str,
+    *,
+    api_key: str,
+    model_params: Mapping[str, Any],
+    callbacks: list[Any],
+) -> Any:
+    chat_class = _load_chat_class(provider_name)
+    return chat_class(
+        **_build_chat_kwargs(provider_name, api_key, model_params, callbacks)
+    )
+
+
+class RuntimeLLMProvider:
+    """Adapter-backed provider used by the legacy llm_factory wrapper."""
+
+    def __init__(
+        self,
+        provider_name: str,
+        *,
+        runtime_settings_loader: Callable[[], Any | None] | None,
+        cost_callback_factory: Callable[[str], Any],
+        exception_handler: Callable[..., Any],
+        logger: Any,
+        environ: MutableMapping[str, str] | None = None,
+        getenv: Callable[[str], str | None] = os.getenv,
+        path_exists: Callable[[str], bool] = os.path.exists,
+    ) -> None:
+        self.provider_name = provider_name
+        self.runtime_settings_loader = runtime_settings_loader
+        self.cost_callback_factory = cost_callback_factory
+        self.exception_handler = exception_handler
+        self.logger = logger
+        self.environ = environ if environ is not None else os.environ
+        self.getenv = getenv
+        self.path_exists = path_exists
+
+    def create_model(
+        self,
+        model_config: dict[str, Any],
+        callbacks: list[Any] | None = None,
+    ) -> Any:
+        spec = _get_provider_spec(self.provider_name)
+        settings = resolve_runtime_settings(self.runtime_settings_loader, self.logger)
+
+        if self.provider_name == "gemini":
+            prepare_google_runtime_environment(
+                self.logger,
+                environ=self.environ,
+                path_exists=self.path_exists,
+            )
+
+        api_key = resolve_provider_api_key(
+            self.provider_name,
+            settings=settings,
+            getenv=self.getenv,
+        )
+        if not api_key:
+            raise ValueError(spec.missing_api_key_message)
+
+        model_params = build_provider_model_params(
+            self.provider_name,
+            model_config,
+            settings=settings,
+            logger=self.logger,
+        )
+        all_callbacks = build_provider_callbacks(
+            self.provider_name,
+            callbacks,
+            cost_callback_factory=self.cost_callback_factory,
+            exception_handler=self.exception_handler,
+            logger=self.logger,
+        )
+        return create_provider_model_instance(
+            self.provider_name,
+            api_key=api_key,
+            model_params=model_params,
+            callbacks=all_callbacks,
+        )
+
+    def is_available(self) -> bool:
+        try:
+            _load_chat_class(self.provider_name)
+        except ImportError:
+            return False
+
+        settings = resolve_runtime_settings(self.runtime_settings_loader, self.logger)
+        return bool(
+            resolve_provider_api_key(
+                self.provider_name,
+                settings=settings,
+                getenv=self.getenv,
+            )
+        )
+
+
+def build_runtime_provider_registry(
+    *,
+    runtime_settings_loader: Callable[[], Any | None] | None,
+    cost_callback_factory: Callable[[str], Any],
+    exception_handler: Callable[..., Any],
+    logger: Any,
+) -> dict[str, RuntimeLLMProvider]:
+    return {
+        name: RuntimeLLMProvider(
+            name,
+            runtime_settings_loader=runtime_settings_loader,
+            cost_callback_factory=cost_callback_factory,
+            exception_handler=exception_handler,
+            logger=logger,
+        )
+        for name in _PROVIDER_SPECS
+    }
+
+
+__all__ = [
+    "RuntimeLLMProvider",
+    "build_provider_callbacks",
+    "build_provider_model_params",
+    "build_runtime_provider_registry",
+    "create_provider_model_instance",
+    "prepare_google_runtime_environment",
+    "resolve_provider_api_key",
+    "resolve_runtime_settings",
+]

--- a/tests/unit_tests/test_llm_factory_runtime_adapters.py
+++ b/tests/unit_tests/test_llm_factory_runtime_adapters.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import newsletter.llm_factory as legacy_llm_factory
+import newsletter_core.infrastructure.llm_factory_runtime as runtime_adapters
+
+
+class _SecretValue:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def get_secret_value(self) -> str:
+        return self.value
+
+
+class _FakeLogger:
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+        self.infos: list[str] = []
+
+    def warning(self, message: str) -> None:
+        self.warnings.append(message)
+
+    def info(self, message: str) -> None:
+        self.infos.append(message)
+
+
+def test_resolve_runtime_settings_logs_and_falls_back_on_loader_error() -> None:
+    logger = _FakeLogger()
+
+    def _broken_loader() -> Any:
+        raise RuntimeError("boom")
+
+    assert runtime_adapters.resolve_runtime_settings(_broken_loader, logger) is None
+    assert any("중앙화된 설정 로드 실패" in message for message in logger.warnings)
+
+
+def test_resolve_provider_api_key_prefers_settings_then_env_fallback() -> None:
+    settings = SimpleNamespace(
+        gemini_api_key=_SecretValue("settings-gemini-key"),
+        openai_api_key=None,
+        anthropic_api_key=None,
+    )
+    env = {
+        "OPENAI_API_KEY": "env-openai-key",
+    }
+
+    assert (
+        runtime_adapters.resolve_provider_api_key(
+            "gemini",
+            settings=settings,
+            getenv=env.get,
+        )
+        == "settings-gemini-key"
+    )
+    assert (
+        runtime_adapters.resolve_provider_api_key(
+            "openai",
+            settings=settings,
+            getenv=env.get,
+        )
+        == "env-openai-key"
+    )
+
+
+def test_build_provider_model_params_applies_fast_mode_defaults() -> None:
+    logger = _FakeLogger()
+    settings = SimpleNamespace(
+        llm_request_timeout=45,
+        enable_fast_mode=True,
+    )
+
+    model_params = runtime_adapters.build_provider_model_params(
+        "gemini",
+        {
+            "model": "gemini-1.5-pro",
+            "temperature": 0.2,
+        },
+        settings=settings,
+        logger=logger,
+    )
+
+    assert model_params["model"] == "gemini-1.5-flash"
+    assert model_params["temperature"] == 0.2
+    assert model_params["max_tokens"] == 4000
+    assert model_params["timeout"] == 45
+    assert "빠른 모드: Gemini Pro를 Flash로 변경" in logger.infos
+
+
+def test_prepare_google_runtime_environment_mutates_only_when_called() -> None:
+    logger = _FakeLogger()
+    runtime_env = {
+        "GOOGLE_APPLICATION_CREDENTIALS": "/tmp/missing-credentials.json",
+        "GOOGLE_CLOUD_PROJECT": "sample-project",
+        "CLOUDSDK_CONFIG": "/tmp/gcloud",
+        "GCLOUD_PROJECT": "sample-gcloud-project",
+    }
+
+    runtime_adapters.prepare_google_runtime_environment(
+        logger,
+        environ=runtime_env,
+        path_exists=lambda _path: False,
+    )
+
+    assert runtime_env["GOOGLE_APPLICATION_CREDENTIALS"] == ""
+    assert runtime_env["GOOGLE_CLOUD_PROJECT"] == ""
+    assert "CLOUDSDK_CONFIG" not in runtime_env
+    assert "GCLOUD_PROJECT" not in runtime_env
+    assert any(
+        "GOOGLE_APPLICATION_CREDENTIALS이 존재하지 않는 파일" in msg for msg in logger.warnings
+    )
+
+
+def test_build_provider_callbacks_appends_cost_callback() -> None:
+    logger = _FakeLogger()
+
+    callbacks = runtime_adapters.build_provider_callbacks(
+        "openai",
+        ["base"],
+        cost_callback_factory=lambda provider_name: f"cost:{provider_name}",
+        exception_handler=lambda *_args, **_kwargs: None,
+        logger=logger,
+    )
+
+    assert callbacks == ["base", "cost:openai"]
+
+
+def test_build_provider_callbacks_handles_callback_factory_errors() -> None:
+    logger = _FakeLogger()
+    handled: dict[str, Any] = {}
+
+    def _broken_factory(_provider_name: str) -> Any:
+        raise RuntimeError("cost-failed")
+
+    def _handle_exception(exc: Exception, message: str, *, log_level: int) -> None:
+        handled["type"] = type(exc).__name__
+        handled["message"] = message
+        handled["log_level"] = log_level
+
+    callbacks = runtime_adapters.build_provider_callbacks(
+        "anthropic",
+        ["base"],
+        cost_callback_factory=_broken_factory,
+        exception_handler=_handle_exception,
+        logger=logger,
+        fallback_path=True,
+    )
+
+    assert callbacks == ["base"]
+    assert handled == {
+        "type": "RuntimeError",
+        "message": "비용 추적 추가 (anthropic)",
+        "log_level": runtime_adapters.logging.INFO,
+    }
+
+
+def test_runtime_provider_creates_model_with_adapter_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = _FakeLogger()
+    runtime_env = {
+        "GOOGLE_APPLICATION_CREDENTIALS": "/tmp/real-credentials.json",
+        "GOOGLE_CLOUD_PROJECT": "sample-project",
+        "CLOUDSDK_CONFIG": "/tmp/gcloud",
+        "GCLOUD_PROJECT": "sample-gcloud-project",
+    }
+    captured: dict[str, Any] = {}
+
+    class _FakeChatModel:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        runtime_adapters,
+        "_load_chat_class",
+        lambda _provider_name: _FakeChatModel,
+    )
+
+    provider = runtime_adapters.RuntimeLLMProvider(
+        "gemini",
+        runtime_settings_loader=lambda: SimpleNamespace(
+            gemini_api_key=_SecretValue("settings-gemini-key"),
+            llm_request_timeout=90,
+            enable_fast_mode=False,
+        ),
+        cost_callback_factory=lambda provider_name: f"cost:{provider_name}",
+        exception_handler=lambda *_args, **_kwargs: None,
+        logger=logger,
+        environ=runtime_env,
+        getenv=runtime_env.get,
+        path_exists=lambda _path: True,
+    )
+
+    model = provider.create_model(
+        {
+            "provider": "gemini",
+            "model": "gemini-1.5-pro",
+            "temperature": 0.4,
+        },
+        ["base"],
+    )
+
+    assert isinstance(model, _FakeChatModel)
+    assert captured == {
+        "google_api_key": "settings-gemini-key",
+        "model": "gemini-1.5-pro",
+        "temperature": 0.4,
+        "max_output_tokens": 4000,
+        "timeout": 90,
+        "callbacks": ["base", "cost:gemini"],
+    }
+    assert runtime_env["GOOGLE_APPLICATION_CREDENTIALS"] == ""
+    assert runtime_env["GOOGLE_CLOUD_PROJECT"] == ""
+    assert "CLOUDSDK_CONFIG" not in runtime_env
+    assert "GCLOUD_PROJECT" not in runtime_env
+
+
+def test_build_runtime_provider_registry_returns_supported_providers() -> None:
+    registry = runtime_adapters.build_runtime_provider_registry(
+        runtime_settings_loader=lambda: None,
+        cost_callback_factory=lambda _provider_name: None,
+        exception_handler=lambda *_args, **_kwargs: None,
+        logger=_FakeLogger(),
+    )
+
+    assert set(registry) == {"gemini", "openai", "anthropic"}
+
+
+def test_legacy_factory_build_callbacks_delegates_to_runtime_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_build_provider_callbacks(
+        provider_name: str,
+        callbacks: list[Any] | None,
+        **kwargs: Any,
+    ) -> list[Any]:
+        captured["provider_name"] = provider_name
+        captured["callbacks"] = list(callbacks or [])
+        captured["fallback_path"] = kwargs["fallback_path"]
+        return ["from-runtime-helper"]
+
+    monkeypatch.setattr(
+        legacy_llm_factory,
+        "build_provider_callbacks",
+        _fake_build_provider_callbacks,
+    )
+
+    callbacks = legacy_llm_factory.LLMFactory()._build_callbacks(
+        "openai",
+        ["base"],
+        fallback_path=True,
+    )
+
+    assert callbacks == ["from-runtime-helper"]
+    assert captured == {
+        "provider_name": "openai",
+        "callbacks": ["base"],
+        "fallback_path": True,
+    }


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Extract provider wiring, env access, and provider SDK instantiation helpers from `newsletter/llm_factory.py` into `newsletter_core` runtime adapters.
- Keep `newsletter/llm_factory.py` as the compatibility/composition boundary so public import paths and fallback behavior stay unchanged while the legacy surface shrinks.
- Refresh the LLM factory architecture note so the required `docs-quality` check runs and the documented boundary matches the code.

## Scope
### In Scope
- `newsletter/llm_factory.py` bounded 2nd extraction only
- `newsletter_core` runtime adapter helpers for env/config access, provider init shaping, callback wiring, and SDK object creation
- regression/unit coverage for the new adapter boundary

### Out of Scope
- fallback orchestration redesign
- lazy singleton/proxy removal
- changes to `newsletter/tools.py`, `newsletter/graph.py`, `web/routes_generation.py`, scheduler, packaging, or release flows
- provider/model policy changes or new providers

## Delivery Unit
- RR: #310
- Delivery Unit ID: DU-20260311-llm-factory-runtime-adapters
- Merge Boundary: bounded `newsletter/llm_factory.py` extraction into `newsletter_core` adapters without runtime behavior changes
- Rollback Boundary: revert this PR to restore the previous legacy provider wiring in `newsletter/llm_factory.py`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed):

### Commands and Results
```bash
git fetch origin && git rev-parse main && git rev-parse origin/main
# b9f88eb741b33a10065089354bbc3065a6dd7d39
# b9f88eb741b33a10065089354bbc3065a6dd7d39

.local/venv/bin/python -m pytest tests/unit_tests/test_llm_factory_core.py -q
# 8 passed

.local/venv/bin/python -m pytest tests/unit_tests/test_llm_factory_runtime_adapters.py -q
# 9 passed

.local/venv/bin/python -m pytest tests/unit_tests/test_config_import_side_effects.py -q
# 8 passed

TESTING=1 MOCK_MODE=1 GEMINI_API_KEY=dummy OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy .local/venv/bin/python -m pytest tests/unit_tests/test_llm.py -q
# 9 passed

TESTING=1 MOCK_MODE=1 GEMINI_API_KEY=dummy OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy .local/venv/bin/python -m pytest tests/unit_tests/test_llm_providers.py -q
# 5 passed, 1 skipped

make check
# PASS

make check-full
# PASS

git diff --check
# clean
```

## Risk & Rollback
- Risk: provider composition moved across the legacy/core boundary; public entrypoints and fallback execution remain in place to limit behavior drift.
- Rollback: revert this PR, which restores the previous provider wiring and env access implementation in `newsletter/llm_factory.py`.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: N/A
- Outbox/send_key 중복 방지 결과: N/A
- import-time side effect 제거 여부: no new import-time side effects introduced; provider SDK imports are now lazy inside the runtime adapter helper

## Not Run (with reason)
- No additional live provider API tests were run beyond the existing mock-mode/provider regression suite; this PR is behavior-preserving extraction only.
