### PR TITLE
Extract Serper search integration orchestration from legacy newsletter/tools.py into newsletter_core

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@ class LLMFactory:
 - 현재 provider/model 선택, 설정 정규화, provider info shaping 같은 순수 결정 로직은 `newsletter_core/application/llm_factory.py` 로 이관되었고, fallback runtime 설정 정규화, fallback chain 구성, retry/error helper 같은 orchestration helper는 `newsletter_core/application/llm_factory_fallback.py` 로 이동했습니다.
 - provider SDK 생성, env/API key 접근, provider 초기화 입력 조립 같은 runtime adapter 책임은 `newsletter_core/infrastructure/llm_factory_runtime.py` 로 이동했습니다.
 - `newsletter/llm_factory.py` 는 fallback/singleton entrypoint와 legacy import path 호환을 담당하는 thin compatibility boundary로 유지됩니다.
-- `newsletter/tools.py` 는 여전히 legacy integration surface이지만, Serper 입력 정규화/결과 shaping과 theme/filename 순수 helper는 `newsletter_core/application/tools_support.py` 로 이동했고 외부 IO/LLM glue만 legacy wrapper에 남깁니다.
+- `newsletter/tools.py` 는 여전히 legacy integration surface이지만, Serper 입력 정규화/결과 shaping과 theme/filename 순수 helper는 `newsletter_core/application/tools_support.py` 로, request plan/response orchestration/aggregation helper는 `newsletter_core/application/tools_search_flow.py` 로 이동했고 실제 network/HTML/LLM glue만 legacy wrapper에 남깁니다.
 
 ### 0.3. 자동 Fallback 시스템
 

--- a/newsletter/tools.py
+++ b/newsletter/tools.py
@@ -6,7 +6,7 @@ Newsletter Generator - Custom Tools
 import json
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
 
 import markdownify
 import requests  # type: ignore[import-untyped]
@@ -17,11 +17,22 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.tools import ToolException
 from langchain_google_genai import ChatGoogleGenerativeAI
 
+from newsletter_core.application.tools_search_flow import (
+    SerperKeywordFailure,
+    SerperKeywordReport,
+    SerperLogMessage,
+    SerperSearchPlan,
+    SerperSearchRequestError,
+    SerperSearchResponseDecodeError,
+    build_serper_failure_log_messages,
+    build_serper_keyword_log_messages,
+    build_serper_search_plans,
+    execute_serper_search_plan,
+    summarize_serper_search_reports,
+)
 from newsletter_core.application.tools_support import (
-    build_serper_payload,
     extract_common_theme_fallback,
     parse_generated_keywords,
-    parse_serper_response,
     resolve_filename_theme,
     resolve_search_request,
     sanitize_filename,
@@ -34,6 +45,33 @@ from .utils.logger import get_logger, show_collection_brief
 
 # 로거 초기화
 logger = get_logger()
+
+
+def _execute_serper_search_request(
+    search_plan: SerperSearchPlan,
+) -> dict[str, Any]:
+    try:
+        response = requests.request(
+            "POST",
+            search_plan.url,
+            headers=search_plan.headers,
+            data=search_plan.payload,
+        )
+        response.raise_for_status()
+    except requests.exceptions.RequestException as exc:
+        raise SerperSearchRequestError(str(exc)) from exc
+
+    try:
+        raw_results = response.json()
+    except json.JSONDecodeError as exc:
+        raise SerperSearchResponseDecodeError(response.text) from exc
+
+    return cast(dict[str, Any], raw_results)
+
+
+def _emit_serper_log_messages(log_messages: list[SerperLogMessage]) -> None:
+    for log_message in log_messages:
+        getattr(logger, log_message.level)(log_message.message)
 
 
 @tool  # type: ignore[untyped-decorator]
@@ -51,87 +89,42 @@ def search_news_articles(keywords: str, num_results: int = 10) -> List[Dict]:
         raise ToolException("SERPER_API_KEY not found. Please set it in the .env file.")
 
     search_request = resolve_search_request(keywords, num_results)
-    all_collected_articles = []
-    keyword_article_counts = {}
+    search_plans = build_serper_search_plans(
+        search_request, api_key=config.SERPER_API_KEY
+    )
+    keyword_reports: list[SerperKeywordReport] = []
 
     logger.info("\nStarting article collection process:")
-    for keyword in search_request.keywords:
-        logger.info(f"Searching articles for keyword: '{keyword}'")
-        url = "https://google.serper.dev/news"
-        payload = build_serper_payload(keyword, search_request.num_results)
+    for search_plan in search_plans:
+        logger.info(f"Searching articles for keyword: '{search_plan.keyword}'")
+        keyword_result = execute_serper_search_plan(
+            search_plan,
+            executor=_execute_serper_search_request,
+        )
 
-        headers = {
-            "X-API-KEY": config.SERPER_API_KEY,
-            "Content-Type": "application/json",
-        }
-
-        try:
-            response = requests.request("POST", url, headers=headers, data=payload)
-            response.raise_for_status()
-
-            results = response.json()
-            parsed_results = parse_serper_response(results, search_request.num_results)
-
-            for container_name in parsed_results.container_names:
-                logger.info(f"Found '{container_name}' results for keyword '{keyword}'")
-
-            logger.info(
-                f"Total container items found: {parsed_results.container_count}"
+        if isinstance(keyword_result, SerperKeywordFailure):
+            _emit_serper_log_messages(
+                list(build_serper_failure_log_messages(keyword_result))
             )
+            continue
 
-            # 디버깅: 응답 구조 확인
-            if not parsed_results.container_count and results:
-                logger.warning(
-                    f"Warning: No result containers found. Available keys: {list(results.keys())}"
-                )
-                if len(results.keys()) <= 3:  # 키가 적으면 전체 구조 확인
-                    logger.warning(
-                        f"Response structure: {json.dumps(results, ensure_ascii=False)[:300]}..."
-                    )
+        _emit_serper_log_messages(
+            list(build_serper_keyword_log_messages(keyword_result))
+        )
+        keyword_reports.append(keyword_result)
 
-            # 각 아이템 처리
-            articles_for_keyword = parsed_results.articles
-            for item_idx, item in enumerate(articles_for_keyword):
-                # 디버깅 정보 (첫 3개 항목만)
-                if item_idx < 3:
-                    logger.debug(
-                        f"Debug: Item keys (index: {item_idx}): {list(item.keys())}"
-                    )
-                    raw_date_val = item.get("date")
-                    raw_published_at_val = item.get("publishedAt")
-                    logger.debug(
-                        f"Debug: Date value: '{raw_date_val}' / PublishedAt: '{raw_published_at_val}'"
-                    )
-
-            if not articles_for_keyword:
-                logger.warning(f"No articles could be parsed for keyword '{keyword}'.")
-
-            num_found = len(articles_for_keyword)
-            keyword_article_counts[keyword] = num_found
-            logger.info(f"Found {num_found} articles for keyword: '{keyword}'")
-            all_collected_articles.extend(articles_for_keyword)
-
-        except requests.exceptions.RequestException as e:
-            logger.error(
-                f"Error fetching articles for keyword '{keyword}' from Serper.dev: {e}"
-            )
-            # Continue to next keyword if one fails
-        except json.JSONDecodeError:
-            logger.error(
-                f"Error decoding JSON response for keyword '{keyword}' from Serper.dev. Response: {response.text}"
-            )
-            # Continue to next keyword
+    search_summary = summarize_serper_search_reports(keyword_reports)
 
     # 검색 결과 간결 표시
-    total_collected = len(all_collected_articles)
-    if keyword_article_counts and total_collected > 0:
-        show_collection_brief(keyword_article_counts)
+    total_collected = len(search_summary.all_articles)
+    if search_summary.keyword_article_counts and total_collected > 0:
+        show_collection_brief(search_summary.keyword_article_counts)
     elif total_collected > 0:
         logger.info(f"📰 총 {total_collected}개 기사 수집 완료")
     else:
         logger.warning("⚠️  수집된 기사가 없습니다")
 
-    return all_collected_articles
+    return cast(List[Dict], search_summary.all_articles)
 
 
 @tool  # type: ignore[untyped-decorator]

--- a/newsletter_core/application/tools_search_flow.py
+++ b/newsletter_core/application/tools_search_flow.py
@@ -1,0 +1,336 @@
+"""Search orchestration helpers extracted from the legacy newsletter.tools module."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Final, Literal, cast
+
+from newsletter_core.application.tools_support import (
+    ParsedSerperResponse,
+    SearchRequest,
+    build_serper_payload,
+    parse_serper_response,
+    select_serper_containers,
+)
+
+_SERPER_NEWS_URL: Final[str] = "https://google.serper.dev/news"
+
+
+@dataclass(frozen=True)
+class SerperSearchPlan:
+    """Precomputed request data for one legacy Serper keyword search."""
+
+    keyword: str
+    num_results: int
+    url: str
+    headers: dict[str, str]
+    payload: str
+
+
+@dataclass(frozen=True)
+class SerperDebugEntry:
+    """Raw-response debug details preserved for legacy logging."""
+
+    index: int
+    item_keys: tuple[str, ...]
+    raw_date: Any
+    raw_published_at: Any
+
+
+@dataclass(frozen=True)
+class SerperKeywordReport:
+    """Structured success payload for one keyword search."""
+
+    keyword: str
+    parsed_response: ParsedSerperResponse
+    raw_keys: tuple[str, ...]
+    debug_entries: tuple[SerperDebugEntry, ...]
+    response_preview: str | None
+
+    @property
+    def articles(self) -> list[dict[str, Any]]:
+        return self.parsed_response.articles
+
+    @property
+    def article_count(self) -> int:
+        return len(self.parsed_response.articles)
+
+    @property
+    def container_names(self) -> tuple[str, ...]:
+        return self.parsed_response.container_names
+
+    @property
+    def container_count(self) -> int:
+        return self.parsed_response.container_count
+
+
+@dataclass(frozen=True)
+class SerperKeywordFailure:
+    """Structured failure payload for one keyword search."""
+
+    keyword: str
+    error_kind: Literal["request", "json"]
+    message: str
+    response_text: str | None = None
+
+
+@dataclass(frozen=True)
+class SerperLogMessage:
+    """Structured log message for the legacy wrapper."""
+
+    level: Literal["info", "warning", "debug", "error"]
+    message: str
+
+
+@dataclass(frozen=True)
+class SerperSearchSummary:
+    """Aggregated search results for the legacy wrapper."""
+
+    keyword_article_counts: dict[str, int]
+    all_articles: list[dict[str, Any]]
+
+
+class SerperSearchRequestError(Exception):
+    """Raised when the legacy wrapper cannot execute the HTTP request."""
+
+
+class SerperSearchResponseDecodeError(Exception):
+    """Raised when the legacy wrapper cannot decode the JSON response."""
+
+    def __init__(self, response_text: str) -> None:
+        super().__init__("Failed to decode Serper response JSON.")
+        self.response_text = response_text
+
+
+SerperSearchExecutor = Callable[[SerperSearchPlan], Mapping[str, Any]]
+
+
+def build_serper_search_plans(
+    search_request: SearchRequest,
+    *,
+    api_key: str,
+) -> tuple[SerperSearchPlan, ...]:
+    """Build stable per-keyword request plans for the legacy wrapper."""
+
+    return tuple(
+        SerperSearchPlan(
+            keyword=keyword,
+            num_results=search_request.num_results,
+            url=_SERPER_NEWS_URL,
+            headers={
+                "X-API-KEY": api_key,
+                "Content-Type": "application/json",
+            },
+            payload=build_serper_payload(keyword, search_request.num_results),
+        )
+        for keyword in search_request.keywords
+    )
+
+
+def _build_debug_entries(
+    results: Mapping[str, Any],
+) -> tuple[SerperDebugEntry, ...]:
+    container_items, _ = select_serper_containers(results)
+    debug_entries: list[SerperDebugEntry] = []
+
+    for index, raw_item in enumerate(container_items[:3]):
+        if not isinstance(raw_item, Mapping):
+            continue
+
+        item = cast(Mapping[str, Any], raw_item)
+        debug_entries.append(
+            SerperDebugEntry(
+                index=index,
+                item_keys=tuple(str(key) for key in item.keys()),
+                raw_date=item.get("date"),
+                raw_published_at=item.get("publishedAt"),
+            )
+        )
+
+    return tuple(debug_entries)
+
+
+def execute_serper_search_plan(
+    search_plan: SerperSearchPlan,
+    *,
+    executor: SerperSearchExecutor,
+) -> SerperKeywordReport | SerperKeywordFailure:
+    """Execute one keyword plan via an injected legacy HTTP executor."""
+
+    try:
+        results = executor(search_plan)
+    except SerperSearchRequestError as exc:
+        return SerperKeywordFailure(
+            keyword=search_plan.keyword,
+            error_kind="request",
+            message=str(exc),
+        )
+    except SerperSearchResponseDecodeError as exc:
+        return SerperKeywordFailure(
+            keyword=search_plan.keyword,
+            error_kind="json",
+            message=str(exc),
+            response_text=exc.response_text,
+        )
+
+    return SerperKeywordReport(
+        keyword=search_plan.keyword,
+        parsed_response=parse_serper_response(results, search_plan.num_results),
+        raw_keys=tuple(str(key) for key in results.keys()),
+        debug_entries=_build_debug_entries(results),
+        response_preview=(
+            json.dumps(results, ensure_ascii=False)[:300]
+            if len(results.keys()) <= 3
+            else None
+        ),
+    )
+
+
+def summarize_serper_search_reports(
+    reports: Sequence[SerperKeywordReport],
+) -> SerperSearchSummary:
+    """Aggregate per-keyword reports for the legacy wrapper."""
+
+    keyword_article_counts = {
+        report.keyword: report.article_count for report in reports
+    }
+    all_articles = [article for report in reports for article in report.articles]
+
+    return SerperSearchSummary(
+        keyword_article_counts=keyword_article_counts,
+        all_articles=all_articles,
+    )
+
+
+def build_serper_keyword_log_messages(
+    search_report: SerperKeywordReport,
+) -> tuple[SerperLogMessage, ...]:
+    """Preserve legacy logging messages without keeping formatting in the wrapper."""
+
+    messages: list[SerperLogMessage] = [
+        SerperLogMessage(
+            level="info",
+            message=(
+                f"Found '{container_name}' results for keyword "
+                f"'{search_report.keyword}'"
+            ),
+        )
+        for container_name in search_report.container_names
+    ]
+    messages.append(
+        SerperLogMessage(
+            level="info",
+            message=f"Total container items found: {search_report.container_count}",
+        )
+    )
+
+    if not search_report.container_count and search_report.raw_keys:
+        messages.append(
+            SerperLogMessage(
+                level="warning",
+                message=(
+                    "Warning: No result containers found. Available keys: "
+                    f"{list(search_report.raw_keys)}"
+                ),
+            )
+        )
+        if search_report.response_preview is not None:
+            messages.append(
+                SerperLogMessage(
+                    level="warning",
+                    message=f"Response structure: {search_report.response_preview}...",
+                )
+            )
+
+    for debug_entry in search_report.debug_entries:
+        messages.append(
+            SerperLogMessage(
+                level="debug",
+                message=(
+                    f"Debug: Item keys (index: {debug_entry.index}): "
+                    f"{list(debug_entry.item_keys)}"
+                ),
+            )
+        )
+        messages.append(
+            SerperLogMessage(
+                level="debug",
+                message=(
+                    "Debug: Date value: "
+                    f"'{debug_entry.raw_date}' / PublishedAt: "
+                    f"'{debug_entry.raw_published_at}'"
+                ),
+            )
+        )
+
+    if not search_report.articles:
+        messages.append(
+            SerperLogMessage(
+                level="warning",
+                message=(
+                    "No articles could be parsed for keyword "
+                    f"'{search_report.keyword}'."
+                ),
+            )
+        )
+
+    messages.append(
+        SerperLogMessage(
+            level="info",
+            message=(
+                f"Found {search_report.article_count} articles for keyword: "
+                f"'{search_report.keyword}'"
+            ),
+        )
+    )
+    return tuple(messages)
+
+
+def build_serper_failure_log_messages(
+    search_failure: SerperKeywordFailure,
+) -> tuple[SerperLogMessage, ...]:
+    """Preserve legacy Serper error logging without reintroducing side effects."""
+
+    if search_failure.error_kind == "request":
+        return (
+            SerperLogMessage(
+                level="error",
+                message=(
+                    "Error fetching articles for keyword "
+                    f"'{search_failure.keyword}' from Serper.dev: "
+                    f"{search_failure.message}"
+                ),
+            ),
+        )
+
+    response_text = search_failure.response_text or ""
+    return (
+        SerperLogMessage(
+            level="error",
+            message=(
+                "Error decoding JSON response for keyword "
+                f"'{search_failure.keyword}' from Serper.dev. Response: "
+                f"{response_text}"
+            ),
+        ),
+    )
+
+
+__all__ = [
+    "SerperDebugEntry",
+    "SerperKeywordFailure",
+    "SerperKeywordReport",
+    "SerperLogMessage",
+    "SerperSearchExecutor",
+    "SerperSearchPlan",
+    "SerperSearchRequestError",
+    "SerperSearchResponseDecodeError",
+    "SerperSearchSummary",
+    "build_serper_failure_log_messages",
+    "build_serper_keyword_log_messages",
+    "build_serper_search_plans",
+    "execute_serper_search_plan",
+    "summarize_serper_search_reports",
+]

--- a/newsletter_core/application/tools_support.py
+++ b/newsletter_core/application/tools_support.py
@@ -49,7 +49,7 @@ def build_serper_payload(keyword: str, num_results: int) -> str:
     return json.dumps({"q": keyword, "gl": "kr", "num": num_results})
 
 
-def _select_serper_containers(
+def select_serper_containers(
     results: Mapping[str, Any]
 ) -> tuple[list[Any], tuple[str, ...]]:
     containers: list[Any] = []
@@ -89,7 +89,7 @@ def parse_serper_response(
 ) -> ParsedSerperResponse:
     """Parse the Serper response while preserving legacy container precedence."""
 
-    containers, container_names = _select_serper_containers(results)
+    containers, container_names = select_serper_containers(results)
     articles = [
         shape_serper_article(cast(Mapping[str, Any], item))
         for item in containers[: min(num_results, len(containers))]
@@ -204,5 +204,6 @@ __all__ = [
     "resolve_filename_theme",
     "resolve_search_request",
     "sanitize_filename",
+    "select_serper_containers",
     "shape_serper_article",
 ]

--- a/tests/unit_tests/test_tools_search_flow.py
+++ b/tests/unit_tests/test_tools_search_flow.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import newsletter.tools as tools_module
+from newsletter import config
+from newsletter_core.application.tools_search_flow import (
+    SerperKeywordFailure,
+    SerperKeywordReport,
+    SerperLogMessage,
+    SerperSearchPlan,
+    SerperSearchRequestError,
+    SerperSearchResponseDecodeError,
+    SerperSearchSummary,
+    build_serper_failure_log_messages,
+    build_serper_keyword_log_messages,
+    build_serper_search_plans,
+    execute_serper_search_plan,
+    summarize_serper_search_reports,
+)
+from newsletter_core.application.tools_support import (
+    ParsedSerperResponse,
+    SearchRequest,
+)
+
+
+def test_build_serper_search_plans_preserves_keyword_order_and_request_shape() -> None:
+    plans = build_serper_search_plans(
+        SearchRequest(keywords=("AI", "반도체"), num_results=3),
+        api_key="dummy-serper-key",
+    )
+
+    assert [plan.keyword for plan in plans] == ["AI", "반도체"]
+    assert plans[0].url == "https://google.serper.dev/news"
+    assert plans[0].headers == {
+        "X-API-KEY": "dummy-serper-key",
+        "Content-Type": "application/json",
+    }
+    assert plans[0].payload == '{"q": "AI", "gl": "kr", "num": 3}'
+
+
+def test_execute_serper_search_plan_returns_report_with_debug_entries() -> None:
+    search_plan = SerperSearchPlan(
+        keyword="AI",
+        num_results=2,
+        url="https://google.serper.dev/news",
+        headers={"X-API-KEY": "dummy", "Content-Type": "application/json"},
+        payload='{"q": "AI"}',
+    )
+
+    report = execute_serper_search_plan(
+        search_plan,
+        executor=lambda _: {
+            "news": [
+                {
+                    "title": "AI 제목",
+                    "link": "https://example.com/ai",
+                    "snippet": "AI 요약",
+                    "source": "AI Source",
+                    "date": "2026-03-11",
+                }
+            ],
+            "topStories": [],
+            "organic": [],
+        },
+    )
+
+    assert isinstance(report, SerperKeywordReport)
+    assert report.keyword == "AI"
+    assert report.container_names == ("news", "topStories")
+    assert report.container_count == 1
+    assert report.article_count == 1
+    assert report.debug_entries[0].item_keys == (
+        "title",
+        "link",
+        "snippet",
+        "source",
+        "date",
+    )
+    assert report.response_preview is not None
+    assert '"title": "AI 제목"' in report.response_preview
+
+
+def test_execute_serper_search_plan_returns_request_failure() -> None:
+    search_plan = SerperSearchPlan(
+        keyword="AI",
+        num_results=2,
+        url="https://google.serper.dev/news",
+        headers={"X-API-KEY": "dummy", "Content-Type": "application/json"},
+        payload='{"q": "AI"}',
+    )
+
+    failure = execute_serper_search_plan(
+        search_plan,
+        executor=lambda _: (_ for _ in ()).throw(
+            SerperSearchRequestError("network boom")
+        ),
+    )
+
+    assert failure == SerperKeywordFailure(
+        keyword="AI",
+        error_kind="request",
+        message="network boom",
+        response_text=None,
+    )
+
+
+def test_execute_serper_search_plan_returns_json_failure() -> None:
+    search_plan = SerperSearchPlan(
+        keyword="AI",
+        num_results=2,
+        url="https://google.serper.dev/news",
+        headers={"X-API-KEY": "dummy", "Content-Type": "application/json"},
+        payload='{"q": "AI"}',
+    )
+
+    failure = execute_serper_search_plan(
+        search_plan,
+        executor=lambda _: (_ for _ in ()).throw(
+            SerperSearchResponseDecodeError("raw body")
+        ),
+    )
+
+    assert failure == SerperKeywordFailure(
+        keyword="AI",
+        error_kind="json",
+        message="Failed to decode Serper response JSON.",
+        response_text="raw body",
+    )
+
+
+def test_summarize_serper_search_reports_aggregates_articles_and_counts() -> None:
+    reports = (
+        SerperKeywordReport(
+            keyword="AI",
+            parsed_response=ParsedSerperResponse(
+                articles=[
+                    {
+                        "title": "AI 기사",
+                        "url": "https://example.com/ai",
+                        "link": "https://example.com/ai",
+                        "snippet": "AI",
+                        "source": "테스트",
+                        "date": "2026-03-11",
+                    }
+                ],
+                container_names=("news",),
+                container_count=1,
+            ),
+            raw_keys=("news",),
+            debug_entries=(),
+            response_preview='{"news": []}',
+        ),
+        SerperKeywordReport(
+            keyword="반도체",
+            parsed_response=ParsedSerperResponse(
+                articles=[],
+                container_names=("news",),
+                container_count=0,
+            ),
+            raw_keys=("news",),
+            debug_entries=(),
+            response_preview='{"news": []}',
+        ),
+    )
+
+    summary = summarize_serper_search_reports(reports)
+
+    assert summary == SerperSearchSummary(
+        keyword_article_counts={"AI": 1, "반도체": 0},
+        all_articles=[
+            {
+                "title": "AI 기사",
+                "url": "https://example.com/ai",
+                "link": "https://example.com/ai",
+                "snippet": "AI",
+                "source": "테스트",
+                "date": "2026-03-11",
+            }
+        ],
+    )
+
+
+def test_build_serper_keyword_log_messages_preserves_legacy_strings() -> None:
+    report = SerperKeywordReport(
+        keyword="AI",
+        parsed_response=ParsedSerperResponse(
+            articles=[],
+            container_names=("news",),
+            container_count=0,
+        ),
+        raw_keys=("news", "topStories"),
+        debug_entries=(),
+        response_preview='{"news": [], "topStories": []}',
+    )
+
+    messages = build_serper_keyword_log_messages(report)
+
+    assert messages == (
+        SerperLogMessage(
+            level="info",
+            message="Found 'news' results for keyword 'AI'",
+        ),
+        SerperLogMessage(
+            level="info",
+            message="Total container items found: 0",
+        ),
+        SerperLogMessage(
+            level="warning",
+            message="Warning: No result containers found. Available keys: ['news', 'topStories']",
+        ),
+        SerperLogMessage(
+            level="warning",
+            message='Response structure: {"news": [], "topStories": []}...',
+        ),
+        SerperLogMessage(
+            level="warning",
+            message="No articles could be parsed for keyword 'AI'.",
+        ),
+        SerperLogMessage(
+            level="info",
+            message="Found 0 articles for keyword: 'AI'",
+        ),
+    )
+
+
+def test_build_serper_failure_log_messages_preserves_error_path() -> None:
+    assert build_serper_failure_log_messages(
+        SerperKeywordFailure(
+            keyword="AI",
+            error_kind="json",
+            message="Failed to decode Serper response JSON.",
+            response_text="raw body",
+        )
+    ) == (
+        SerperLogMessage(
+            level="error",
+            message=(
+                "Error decoding JSON response for keyword "
+                "'AI' from Serper.dev. Response: raw body"
+            ),
+        ),
+    )
+
+
+def test_legacy_search_news_articles_delegates_to_core_search_flow(
+    monkeypatch,
+) -> None:
+    calls: dict[str, object] = {}
+
+    monkeypatch.setattr(config, "SERPER_API_KEY", "dummy-tools-key")
+
+    def fake_resolve_search_request(keywords: str, num_results: int) -> SearchRequest:
+        calls["raw_request"] = (keywords, num_results)
+        return SearchRequest(keywords=("정제된 키워드",), num_results=3)
+
+    def fake_build_serper_search_plans(
+        search_request: SearchRequest, *, api_key: str
+    ) -> tuple[SerperSearchPlan, ...]:
+        calls["search_request"] = search_request
+        calls["api_key"] = api_key
+        return (
+            SerperSearchPlan(
+                keyword="정제된 키워드",
+                num_results=3,
+                url="https://example.com/serper",
+                headers={"X-API-KEY": api_key},
+                payload='{"q": "정제된 키워드"}',
+            ),
+        )
+
+    def fake_execute_serper_search_plan(
+        search_plan: SerperSearchPlan,
+        *,
+        executor,
+    ) -> SerperKeywordReport:
+        calls["search_plan"] = search_plan
+        calls["executor"] = executor
+        return SerperKeywordReport(
+            keyword="정제된 키워드",
+            parsed_response=ParsedSerperResponse(
+                articles=[
+                    {
+                        "title": "정제된 기사",
+                        "url": "https://example.com/article",
+                        "link": "https://example.com/article",
+                        "snippet": "요약",
+                        "source": "테스트 소스",
+                        "date": "2026-03-11",
+                    }
+                ],
+                container_names=("news",),
+                container_count=1,
+            ),
+            raw_keys=("news",),
+            debug_entries=(),
+            response_preview='{"news": [{"title": "정제된 기사"}]}',
+        )
+
+    def fake_summarize_serper_search_reports(
+        reports: tuple[SerperKeywordReport, ...] | list[SerperKeywordReport],
+    ) -> SerperSearchSummary:
+        calls["reports"] = list(reports)
+        return SerperSearchSummary(
+            keyword_article_counts={"정제된 키워드": 1},
+            all_articles=[
+                {
+                    "title": "정제된 기사",
+                    "url": "https://example.com/article",
+                    "link": "https://example.com/article",
+                    "snippet": "요약",
+                    "source": "테스트 소스",
+                    "date": "2026-03-11",
+                }
+            ],
+        )
+
+    monkeypatch.setattr(
+        tools_module, "resolve_search_request", fake_resolve_search_request
+    )
+    monkeypatch.setattr(
+        tools_module, "build_serper_search_plans", fake_build_serper_search_plans
+    )
+    monkeypatch.setattr(
+        tools_module, "execute_serper_search_plan", fake_execute_serper_search_plan
+    )
+    monkeypatch.setattr(
+        tools_module,
+        "summarize_serper_search_reports",
+        fake_summarize_serper_search_reports,
+    )
+
+    result = tools_module.search_news_articles.invoke(
+        {"keywords": "원본 키워드", "num_results": 99}
+    )
+
+    assert calls["raw_request"] == ("원본 키워드", 99)
+    assert calls["search_request"] == SearchRequest(
+        keywords=("정제된 키워드",), num_results=3
+    )
+    assert calls["api_key"] == "dummy-tools-key"
+    assert calls["search_plan"] == SerperSearchPlan(
+        keyword="정제된 키워드",
+        num_results=3,
+        url="https://example.com/serper",
+        headers={"X-API-KEY": "dummy-tools-key"},
+        payload='{"q": "정제된 키워드"}',
+    )
+    assert calls["executor"] is tools_module._execute_serper_search_request
+    assert calls["reports"] == [
+        SerperKeywordReport(
+            keyword="정제된 키워드",
+            parsed_response=ParsedSerperResponse(
+                articles=[
+                    {
+                        "title": "정제된 기사",
+                        "url": "https://example.com/article",
+                        "link": "https://example.com/article",
+                        "snippet": "요약",
+                        "source": "테스트 소스",
+                        "date": "2026-03-11",
+                    }
+                ],
+                container_names=("news",),
+                container_count=1,
+            ),
+            raw_keys=("news",),
+            debug_entries=(),
+            response_preview='{"news": [{"title": "정제된 기사"}]}',
+        )
+    ]
+    assert result == [
+        {
+            "title": "정제된 기사",
+            "url": "https://example.com/article",
+            "link": "https://example.com/article",
+            "snippet": "요약",
+            "source": "테스트 소스",
+            "date": "2026-03-11",
+        }
+    ]

--- a/tests/unit_tests/test_tools_support_helpers.py
+++ b/tests/unit_tests/test_tools_support_helpers.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-from unittest.mock import Mock
-
 import newsletter.tools as tools_module
-from newsletter import config
 from newsletter_core.application.tools_support import (
-    ParsedSerperResponse,
     SearchRequest,
     extract_common_theme_fallback,
     parse_generated_keywords,
@@ -140,75 +136,6 @@ def test_resolve_filename_theme_uses_extractor_only_for_multi_keyword_inputs() -
         == "직접도메인"
     )
     assert calls == [["AI", "반도체"], "AI, 반도체"]
-
-
-def test_legacy_search_news_articles_delegates_to_core_helpers(
-    monkeypatch,
-) -> None:
-    search_calls: list[tuple[str, int]] = []
-    payload_calls: list[tuple[str, int]] = []
-    parse_calls: list[tuple[dict[str, object], int]] = []
-
-    monkeypatch.setattr(config, "SERPER_API_KEY", "dummy-tools-key")
-
-    def fake_resolve_search_request(keywords: str, num_results: int) -> SearchRequest:
-        search_calls.append((keywords, num_results))
-        return SearchRequest(keywords=("정제된 키워드",), num_results=3)
-
-    def fake_build_serper_payload(keyword: str, num_results: int) -> str:
-        payload_calls.append((keyword, num_results))
-        return '{"q": "정제된 키워드", "num": 3}'
-
-    def fake_parse_serper_response(
-        results: dict[str, object],
-        num_results: int,
-    ) -> ParsedSerperResponse:
-        parse_calls.append((results, num_results))
-        return ParsedSerperResponse(
-            articles=[
-                {
-                    "title": "정제된 기사",
-                    "url": "https://example.com/article",
-                    "link": "https://example.com/article",
-                    "snippet": "요약",
-                    "source": "테스트 소스",
-                    "date": "2026-03-11",
-                }
-            ],
-            container_names=("news",),
-            container_count=1,
-        )
-
-    response = Mock()
-    response.raise_for_status = Mock()
-    response.json.return_value = {"news": [{"title": "raw"}]}
-
-    monkeypatch.setattr(
-        tools_module, "resolve_search_request", fake_resolve_search_request
-    )
-    monkeypatch.setattr(tools_module, "build_serper_payload", fake_build_serper_payload)
-    monkeypatch.setattr(
-        tools_module, "parse_serper_response", fake_parse_serper_response
-    )
-    monkeypatch.setattr(tools_module.requests, "request", Mock(return_value=response))
-
-    result = tools_module.search_news_articles.invoke(
-        {"keywords": "원본 키워드", "num_results": 99}
-    )
-
-    assert search_calls == [("원본 키워드", 99)]
-    assert payload_calls == [("정제된 키워드", 3)]
-    assert parse_calls == [({"news": [{"title": "raw"}]}, 3)]
-    assert result == [
-        {
-            "title": "정제된 기사",
-            "url": "https://example.com/article",
-            "link": "https://example.com/article",
-            "snippet": "요약",
-            "source": "테스트 소스",
-            "date": "2026-03-11",
-        }
-    ]
 
 
 def test_legacy_get_filename_safe_theme_delegates_to_core_helpers(


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- extract Serper search-flow composition and response orchestration from `newsletter/tools.py` into `newsletter_core/application/tools_search_flow.py`
- keep raw `requests` execution and other HTML/file/LLM runtime glue in the legacy wrapper while shrinking the legacy search surface

## Scope
### In Scope
- `newsletter/tools.py` search-flow decomposition
- new `newsletter_core` search orchestration helpers for request plans, per-keyword result handling, log-message shaping, and aggregate summaries
- unit/contract coverage for the new search boundary and legacy delegation
- minimal architecture note update for the new boundary

### Out of Scope
- HTML parsing extraction
- file output extraction
- LLM/runtime glue extraction
- changes to `newsletter/graph.py`, `newsletter/llm_factory.py`, `web/routes_generation.py`, scheduler/web/release/packaging
- Serper provider/retry/timeout/ranking semantics changes

## Delivery Unit
- RR: #316
- Delivery Unit ID: DU-20260311-tools-search-orchestration
- Merge Boundary: search orchestration extraction for `newsletter/tools.py`
- Rollback Boundary: revert the single squash merge commit for this PR

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): tools search-flow unit tests, import-side-effect regression, Serper/tools regression suite

### Commands and Results
```bash
.local/venv/bin/python -m pytest tests/unit_tests/test_tools_support_helpers.py tests/unit_tests/test_tools_search_flow.py tests/unit_tests/test_config_import_side_effects.py -q
# 23 passed

SERPER_API_KEY=dummy_tools_key .local/venv/bin/python -m pytest tests/unit_tests/test_theme_extraction.py tests/unit_tests/test_filename_generation.py tests/test_themes.py tests/test_serper_api.py tests/api_tests/test_improved_search.py tests/test_suggest.py -q
# 24 passed

make check
# passed

make check-full
# passed
```

## Risk & Rollback
- Risk: `search_news_articles` now routes per-keyword aggregation, failure shaping, and log-message composition through the new core boundary
- Rollback: revert the squash merge commit to restore the previous legacy search orchestration path

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 해당 없음
- Outbox/send_key 중복 방지 결과: 해당 없음
- import-time side effect 제거 여부: 유지, 신규 import-time side effect 없음

## Not Run (with reason)
- Deployment pipeline validation: PR required gate가 아니며 merge 후 GitHub Actions에서 별도 확인
