### PR TITLE
Extract fallback orchestration boundary from legacy llm_factory while preserving singleton compatibility

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,8 +48,9 @@ class LLMFactory:
         # 자동 fallback 지원
 ```
 
-- 현재 provider/model 선택, 설정 정규화, provider info shaping 같은 순수 결정 로직은 `newsletter_core/application/llm_factory.py` 로 이관되었고, provider SDK 생성, env/API key 접근, provider 초기화 입력 조립 같은 runtime adapter 책임은 `newsletter_core/infrastructure/llm_factory_runtime.py` 로 이동했습니다.
-- `newsletter/llm_factory.py` 는 fallback execution, lazy singleton/proxy, legacy import path 호환을 담당하는 compatibility boundary로 유지됩니다.
+- 현재 provider/model 선택, 설정 정규화, provider info shaping 같은 순수 결정 로직은 `newsletter_core/application/llm_factory.py` 로 이관되었고, fallback runtime 설정 정규화, fallback chain 구성, retry/error helper 같은 orchestration helper는 `newsletter_core/application/llm_factory_fallback.py` 로 이동했습니다.
+- provider SDK 생성, env/API key 접근, provider 초기화 입력 조립 같은 runtime adapter 책임은 `newsletter_core/infrastructure/llm_factory_runtime.py` 로 이동했습니다.
+- `newsletter/llm_factory.py` 는 fallback/singleton entrypoint와 legacy import path 호환을 담당하는 thin compatibility boundary로 유지됩니다.
 
 ### 0.3. 자동 Fallback 시스템
 

--- a/newsletter/llm_factory.py
+++ b/newsletter/llm_factory.py
@@ -7,14 +7,18 @@ LLM Factory Module
 F-14: 중앙화된 설정을 활용한 성능 최적화
 """
 
-import logging
-import time
 from typing import Any, Dict, Iterator, List, Optional, cast
 
 from newsletter_core.application.llm_factory import (
     build_provider_info,
     get_default_model,
     resolve_provider_selection,
+)
+from newsletter_core.application.llm_factory_fallback import (
+    create_fallback_model,
+    invoke_with_fallback,
+    is_fallback_trigger_error,
+    resolve_fallback_runtime_config,
 )
 from newsletter_core.infrastructure.llm_factory_runtime import (
     build_provider_callbacks,
@@ -42,13 +46,10 @@ logger = get_logger()
 try:
     from langchain_core.runnables import Runnable
     from langchain_core.runnables.config import RunnableConfig
-    from langchain_core.runnables.utils import Input, Output
 except ImportError:
     # Fallback for older versions
     Runnable = object
     RunnableConfig = dict
-    Input = Any
-    Output = Any
 
 
 def _load_runtime_settings() -> Any | None:
@@ -84,40 +85,22 @@ class LLMWithFallback(Runnable):
         self.callbacks = callbacks or []
         self.last_used = "primary"
 
-        # F-14: 중앙화된 설정에서 성능 파라미터 가져오기
-        try:
-            from .centralized_settings import get_settings
+        self.runtime_config = resolve_fallback_runtime_config(
+            _load_runtime_settings,
+            logger=logger,
+        )
+        self.max_retries = self.runtime_config.max_retries
+        self.retry_delay = self.runtime_config.retry_delay
+        self.timeout = self.runtime_config.timeout
+        self.test_mode = self.runtime_config.test_mode
+        self.mock_responses = self.runtime_config.mock_responses
+        self.skip_real_api = self.runtime_config.skip_real_api
 
-            settings = get_settings()
-            self.max_retries = settings.llm_max_retries
-            self.retry_delay = settings.llm_retry_delay
-            self.timeout = settings.llm_request_timeout
-
-            # F-14: 테스트 모드 감지 및 설정
-            self.test_mode = getattr(settings, "test_mode", False)
-            self.mock_responses = getattr(settings, "mock_api_responses", False)
-            self.skip_real_api = getattr(settings, "skip_real_api_calls", False)
-
-            logger.info(
-                f"F-14 LLM 설정 로드: 재시도={self.max_retries}, "
-                f"지연={self.retry_delay}초, 타임아웃={self.timeout}초, "
-                f"테스트모드={self.test_mode}"
-            )
-
-        except Exception as e:
-            # F-14 설정 로드 실패 시 기본값 사용
-            logger.warning(f"F-14 설정 로드 실패, 기본값 사용: {e}")
-            self.max_retries = 3
-            self.retry_delay = 1.0
-            self.timeout = 60
-
-            # 테스트 환경 감지 (pytest 또는 환경변수)
-            import os
-            import sys
-
-            self.test_mode = "pytest" in sys.modules or os.getenv("TESTING") == "1"
-            self.mock_responses = self.test_mode
-            self.skip_real_api = self.test_mode
+        logger.info(
+            f"F-14 LLM 설정 로드: 재시도={self.max_retries}, "
+            f"지연={self.retry_delay}초, 타임아웃={self.timeout}초, "
+            f"테스트모드={self.test_mode}"
+        )
 
         logger.info(
             f"F-14 LLM ({task}) 초기화 완료: "
@@ -190,43 +173,17 @@ class LLMWithFallback(Runnable):
         **kwargs: Any,
     ) -> Any:
         """실제 LLM 호출 (프로덕션 모드)"""
-        # 기존 retry 로직 유지
-        max_retries = self.max_retries
-
-        for attempt in range(max_retries + 1):
-            try:
-                logger.debug(f"LLM 호출 시도 {attempt + 1}/{max_retries + 1}")
-
-                result = self.primary_llm.invoke(input_data, config=config, **kwargs)
-                self.last_used = "primary"
-                return result
-
-            except Exception as e:
-                if self._is_retryable_error(e) and attempt < max_retries:
-                    delay = self.retry_delay
-                    wait_time = delay * (2**attempt)  # Exponential backoff
-                    logger.warning(f"LLM 호출 실패, {wait_time}초 후 재시도: {e}")
-                    time.sleep(wait_time)
-                    continue
-                else:
-                    fallback_llm = self.fallback_llm
-                    if fallback_llm is None:
-                        fallback_llm = self._get_fallback_llm()
-                        self.fallback_llm = fallback_llm
-
-                    if fallback_llm is not None:
-                        logger.warning(f"Primary LLM 실패, fallback 사용: {e}")
-                        try:
-                            result = fallback_llm.invoke(
-                                input_data, config=config, **kwargs
-                            )
-                            self.last_used = "fallback"
-                            return result
-                        except Exception as fallback_error:
-                            logger.error(f"Fallback LLM도 실패: {fallback_error}")
-
-                    logger.error(f"모든 LLM 호출 실패: {e}")
-                    raise e
+        result, last_used = invoke_with_fallback(
+            primary_llm=self.primary_llm,
+            input_data=input_data,
+            config=config,
+            kwargs=kwargs,
+            runtime_config=self.runtime_config,
+            fallback_loader=self._load_fallback_llm,
+            logger=logger,
+        )
+        self.last_used = last_used
+        return result
 
     def stream(
         self,
@@ -237,39 +194,35 @@ class LLMWithFallback(Runnable):
         """스트리밍 지원 (F-14 개선)"""
         try:
             if hasattr(self.primary_llm, "stream"):
-                yield from self.primary_llm.stream(input_data, config=config, **kwargs)
+                yield from self.primary_llm.stream(
+                    input_data,
+                    config=config,
+                    **kwargs,
+                )
                 return
 
             result = self.invoke(input_data, config=config, **kwargs)
             yield result
         except Exception as e:
-            error_str = str(e).lower()
-            is_retryable = any(
-                keyword in error_str
-                for keyword in [
-                    "529",
-                    "429",
-                    "quota",
-                    "rate limit",
-                    "too many requests",
-                    "overloaded",
-                ]
-            )
-
-            if is_retryable:
-                fallback_llm = self.fallback_llm
-                if fallback_llm is None:
-                    fallback_llm = self._get_fallback_llm()
-                    self.fallback_llm = fallback_llm
+            if is_fallback_trigger_error(e):
+                fallback_llm = self._load_fallback_llm()
 
                 if fallback_llm is None:
                     raise e
 
                 if hasattr(fallback_llm, "stream"):
-                    yield from fallback_llm.stream(input_data, config=config, **kwargs)
+                    yield from fallback_llm.stream(
+                        input_data,
+                        config=config,
+                        **kwargs,
+                    )
                     return
 
-                result = fallback_llm.invoke(input_data, config=config, **kwargs)
+                result = fallback_llm.invoke(
+                    input_data,
+                    config=config,
+                    **kwargs,
+                )
                 yield result
                 return
 
@@ -291,24 +244,8 @@ class LLMWithFallback(Runnable):
                 for input_data in inputs
             ]
         except Exception as e:
-            error_str = str(e).lower()
-            is_retryable = any(
-                keyword in error_str
-                for keyword in [
-                    "529",
-                    "429",
-                    "quota",
-                    "rate limit",
-                    "too many requests",
-                    "overloaded",
-                ]
-            )
-
-            if is_retryable:
-                fallback_llm = self.fallback_llm
-                if fallback_llm is None:
-                    fallback_llm = self._get_fallback_llm()
-                    self.fallback_llm = fallback_llm
+            if is_fallback_trigger_error(e):
+                fallback_llm = self._load_fallback_llm()
 
                 if fallback_llm is None:
                     raise e
@@ -323,121 +260,29 @@ class LLMWithFallback(Runnable):
 
             raise e
 
-    def _get_fallback_llm(self) -> Any | None:
-        """Fallback LLM을 찾아서 반환"""
+    def _load_fallback_llm(self) -> Any | None:
+        """Fallback LLM을 생성해 캐시하거나 기존 인스턴스를 반환합니다."""
+        if self.fallback_llm is not None:
+            return self.fallback_llm
+
         primary_provider = type(self.primary_llm).__name__
         primary_model = getattr(self.primary_llm, "model", "unknown")
-
-        logger.info(f"{primary_provider} ({primary_model})에 대한 대체 모델을 찾는 중입니다")
-
-        # 1. 같은 제공자 내에서 안정적인 모델로 fallback 시도
-        if "gemini" in primary_provider.lower():
-            stable_models = ["gemini-1.5-pro", "gemini-1.5-flash"]
-
-            for stable_model in stable_models:
-                if stable_model != primary_model:  # 동일한 모델이 아닌 경우만
-                    try:
-                        logger.info(f"안정적인 Gemini 모델을 시도합니다: {stable_model}")
-                        fallback_config = {
-                            "provider": "gemini",
-                            "model": stable_model,
-                            "temperature": getattr(
-                                self.primary_llm, "temperature", 0.3
-                            ),
-                            "max_retries": 2,
-                            "timeout": 60,
-                        }
-
-                        # 비용 추적 콜백 추가
-                        fallback_callbacks = list(self.callbacks)
-                        try:
-                            cost_callback = get_cost_callback_for_provider("gemini")
-                            fallback_callbacks.append(cost_callback)
-                        except Exception as e:
-                            handle_exception(e, "비용 추적 콜백 추가", log_level=logging.INFO)
-                            # 비용 추적 실패는 치명적이지 않음
-
-                        provider = self.factory.providers.get("gemini")
-                        if provider and provider.is_available():
-                            return provider.create_model(
-                                fallback_config, fallback_callbacks
-                            )
-                    except Exception as e:
-                        logger.warning(f"안정적인 Gemini 모델 {stable_model} 생성에 실패했습니다: {e}")
-                        continue
-
-        # 2. 다른 제공자로 fallback 시도
-        available_providers = self.factory.get_available_providers()
-
-        for provider_name in available_providers:
-            provider = self.factory.providers[provider_name]
-
-            # 이미 시도한 제공자는 스킵 (단, Gemini는 다른 모델로 이미 시도했으므로 제외)
-            if provider_name == "gemini":
-                continue
-
-            try:
-                # 제공자별 안정적인 기본 모델 사용
-                stable_model_map = {
-                    "openai": "gpt-4o",
-                    "anthropic": "claude-3-5-sonnet-20241022",
-                }
-
-                fallback_model = stable_model_map.get(
-                    provider_name, self.factory._get_default_model(provider_name)
-                )
-
-                logger.info(f"다른 제공자를 시도합니다: {provider_name} (모델: {fallback_model})")
-
-                fallback_config = {
-                    "provider": provider_name,
-                    "model": fallback_model,
-                    "temperature": getattr(self.primary_llm, "temperature", 0.3),
-                    "max_retries": 2,
-                    "timeout": 60,
-                }
-
-                # 비용 추적 콜백 추가
-                fallback_callbacks = list(self.callbacks)
-                try:
-                    cost_callback = get_cost_callback_for_provider(provider_name)
-                    fallback_callbacks.append(cost_callback)
-                except Exception as e:
-                    handle_exception(
-                        e,
-                        f"비용 추적 콜백 추가 ({provider_name})",
-                        log_level=logging.INFO,
-                    )
-                    # 비용 추적 실패는 치명적이지 않음
-
-                return provider.create_model(fallback_config, fallback_callbacks)
-
-            except Exception as e:
-                logger.warning(f"{provider_name}으로 대체 LLM 생성에 실패했습니다: {e}")
-                continue
-
-        logger.warning("대체 LLM을 생성할 수 없습니다")
-        return None
+        self.fallback_llm = create_fallback_model(
+            primary_provider_name=primary_provider,
+            primary_model=primary_model,
+            temperature=getattr(self.primary_llm, "temperature", 0.3),
+            available_providers=self.factory.get_available_providers(),
+            default_model_getter=self.factory._get_default_model,
+            providers=self.factory.providers,
+            callbacks=list(self.callbacks),
+            callback_builder=self.factory._build_callbacks,
+            logger=logger,
+        )
+        return self.fallback_llm
 
     def __getattr__(self, name: str) -> Any:
         """다른 속성들은 primary LLM에 위임"""
         return getattr(self.primary_llm, name)
-
-    def _is_retryable_error(self, e: Exception) -> bool:
-        error_str = str(e).lower()
-        return any(
-            keyword in error_str
-            for keyword in [
-                "529",
-                "429",
-                "quota",
-                "rate limit",
-                "too many requests",
-                "overloaded",
-                "timeout",
-                "connection",
-            ]
-        )
 
 
 class LLMFactory:
@@ -500,7 +345,10 @@ class LLMFactory:
 
         if selection.used_fallback:
             logger.warning(
-                f"{selection.requested_provider}을 사용할 수 없어 {provider_name}으로 대체합니다"
+                (
+                    f"{selection.requested_provider}을 사용할 수 없어 "
+                    f"{provider_name}으로 대체합니다"
+                )
             )
 
         final_callbacks = self._build_callbacks(
@@ -523,15 +371,17 @@ class LLMFactory:
 
     def get_available_providers(self) -> List[str]:
         """사용 가능한 제공자 목록을 반환합니다."""
-        return [
-            name for name, provider in self.providers.items() if provider.is_available()
-        ]
+        available_providers: List[str] = []
+        for name, provider in self.providers.items():
+            if provider.is_available():
+                available_providers.append(name)
+        return available_providers
 
     def get_provider_info(self) -> Dict[str, Dict[str, Any]]:
         """각 제공자의 사용 가능 여부와 모델 정보를 반환합니다."""
-        availability = {
-            name: provider.is_available() for name, provider in self.providers.items()
-        }
+        availability: Dict[str, bool] = {}
+        for name, provider in self.providers.items():
+            availability[name] = provider.is_available()
         provider_info: Dict[str, Dict[str, Any]] = build_provider_info(
             self.llm_config,
             self.providers.keys(),

--- a/newsletter_core/application/llm_factory_fallback.py
+++ b/newsletter_core/application/llm_factory_fallback.py
@@ -1,0 +1,277 @@
+"""Fallback orchestration helpers for legacy llm_factory compatibility."""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class FallbackRuntimeConfig:
+    max_retries: int
+    retry_delay: float
+    timeout: int | float
+    test_mode: bool
+    mock_responses: bool
+    skip_real_api: bool
+
+
+@dataclass(frozen=True)
+class FallbackCandidate:
+    provider_name: str
+    model_config: dict[str, Any]
+    attempt_message: str
+    failure_prefix: str
+
+
+_RETRYABLE_ERROR_KEYWORDS = (
+    "529",
+    "429",
+    "quota",
+    "rate limit",
+    "too many requests",
+    "overloaded",
+    "timeout",
+    "connection",
+)
+_FALLBACK_TRIGGER_ERROR_KEYWORDS = (
+    "529",
+    "429",
+    "quota",
+    "rate limit",
+    "too many requests",
+    "overloaded",
+)
+_GEMINI_STABLE_MODELS = ("gemini-1.5-pro", "gemini-1.5-flash")
+_STABLE_FALLBACK_MODELS = {
+    "openai": "gpt-4o",
+    "anthropic": "claude-3-5-sonnet-20241022",
+}
+
+
+def resolve_fallback_runtime_config(
+    runtime_settings_loader: Callable[[], Any | None] | None,
+    *,
+    getenv: Callable[[str], str | None] = os.getenv,
+    modules: Mapping[str, Any] | None = None,
+    logger: Any | None = None,
+) -> FallbackRuntimeConfig:
+    if runtime_settings_loader is not None:
+        try:
+            settings = runtime_settings_loader()
+        except Exception as exc:
+            if logger is not None:
+                logger.warning(f"F-14 설정 로드 실패, 기본값 사용: {exc}")
+        else:
+            if settings is not None:
+                max_retries = int(getattr(settings, "llm_max_retries", 3))
+                retry_delay = float(getattr(settings, "llm_retry_delay", 1.0))
+                timeout = getattr(settings, "llm_request_timeout", 60)
+                test_mode = bool(getattr(settings, "test_mode", False))
+                mock_response_attr = getattr(
+                    settings,
+                    "mock_api_responses",
+                    False,
+                )
+                skip_real_api_attr = getattr(
+                    settings,
+                    "skip_real_api_calls",
+                    False,
+                )
+                mock_responses = bool(mock_response_attr)
+                skip_real_api = bool(skip_real_api_attr)
+                return FallbackRuntimeConfig(
+                    max_retries=max_retries,
+                    retry_delay=retry_delay,
+                    timeout=timeout,
+                    test_mode=test_mode,
+                    mock_responses=mock_responses,
+                    skip_real_api=skip_real_api,
+                )
+
+    loaded_modules = modules if modules is not None else sys.modules
+    test_mode = "pytest" in loaded_modules or getenv("TESTING") == "1"
+    return FallbackRuntimeConfig(
+        max_retries=3,
+        retry_delay=1.0,
+        timeout=60,
+        test_mode=test_mode,
+        mock_responses=test_mode,
+        skip_real_api=test_mode,
+    )
+
+
+def is_retryable_error(exc: Exception) -> bool:
+    return _matches_error_keywords(exc, _RETRYABLE_ERROR_KEYWORDS)
+
+
+def is_fallback_trigger_error(exc: Exception) -> bool:
+    return _matches_error_keywords(exc, _FALLBACK_TRIGGER_ERROR_KEYWORDS)
+
+
+def build_fallback_candidates(
+    *,
+    primary_provider_name: str,
+    primary_model: str,
+    temperature: float,
+    available_providers: Iterable[str],
+    default_model_getter: Callable[[str], str],
+) -> list[FallbackCandidate]:
+    candidates: list[FallbackCandidate] = []
+
+    if "gemini" in primary_provider_name.lower():
+        for stable_model in _GEMINI_STABLE_MODELS:
+            if stable_model == primary_model:
+                continue
+            attempt_message = f"안정적인 Gemini 모델을 시도합니다: {stable_model}"
+            failure_prefix = f"안정적인 Gemini 모델 {stable_model} 생성에 실패했습니다"
+            candidates.append(
+                FallbackCandidate(
+                    provider_name="gemini",
+                    model_config={
+                        "provider": "gemini",
+                        "model": stable_model,
+                        "temperature": temperature,
+                        "max_retries": 2,
+                        "timeout": 60,
+                    },
+                    attempt_message=attempt_message,
+                    failure_prefix=failure_prefix,
+                )
+            )
+
+    for provider_name in available_providers:
+        if provider_name == "gemini":
+            continue
+        fallback_model = _STABLE_FALLBACK_MODELS.get(
+            provider_name,
+            default_model_getter(provider_name),
+        )
+        candidates.append(
+            FallbackCandidate(
+                provider_name=provider_name,
+                model_config={
+                    "provider": provider_name,
+                    "model": fallback_model,
+                    "temperature": temperature,
+                    "max_retries": 2,
+                    "timeout": 60,
+                },
+                attempt_message=(
+                    f"다른 제공자를 시도합니다: {provider_name} (모델: {fallback_model})"
+                ),
+                failure_prefix=f"{provider_name}으로 대체 LLM 생성에 실패했습니다",
+            )
+        )
+
+    return candidates
+
+
+def create_fallback_model(
+    *,
+    primary_provider_name: str,
+    primary_model: str,
+    temperature: float,
+    available_providers: Iterable[str],
+    default_model_getter: Callable[[str], str],
+    providers: Mapping[str, Any],
+    callbacks: list[Any],
+    callback_builder: Callable[..., list[Any]],
+    logger: Any,
+) -> Any | None:
+    provider_label = f"{primary_provider_name} ({primary_model})"
+    search_message = f"{provider_label}에 대한 대체 모델을 찾는 중입니다"
+    logger.info(search_message)
+
+    candidates = build_fallback_candidates(
+        primary_provider_name=primary_provider_name,
+        primary_model=primary_model,
+        temperature=temperature,
+        available_providers=available_providers,
+        default_model_getter=default_model_getter,
+    )
+
+    for candidate in candidates:
+        provider = providers.get(candidate.provider_name)
+        if provider is None or not provider.is_available():
+            continue
+
+        try:
+            logger.info(candidate.attempt_message)
+            fallback_callbacks = callback_builder(
+                candidate.provider_name,
+                callbacks,
+                fallback_path=True,
+            )
+            return provider.create_model(
+                dict(candidate.model_config),
+                fallback_callbacks,
+            )
+        except Exception as exc:
+            logger.warning(f"{candidate.failure_prefix}: {exc}")
+
+    logger.warning("대체 LLM을 생성할 수 없습니다")
+    return None
+
+
+def invoke_with_fallback(
+    *,
+    primary_llm: Any,
+    input_data: Any,
+    config: Any | None,
+    kwargs: Mapping[str, Any],
+    runtime_config: FallbackRuntimeConfig,
+    fallback_loader: Callable[[], Any | None],
+    logger: Any,
+    sleep: Callable[[float], None] = time.sleep,
+) -> tuple[Any, str]:
+    max_retries = runtime_config.max_retries
+
+    for attempt in range(max_retries + 1):
+        try:
+            logger.debug(f"LLM 호출 시도 {attempt + 1}/{max_retries + 1}")
+            result = primary_llm.invoke(input_data, config=config, **kwargs)
+            return result, "primary"
+        except Exception as exc:
+            if is_retryable_error(exc) and attempt < max_retries:
+                wait_time = runtime_config.retry_delay * (2**attempt)
+                logger.warning(f"LLM 호출 실패, {wait_time}초 후 재시도: {exc}")
+                sleep(wait_time)
+                continue
+
+            fallback_llm = fallback_loader()
+            if fallback_llm is not None:
+                logger.warning(f"Primary LLM 실패, fallback 사용: {exc}")
+                try:
+                    result = fallback_llm.invoke(
+                        input_data,
+                        config=config,
+                        **kwargs,
+                    )
+                    return result, "fallback"
+                except Exception as fallback_error:
+                    logger.error(f"Fallback LLM도 실패: {fallback_error}")
+
+            logger.error(f"모든 LLM 호출 실패: {exc}")
+            raise
+
+
+def _matches_error_keywords(exc: Exception, keywords: tuple[str, ...]) -> bool:
+    error_str = str(exc).lower()
+    return any(keyword in error_str for keyword in keywords)
+
+
+__all__ = [
+    "FallbackCandidate",
+    "FallbackRuntimeConfig",
+    "build_fallback_candidates",
+    "create_fallback_model",
+    "invoke_with_fallback",
+    "is_fallback_trigger_error",
+    "is_retryable_error",
+    "resolve_fallback_runtime_config",
+]

--- a/tests/unit_tests/test_llm_factory_fallback_helpers.py
+++ b/tests/unit_tests/test_llm_factory_fallback_helpers.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import newsletter.llm_factory as legacy_llm_factory
+import newsletter_core.application.llm_factory_fallback as fallback_helpers
+
+
+class _FakeLogger:
+    def __init__(self) -> None:
+        self.debugs: list[str] = []
+        self.infos: list[str] = []
+        self.warnings: list[str] = []
+        self.errors: list[str] = []
+
+    def debug(self, message: str) -> None:
+        self.debugs.append(message)
+
+    def info(self, message: str) -> None:
+        self.infos.append(message)
+
+    def warning(self, message: str) -> None:
+        self.warnings.append(message)
+
+    def error(self, message: str) -> None:
+        self.errors.append(message)
+
+
+class _FakeLLM:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def invoke(
+        self,
+        input_data: Any,
+        config: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        self.calls.append(
+            {
+                "input_data": input_data,
+                "config": config,
+                "kwargs": dict(kwargs),
+            }
+        )
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class _FakeProvider:
+    def __init__(
+        self,
+        *,
+        available: bool = True,
+        create_result: Any | None = None,
+        create_error: Exception | None = None,
+    ) -> None:
+        self.available = available
+        self.create_result = create_result
+        self.create_error = create_error
+        self.created: list[tuple[dict[str, Any], list[Any]]] = []
+
+    def is_available(self) -> bool:
+        return self.available
+
+    def create_model(
+        self,
+        model_config: dict[str, Any],
+        callbacks: list[Any] | None = None,
+    ) -> Any:
+        snapshot = dict(model_config)
+        callback_list = list(callbacks or [])
+        self.created.append((snapshot, callback_list))
+        if self.create_error is not None:
+            raise self.create_error
+        return self.create_result
+
+
+class _LegacyFactoryStub:
+    def __init__(self) -> None:
+        self.providers = {
+            "gemini": object(),
+            "openai": object(),
+            "anthropic": object(),
+        }
+
+    def get_available_providers(self) -> list[str]:
+        return ["gemini", "openai", "anthropic"]
+
+    def _get_default_model(self, provider_name: str) -> str:
+        return f"default:{provider_name}"
+
+    def _build_callbacks(
+        self,
+        provider_name: str,
+        callbacks: list[Any] | None = None,
+        *,
+        fallback_path: bool = False,
+    ) -> list[Any]:
+        callback_list = list(callbacks or [])
+        return callback_list + [f"cost:{provider_name}:{fallback_path}"]
+
+
+def test_resolve_fallback_runtime_config_prefers_loaded_settings() -> None:
+    logger = _FakeLogger()
+    settings = SimpleNamespace(
+        llm_max_retries=5,
+        llm_retry_delay=2.5,
+        llm_request_timeout=90,
+        test_mode=True,
+        mock_api_responses=False,
+        skip_real_api_calls=True,
+    )
+
+    config = fallback_helpers.resolve_fallback_runtime_config(
+        lambda: settings,
+        logger=logger,
+    )
+
+    assert config == fallback_helpers.FallbackRuntimeConfig(
+        max_retries=5,
+        retry_delay=2.5,
+        timeout=90,
+        test_mode=True,
+        mock_responses=False,
+        skip_real_api=True,
+    )
+    warnings = logger.warnings
+    assert warnings == []
+
+
+def test_resolve_fallback_runtime_config_uses_test_env_defaults() -> None:
+    config = fallback_helpers.resolve_fallback_runtime_config(
+        lambda: None,
+        getenv=lambda key: "1" if key == "TESTING" else None,
+        modules={},
+    )
+
+    assert config == fallback_helpers.FallbackRuntimeConfig(
+        max_retries=3,
+        retry_delay=1.0,
+        timeout=60,
+        test_mode=True,
+        mock_responses=True,
+        skip_real_api=True,
+    )
+
+
+def test_build_fallback_candidates_preserve_gemini_order() -> None:
+    def _default_model(provider_name: str) -> str:
+        return f"default:{provider_name}"
+
+    candidates = fallback_helpers.build_fallback_candidates(
+        primary_provider_name="GeminiChatModel",
+        primary_model="gemini-1.5-pro",
+        temperature=0.4,
+        available_providers=("gemini", "openai", "anthropic"),
+        default_model_getter=_default_model,
+    )
+
+    assert [
+        (candidate.provider_name, candidate.model_config["model"])
+        for candidate in candidates
+    ] == [
+        ("gemini", "gemini-1.5-flash"),
+        ("openai", "gpt-4o"),
+        ("anthropic", "claude-3-5-sonnet-20241022"),
+    ]
+    candidate_temperatures = [
+        candidate.model_config["temperature"] for candidate in candidates
+    ]
+    assert candidate_temperatures == [0.4, 0.4, 0.4]
+
+
+def test_build_fallback_candidates_keep_legacy_type_matching() -> None:
+    def _default_model(provider_name: str) -> str:
+        return f"default:{provider_name}"
+
+    candidates = fallback_helpers.build_fallback_candidates(
+        primary_provider_name="ChatGoogleGenerativeAI",
+        primary_model="gemini-1.5-pro",
+        temperature=0.4,
+        available_providers=("gemini", "openai", "anthropic"),
+        default_model_getter=_default_model,
+    )
+
+    assert [
+        (candidate.provider_name, candidate.model_config["model"])
+        for candidate in candidates
+    ] == [
+        ("openai", "gpt-4o"),
+        ("anthropic", "claude-3-5-sonnet-20241022"),
+    ]
+
+
+def test_create_fallback_model_uses_runtime_candidates() -> None:
+    logger = _FakeLogger()
+    gemini_provider = _FakeProvider(available=False)
+    openai_provider = _FakeProvider(create_result="openai-fallback")
+    callback_calls: list[tuple[str, list[Any], bool]] = []
+
+    def _default_model(provider_name: str) -> str:
+        return f"default:{provider_name}"
+
+    def _build_callbacks(
+        provider_name: str,
+        callbacks: list[Any] | None = None,
+        *,
+        fallback_path: bool = False,
+    ) -> list[Any]:
+        callback_snapshot = list(callbacks or [])
+        callback_record = (provider_name, callback_snapshot, fallback_path)
+        callback_calls.append(callback_record)
+        return callback_snapshot + [f"cost:{provider_name}"]
+
+    fallback = fallback_helpers.create_fallback_model(
+        primary_provider_name="ChatGoogleGenerativeAI",
+        primary_model="gemini-1.5-pro",
+        temperature=0.2,
+        available_providers=("gemini", "openai", "anthropic"),
+        default_model_getter=_default_model,
+        providers={
+            "gemini": gemini_provider,
+            "openai": openai_provider,
+            "anthropic": _FakeProvider(),
+        },
+        callbacks=["base"],
+        callback_builder=_build_callbacks,
+        logger=logger,
+    )
+
+    assert fallback == "openai-fallback"
+    assert callback_calls == [("openai", ["base"], True)]
+    assert openai_provider.created == [
+        (
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "temperature": 0.2,
+                "max_retries": 2,
+                "timeout": 60,
+            },
+            ["base", "cost:openai"],
+        )
+    ]
+    assert any("대체 모델을 찾는 중입니다" in message for message in logger.infos)
+
+
+def test_invoke_with_fallback_retries_before_primary_success() -> None:
+    logger = _FakeLogger()
+    primary_llm = _FakeLLM([RuntimeError("429 rate limit"), "ok"])
+    sleeps: list[float] = []
+
+    result, last_used = fallback_helpers.invoke_with_fallback(
+        primary_llm=primary_llm,
+        input_data="payload",
+        config={"trace": 1},
+        kwargs={"extra": "value"},
+        runtime_config=fallback_helpers.FallbackRuntimeConfig(
+            max_retries=2,
+            retry_delay=0.5,
+            timeout=60,
+            test_mode=False,
+            mock_responses=False,
+            skip_real_api=False,
+        ),
+        fallback_loader=lambda: None,
+        logger=logger,
+        sleep=sleeps.append,
+    )
+
+    assert result == "ok"
+    assert last_used == "primary"
+    assert sleeps == [0.5]
+    assert len(primary_llm.calls) == 2
+
+
+def test_invoke_with_fallback_uses_fallback_after_retries_exhausted() -> None:
+    logger = _FakeLogger()
+    primary_llm = _FakeLLM(
+        [RuntimeError("429 rate limit"), RuntimeError("429 rate limit")]
+    )
+    fallback_llm = _FakeLLM(["fallback-result"])
+    sleeps: list[float] = []
+
+    result, last_used = fallback_helpers.invoke_with_fallback(
+        primary_llm=primary_llm,
+        input_data="payload",
+        config=None,
+        kwargs={},
+        runtime_config=fallback_helpers.FallbackRuntimeConfig(
+            max_retries=1,
+            retry_delay=0.25,
+            timeout=60,
+            test_mode=False,
+            mock_responses=False,
+            skip_real_api=False,
+        ),
+        fallback_loader=lambda: fallback_llm,
+        logger=logger,
+        sleep=sleeps.append,
+    )
+
+    assert result == "fallback-result"
+    assert last_used == "fallback"
+    assert sleeps == [0.25]
+    assert len(fallback_llm.calls) == 1
+
+
+def test_is_fallback_trigger_error_matches_legacy_subset() -> None:
+    retryable_error = RuntimeError("quota exceeded")
+    assert fallback_helpers.is_fallback_trigger_error(retryable_error)
+    assert not fallback_helpers.is_fallback_trigger_error(
+        RuntimeError("connection reset by peer")
+    )
+
+
+def test_legacy_wrapper_delegates_runtime_config_to_core_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = fallback_helpers.FallbackRuntimeConfig(
+        max_retries=4,
+        retry_delay=1.5,
+        timeout=75,
+        test_mode=False,
+        mock_responses=False,
+        skip_real_api=False,
+    )
+
+    monkeypatch.setattr(
+        legacy_llm_factory,
+        "resolve_fallback_runtime_config",
+        lambda *_args, **_kwargs: config,
+    )
+
+    wrapper = legacy_llm_factory.LLMWithFallback(
+        _FakeLLM(["ok"]),
+        _LegacyFactoryStub(),
+        "translation",
+        ["base"],
+    )
+
+    assert wrapper.runtime_config == config
+    assert wrapper.max_retries == 4
+    assert wrapper.retry_delay == 1.5
+    assert wrapper.timeout == 75
+
+
+def test_legacy_wrapper_delegates_fallback_creation_to_core_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    fallback_model = object()
+
+    monkeypatch.setattr(
+        legacy_llm_factory,
+        "resolve_fallback_runtime_config",
+        lambda *_args, **_kwargs: fallback_helpers.FallbackRuntimeConfig(
+            max_retries=1,
+            retry_delay=0.1,
+            timeout=60,
+            test_mode=False,
+            mock_responses=False,
+            skip_real_api=False,
+        ),
+    )
+
+    def _fake_create_fallback_model(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return fallback_model
+
+    monkeypatch.setattr(
+        legacy_llm_factory,
+        "create_fallback_model",
+        _fake_create_fallback_model,
+    )
+
+    primary_llm = SimpleNamespace(model="gemini-1.5-pro", temperature=0.6)
+    factory = _LegacyFactoryStub()
+    wrapper = legacy_llm_factory.LLMWithFallback(
+        primary_llm,
+        factory,
+        "translation",
+        ["base"],
+    )
+
+    assert wrapper._load_fallback_llm() is fallback_model
+    assert captured["primary_provider_name"] == "SimpleNamespace"
+    assert captured["primary_model"] == "gemini-1.5-pro"
+    assert captured["temperature"] == 0.6
+    assert captured["available_providers"] == [
+        "gemini",
+        "openai",
+        "anthropic",
+    ]
+    assert captured["providers"] == factory.providers
+    assert captured["callbacks"] == ["base"]
+    assert callable(captured["default_model_getter"])
+    assert callable(captured["callback_builder"])
+
+
+def test_legacy_wrapper_delegates_real_invoke_to_core_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        legacy_llm_factory,
+        "resolve_fallback_runtime_config",
+        lambda *_args, **_kwargs: fallback_helpers.FallbackRuntimeConfig(
+            max_retries=2,
+            retry_delay=0.5,
+            timeout=60,
+            test_mode=False,
+            mock_responses=False,
+            skip_real_api=False,
+        ),
+    )
+
+    def _fake_invoke_with_fallback(**kwargs: Any) -> tuple[str, str]:
+        captured.update(kwargs)
+        return "core-result", "fallback"
+
+    monkeypatch.setattr(
+        legacy_llm_factory,
+        "invoke_with_fallback",
+        _fake_invoke_with_fallback,
+    )
+
+    primary_llm = _FakeLLM(["unused"])
+    wrapper = legacy_llm_factory.LLMWithFallback(
+        primary_llm,
+        _LegacyFactoryStub(),
+        "translation",
+        ["base"],
+    )
+
+    assert (
+        wrapper._invoke_real_llm(
+            "payload",
+            {"trace": 1},
+            test=True,
+        )
+        == "core-result"
+    )
+    assert wrapper.last_used == "fallback"
+    assert captured["primary_llm"] is primary_llm
+    assert captured["input_data"] == "payload"
+    assert captured["config"] == {"trace": 1}
+    assert captured["kwargs"] == {"test": True}
+    assert captured["fallback_loader"] == wrapper._load_fallback_llm


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Extract behavior-preserving fallback runtime config, fallback chain construction, and invoke orchestration helpers from `newsletter/llm_factory.py` into `newsletter_core/application/llm_factory_fallback.py`.
- Keep `newsletter/llm_factory.py` as a thinner compatibility shell with the existing public import path and lazy singleton/proxy contract intact.

## Scope
### In Scope
- Move fallback runtime settings normalization into `newsletter_core`
- Move fallback candidate construction and fallback model composition into `newsletter_core`
- Move retry/fallback invoke helper logic into `newsletter_core`
- Add fallback helper and legacy delegation regression tests
- Minimal architecture note update so the required `docs-quality` check runs against the new boundary

### Out of Scope
- Fallback policy changes, retry semantic changes, provider ordering changes
- Removing the lazy singleton/proxy compatibility layer
- Changes to `newsletter/tools.py`, `newsletter/graph.py`, `web/routes_generation.py`, web runtime, scheduler, packaging, or release flows

## Delivery Unit
- RR: #312
- Delivery Unit ID: DU-20260311-llm-factory-fallback-composition
- Merge Boundary: merge only this fallback-orchestration extraction and its contract tests
- Rollback Boundary: revert this PR to restore the previous legacy `newsletter/llm_factory.py` fallback composition

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): targeted llm_factory unit/contract/import regression suite

### Commands and Results
```bash
.local/venv/bin/python -m black --check newsletter/llm_factory.py newsletter_core/application/llm_factory_fallback.py tests/unit_tests/test_llm_factory_fallback_helpers.py
.local/venv/bin/python -m isort --check-only newsletter/llm_factory.py newsletter_core/application/llm_factory_fallback.py tests/unit_tests/test_llm_factory_fallback_helpers.py
.local/venv/bin/python -m flake8 newsletter/llm_factory.py newsletter_core/application/llm_factory_fallback.py tests/unit_tests/test_llm_factory_fallback_helpers.py
.local/venv/bin/python -m pytest tests/unit_tests/test_llm_factory_fallback_helpers.py -q
.local/venv/bin/python -m pytest tests/unit_tests/test_llm_factory_core.py -q
.local/venv/bin/python -m pytest tests/unit_tests/test_llm_factory_runtime_adapters.py -q
.local/venv/bin/python -m pytest tests/unit_tests/test_config_import_side_effects.py -q
TESTING=1 MOCK_MODE=1 GEMINI_API_KEY=dummy OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy .local/venv/bin/python -m pytest tests/unit_tests/test_llm.py -q
TESTING=1 MOCK_MODE=1 GEMINI_API_KEY=dummy OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy .local/venv/bin/python -m pytest tests/unit_tests/test_llm_providers.py -q
make check
make check-full
```

## Risk & Rollback
- Risk: low-to-moderate; the behavior-sensitive area is fallback delegation inside `newsletter/llm_factory.py`, but provider policy and the public compatibility layer remain unchanged.
- Rollback: revert this PR's squash commit.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: not applicable
- Outbox/send_key 중복 방지 결과: not applicable
- import-time side effect 제거 여부: maintained; `newsletter.llm_factory` still does not mutate Google env on import and the import side-effect test passes

## Not Run (with reason)
- Real API provider tests were not run; local verification stayed in `MOCK_MODE` per repo contract.
