### PR TITLE
Extract raw Serper request execution boundary from legacy newsletter/tools.py into newsletter_core infrastructure

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@ class LLMFactory:
 - 현재 provider/model 선택, 설정 정규화, provider info shaping 같은 순수 결정 로직은 `newsletter_core/application/llm_factory.py` 로 이관되었고, fallback runtime 설정 정규화, fallback chain 구성, retry/error helper 같은 orchestration helper는 `newsletter_core/application/llm_factory_fallback.py` 로 이동했습니다.
 - provider SDK 생성, env/API key 접근, provider 초기화 입력 조립 같은 runtime adapter 책임은 `newsletter_core/infrastructure/llm_factory_runtime.py` 로 이동했습니다.
 - `newsletter/llm_factory.py` 는 fallback/singleton entrypoint와 legacy import path 호환을 담당하는 thin compatibility boundary로 유지됩니다.
-- `newsletter/tools.py` 는 여전히 legacy integration surface이지만, Serper 입력 정규화/결과 shaping과 theme/filename 순수 helper는 `newsletter_core/application/tools_support.py` 로, request plan/response orchestration/aggregation helper는 `newsletter_core/application/tools_search_flow.py` 로 이동했고 실제 network/HTML/LLM glue만 legacy wrapper에 남깁니다.
+- `newsletter/tools.py` 는 여전히 legacy integration surface이지만, Serper 입력 정규화/결과 shaping과 theme/filename 순수 helper는 `newsletter_core/application/tools_support.py` 로, request plan/response orchestration/aggregation helper는 `newsletter_core/application/tools_search_flow.py` 로, raw Serper request execution/status normalization은 `newsletter_core/infrastructure/tools_search_runtime.py` 로 이동했고 HTML/file/LLM/app-context glue만 legacy wrapper에 남깁니다.
 
 ### 0.3. 자동 Fallback 시스템
 

--- a/newsletter/tools.py
+++ b/newsletter/tools.py
@@ -3,7 +3,6 @@ Newsletter Generator - Custom Tools
 이 모듈은 뉴스레터 생성을 위한 LangChain 도구를 정의합니다.
 """
 
-import json
 import logging
 import os
 from typing import Any, Dict, List, cast
@@ -21,9 +20,6 @@ from newsletter_core.application.tools_search_flow import (
     SerperKeywordFailure,
     SerperKeywordReport,
     SerperLogMessage,
-    SerperSearchPlan,
-    SerperSearchRequestError,
-    SerperSearchResponseDecodeError,
     build_serper_failure_log_messages,
     build_serper_keyword_log_messages,
     build_serper_search_plans,
@@ -37,6 +33,9 @@ from newsletter_core.application.tools_support import (
     resolve_search_request,
     sanitize_filename,
 )
+from newsletter_core.infrastructure.tools_search_runtime import (
+    execute_serper_search_request,
+)
 
 from . import config
 from .html_utils import clean_html_markers
@@ -45,28 +44,6 @@ from .utils.logger import get_logger, show_collection_brief
 
 # 로거 초기화
 logger = get_logger()
-
-
-def _execute_serper_search_request(
-    search_plan: SerperSearchPlan,
-) -> dict[str, Any]:
-    try:
-        response = requests.request(
-            "POST",
-            search_plan.url,
-            headers=search_plan.headers,
-            data=search_plan.payload,
-        )
-        response.raise_for_status()
-    except requests.exceptions.RequestException as exc:
-        raise SerperSearchRequestError(str(exc)) from exc
-
-    try:
-        raw_results = response.json()
-    except json.JSONDecodeError as exc:
-        raise SerperSearchResponseDecodeError(response.text) from exc
-
-    return cast(dict[str, Any], raw_results)
 
 
 def _emit_serper_log_messages(log_messages: list[SerperLogMessage]) -> None:
@@ -99,7 +76,7 @@ def search_news_articles(keywords: str, num_results: int = 10) -> List[Dict]:
         logger.info(f"Searching articles for keyword: '{search_plan.keyword}'")
         keyword_result = execute_serper_search_plan(
             search_plan,
-            executor=_execute_serper_search_request,
+            executor=execute_serper_search_request,
         )
 
         if isinstance(keyword_result, SerperKeywordFailure):
@@ -436,7 +413,7 @@ def extract_common_theme_from_keywords(
 
     if not has_any_api_key:
         logger.warning("API 키가 없습니다. 테마 추출을 위한 간단한 대체 방법을 사용합니다.")
-        return extract_common_theme_fallback(keywords)
+        return str(extract_common_theme_fallback(keywords))
 
     try:
         # LLM 팩토리를 사용하여 테마 추출에 최적화된 모델 사용
@@ -481,7 +458,7 @@ def extract_common_theme_from_keywords(
             # Check if API key is available before trying Gemini fallback
             if not api_key:
                 logger.warning("GEMINI_API_KEY를 찾을 수 없습니다. 테마 추출을 위한 간단한 대체 방법을 사용합니다.")
-                return extract_common_theme_fallback(keywords)
+                return str(extract_common_theme_fallback(keywords))
 
         # Fallback using LangChain Google GenAI
         from langchain_core.messages import HumanMessage as FallbackHumanMessage
@@ -511,11 +488,11 @@ def extract_common_theme_from_keywords(
 
         except Exception as llm_error:
             logger.warning(f"LLM factory를 통한 테마 추출이 실패했습니다: {llm_error}")
-            return extract_common_theme_fallback(keywords)
+            return str(extract_common_theme_fallback(keywords))
 
     except Exception as e:
         logger.error(f"테마 추출 중 오류 발생: {e}")
-        return extract_common_theme_fallback(keywords)
+        return str(extract_common_theme_fallback(keywords))
 
 
 def get_filename_safe_theme(keywords: Any, domain: str | None = None) -> str:
@@ -534,7 +511,7 @@ def get_filename_safe_theme(keywords: Any, domain: str | None = None) -> str:
         domain,
         theme_extractor=extract_common_theme_from_keywords,
     )
-    return sanitize_filename(theme)
+    return str(sanitize_filename(theme))
 
 
 def regenerate_section_with_gemini(section_title: str, news_links: list) -> list:

--- a/newsletter_core/infrastructure/tools_search_runtime.py
+++ b/newsletter_core/infrastructure/tools_search_runtime.py
@@ -1,0 +1,65 @@
+"""Runtime adapter helpers for the legacy newsletter.tools search boundary."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any, cast
+
+import requests  # type: ignore[import-untyped]
+
+from newsletter_core.application.tools_search_flow import (
+    SerperSearchPlan,
+    SerperSearchRequestError,
+    SerperSearchResponseDecodeError,
+)
+
+SerperRequestCallable = Callable[..., Any]
+
+
+def build_serper_request_kwargs(search_plan: SerperSearchPlan) -> dict[str, Any]:
+    """Preserve the legacy raw request shape for one Serper search plan."""
+
+    return {
+        "method": "POST",
+        "url": search_plan.url,
+        "headers": search_plan.headers,
+        "data": search_plan.payload,
+    }
+
+
+def decode_serper_response_json(response: Any) -> dict[str, Any]:
+    """Decode one Serper response body without changing legacy error semantics."""
+
+    try:
+        raw_results = response.json()
+    except json.JSONDecodeError as exc:
+        response_text = getattr(response, "text", "")
+        raise SerperSearchResponseDecodeError(response_text) from exc
+
+    return cast(dict[str, Any], raw_results)
+
+
+def execute_serper_search_request(
+    search_plan: SerperSearchPlan,
+    *,
+    request: SerperRequestCallable | None = None,
+) -> dict[str, Any]:
+    """Execute one Serper search plan through the infrastructure boundary."""
+
+    request_callable = request or requests.request
+    try:
+        response = request_callable(**build_serper_request_kwargs(search_plan))
+        response.raise_for_status()
+    except requests.exceptions.RequestException as exc:
+        raise SerperSearchRequestError(str(exc)) from exc
+
+    return decode_serper_response_json(response)
+
+
+__all__ = [
+    "SerperRequestCallable",
+    "build_serper_request_kwargs",
+    "decode_serper_response_json",
+    "execute_serper_search_request",
+]

--- a/tests/api_tests/test_improved_search.py
+++ b/tests/api_tests/test_improved_search.py
@@ -10,10 +10,10 @@ from unittest.mock import MagicMock, patch
 # 프로젝트 루트 디렉토리를 sys.path에 추가
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from newsletter import config
+from newsletter import config  # noqa: E402
 
 # 테스트할 모듈 임포트
-from newsletter.tools import search_news_articles
+from newsletter.tools import search_news_articles  # noqa: E402
 
 
 class TestImprovedSearch(unittest.TestCase):
@@ -31,7 +31,7 @@ class TestImprovedSearch(unittest.TestCase):
         elif hasattr(config, "SERPER_API_KEY"):
             del config.SERPER_API_KEY  # 원래 키가 없었다면 삭제
 
-    @patch("newsletter.tools.requests.request")
+    @patch("newsletter_core.infrastructure.tools_search_runtime.requests.request")
     def test_improved_search_functionality(self, mock_request):
         """수정된 search_news_articles 함수의 기본 기능 테스트"""
         # 모의(mock) API 응답 설정
@@ -77,24 +77,18 @@ class TestImprovedSearch(unittest.TestCase):
 
             # 첫 번째 결과의 필요한 속성 확인
             first_article = articles[0]
-            self.assertIsInstance(
-                first_article, dict, "기사 항목이 딕셔너리가 아닙니다"
-            )
+            self.assertIsInstance(first_article, dict, "기사 항목이 딕셔너리가 아닙니다")
 
             # 필수 속성 확인
             required_fields = ["title", "link"]
             for field in required_fields:
-                self.assertIn(
-                    field, first_article, f"기사에 필수 필드 {field}가 없습니다"
-                )
-                self.assertIsNotNone(
-                    first_article[field], f"기사의 {field} 필드가 None입니다"
-                )
+                self.assertIn(field, first_article, f"기사에 필수 필드 {field}가 없습니다")
+                self.assertIsNotNone(first_article[field], f"기사의 {field} 필드가 None입니다")
                 self.assertNotEqual(
                     first_article[field], "", f"기사의 {field} 필드가 비어 있습니다"
                 )
 
-    @patch("newsletter.tools.requests.request")
+    @patch("newsletter_core.infrastructure.tools_search_runtime.requests.request")
     def test_multiple_keywords(self, mock_request):
         """여러 키워드로 검색하는 기능 테스트"""
         # 모의(mock) API 응답 설정 (키워드별로 다른 응답을 줄 수 있도록 side_effect 사용 가능)

--- a/tests/test_serper_api.py
+++ b/tests/test_serper_api.py
@@ -3,7 +3,6 @@ Serper.dev API 통합 테스트
 - 뉴스 검색 API 호출 및 응답 처리 검증
 """
 
-import json
 import os
 import sys
 import unittest
@@ -13,7 +12,7 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # tools 모듈에서 뉴스 검색 함수 import
-from newsletter.tools import search_news_articles
+from newsletter.tools import search_news_articles  # noqa: E402
 
 
 class TestSerperApi(unittest.TestCase):
@@ -41,19 +40,13 @@ class TestSerperApi(unittest.TestCase):
 
             # 첫 번째 결과의 필요한 속성 확인
             first_article = articles[0]
-            self.assertIsInstance(
-                first_article, dict, "기사 항목이 딕셔너리가 아닙니다"
-            )
+            self.assertIsInstance(first_article, dict, "기사 항목이 딕셔너리가 아닙니다")
 
             # 필수 속성 확인
             required_fields = ["title", "link"]
             for field in required_fields:
-                self.assertIn(
-                    field, first_article, f"기사에 필수 필드 {field}가 없습니다"
-                )
-                self.assertIsNotNone(
-                    first_article[field], f"기사의 {field} 필드가 None입니다"
-                )
+                self.assertIn(field, first_article, f"기사에 필수 필드 {field}가 없습니다")
+                self.assertIsNotNone(first_article[field], f"기사의 {field} 필드가 None입니다")
                 self.assertNotEqual(
                     first_article[field], "", f"기사의 {field} 필드가 비어 있습니다"
                 )
@@ -62,7 +55,7 @@ class TestSerperApi(unittest.TestCase):
 class TestSerperApiMock(unittest.TestCase):
     """Serper.dev API 모의 호출 테스트"""
 
-    @patch("newsletter.tools.requests.request")
+    @patch("newsletter_core.infrastructure.tools_search_runtime.requests.request")
     def test_search_news_articles_api_call(self, mock_request):
         """search_news_articles 함수가 올바른 API 호출을 하는지 테스트합니다"""
         # 모의 응답 생성
@@ -89,15 +82,11 @@ class TestSerperApiMock(unittest.TestCase):
 
         # 호출 인자 검증
         call_args = mock_request.call_args
-        self.assertIn(
-            "data", call_args[1], "API 호출이 JSON 데이터를 포함하지 않습니다"
-        )
+        self.assertIn("data", call_args[1], "API 호출이 JSON 데이터를 포함하지 않습니다")
 
         # 결과 검증
         self.assertEqual(len(articles), 1, "예상된 기사 수와 일치하지 않습니다")
-        self.assertEqual(
-            articles[0]["title"], "테스트 기사 제목", "기사 제목이 일치하지 않습니다"
-        )
+        self.assertEqual(articles[0]["title"], "테스트 기사 제목", "기사 제목이 일치하지 않습니다")
         self.assertEqual(
             articles[0]["link"],
             "https://example.com/article1",

--- a/tests/unit_tests/test_tools_search_flow.py
+++ b/tests/unit_tests/test_tools_search_flow.py
@@ -344,7 +344,7 @@ def test_legacy_search_news_articles_delegates_to_core_search_flow(
         headers={"X-API-KEY": "dummy-tools-key"},
         payload='{"q": "정제된 키워드"}',
     )
-    assert calls["executor"] is tools_module._execute_serper_search_request
+    assert calls["executor"] is tools_module.execute_serper_search_request
     assert calls["reports"] == [
         SerperKeywordReport(
             keyword="정제된 키워드",

--- a/tests/unit_tests/test_tools_search_runtime.py
+++ b/tests/unit_tests/test_tools_search_runtime.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import requests
+
+import newsletter_core.infrastructure.tools_search_runtime as runtime_adapters
+from newsletter_core.application.tools_search_flow import SerperSearchPlan
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        payload: Any = None,
+        text: str = "",
+        status_error: Exception | None = None,
+    ) -> None:
+        self.payload = payload
+        self.text = text
+        self.status_error = status_error
+
+    def raise_for_status(self) -> None:
+        if self.status_error is not None:
+            raise self.status_error
+
+    def json(self) -> Any:
+        if isinstance(self.payload, Exception):
+            raise self.payload
+        return self.payload
+
+
+def test_build_serper_request_kwargs_preserves_legacy_request_shape() -> None:
+    search_plan = SerperSearchPlan(
+        keyword="AI",
+        num_results=3,
+        url="https://google.serper.dev/news",
+        headers={"X-API-KEY": "dummy", "Content-Type": "application/json"},
+        payload='{"q": "AI", "gl": "kr", "num": 3}',
+    )
+
+    assert runtime_adapters.build_serper_request_kwargs(search_plan) == {
+        "method": "POST",
+        "url": "https://google.serper.dev/news",
+        "headers": {
+            "X-API-KEY": "dummy",
+            "Content-Type": "application/json",
+        },
+        "data": '{"q": "AI", "gl": "kr", "num": 3}',
+    }
+
+
+def test_execute_serper_search_request_calls_request_and_decodes_json() -> None:
+    calls: dict[str, Any] = {}
+    search_plan = SerperSearchPlan(
+        keyword="AI",
+        num_results=3,
+        url="https://google.serper.dev/news",
+        headers={"X-API-KEY": "dummy", "Content-Type": "application/json"},
+        payload='{"q": "AI", "gl": "kr", "num": 3}',
+    )
+
+    def fake_request(**kwargs: Any) -> _FakeResponse:
+        calls.update(kwargs)
+        return _FakeResponse(payload={"news": [{"title": "AI"}]})
+
+    results = runtime_adapters.execute_serper_search_request(
+        search_plan,
+        request=fake_request,
+    )
+
+    assert calls == {
+        "method": "POST",
+        "url": "https://google.serper.dev/news",
+        "headers": {
+            "X-API-KEY": "dummy",
+            "Content-Type": "application/json",
+        },
+        "data": '{"q": "AI", "gl": "kr", "num": 3}',
+    }
+    assert results == {"news": [{"title": "AI"}]}
+
+
+def test_execute_serper_search_request_normalizes_request_errors() -> None:
+    search_plan = SerperSearchPlan(
+        keyword="AI",
+        num_results=3,
+        url="https://google.serper.dev/news",
+        headers={"X-API-KEY": "dummy", "Content-Type": "application/json"},
+        payload='{"q": "AI"}',
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        runtime_adapters.execute_serper_search_request(
+            search_plan,
+            request=lambda **_kwargs: (_ for _ in ()).throw(
+                requests.exceptions.Timeout("timed out")
+            ),
+        )
+
+    assert type(exc_info.value).__name__ == "SerperSearchRequestError"
+    assert str(exc_info.value) == "timed out"
+
+
+def test_execute_serper_search_request_normalizes_http_status_errors() -> None:
+    search_plan = SerperSearchPlan(
+        keyword="AI",
+        num_results=3,
+        url="https://google.serper.dev/news",
+        headers={"X-API-KEY": "dummy", "Content-Type": "application/json"},
+        payload='{"q": "AI"}',
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        runtime_adapters.execute_serper_search_request(
+            search_plan,
+            request=lambda **_kwargs: _FakeResponse(
+                status_error=requests.exceptions.HTTPError("503 server error")
+            ),
+        )
+
+    assert type(exc_info.value).__name__ == "SerperSearchRequestError"
+    assert str(exc_info.value) == "503 server error"
+
+
+def test_decode_serper_response_json_normalizes_json_error() -> None:
+    response = _FakeResponse(
+        payload=json.JSONDecodeError("bad json", "{}", 0),
+        text="not-json",
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        runtime_adapters.decode_serper_response_json(response)
+
+    assert type(exc_info.value).__name__ == "SerperSearchResponseDecodeError"
+    assert str(exc_info.value) == "Failed to decode Serper response JSON."
+    assert exc_info.value.response_text == "not-json"


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Extract raw Serper request execution from `newsletter/tools.py` into `newsletter_core/infrastructure/tools_search_runtime.py`.
- Keep the legacy tool surface stable while reducing `tools.py` to a thinner compatibility/integration shell.

## Scope
### In Scope
- add Serper runtime execution adapter in `newsletter_core/infrastructure`
- delegate legacy `search_news_articles()` execution seam to the new adapter
- align runtime/search tests and architecture note with the moved boundary

### Out of Scope
- HTML parsing, file IO, LLM/runtime glue, app/runtime context extraction
- changes to `newsletter/graph.py`, `newsletter/llm_factory.py`, `web/routes_generation.py`
- provider/timeout/retry/ranking semantics changes

## Delivery Unit
- RR: #318
- Delivery Unit ID: DU-20260311-tools-search-runtime
- Merge Boundary: tools raw Serper execution boundary extraction only
- Rollback Boundary: revert this PR squash commit

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): runtime adapter, import-side-effect, serper/tools regression suites

### Commands and Results
```bash
.local/venv/bin/python -m pytest tests/unit_tests/test_tools_support_helpers.py tests/unit_tests/test_tools_search_flow.py -q
# 15 passed

.local/venv/bin/python -m pytest tests/unit_tests/test_tools_search_runtime.py -q
# 5 passed

.local/venv/bin/python -m pytest tests/unit_tests/test_config_import_side_effects.py -q
# 8 passed

SERPER_API_KEY=dummy_tools_key .local/venv/bin/python -m pytest tests/unit_tests/test_theme_extraction.py tests/unit_tests/test_filename_generation.py tests/test_themes.py tests/test_serper_api.py tests/api_tests/test_improved_search.py tests/test_suggest.py -q
# 24 passed

make check
# passed

make check-full
# passed
```

## Risk & Rollback
- Risk: Serper request/error handling could drift at the moved runtime seam if adapter semantics diverge.
- Rollback: revert the merge commit, or restore the legacy request helper in `newsletter/tools.py`.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 해당 없음
- Outbox/send_key 중복 방지 결과: 해당 없음
- import-time side effect 제거 여부: 신규 side effect 없음, 기존 금지 계약 유지

## Not Run (with reason)
- None
