### PR TITLE
Extract node-level graph transformation helpers from legacy newsletter/graph.py into newsletter_core

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,7 +52,7 @@ class LLMFactory:
 - provider SDK 생성, env/API key 접근, provider 초기화 입력 조립 같은 runtime adapter 책임은 `newsletter_core/infrastructure/llm_factory_runtime.py` 로 이동했습니다.
 - `newsletter/llm_factory.py` 는 fallback/singleton entrypoint와 legacy import path 호환을 담당하는 thin compatibility boundary로 유지됩니다.
 - `newsletter/tools.py` 는 여전히 legacy integration surface이지만, Serper 입력 정규화/결과 shaping과 theme/filename 순수 helper는 `newsletter_core/application/tools_support.py` 로, request plan/response orchestration/aggregation helper는 `newsletter_core/application/tools_search_flow.py` 로, raw Serper request execution/status normalization은 `newsletter_core/infrastructure/tools_search_runtime.py` 로 이동했고 HTML/file/LLM/app-context glue만 legacy wrapper에 남깁니다.
-- `newsletter/graph.py` 는 여전히 legacy runtime shell이지만, state 초기화, branch routing, summary result normalization, final result shaping 같은 graph application helper는 `newsletter_core/application/graph_workflow.py` 로 이동했고 node IO/file/runtime glue와 LangGraph wiring만 legacy 경계에 남깁니다.
+- `newsletter/graph.py` 는 여전히 legacy runtime shell이지만, state 초기화, branch routing, summary result normalization, final result shaping은 `newsletter_core/application/graph_workflow.py` 로, collect/process/score/summarize/compose node 내부의 transformation/state-update helper는 `newsletter_core/application/graph_node_helpers.py` 로 이동했고 node IO/file/runtime glue와 LangGraph wiring만 legacy 경계에 남깁니다.
 
 ### 0.3. 자동 Fallback 시스템
 

--- a/newsletter/graph.py
+++ b/newsletter/graph.py
@@ -6,11 +6,34 @@ Newsletter Generator - LangGraph Workflow
 import json
 import os
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 from langgraph.graph import END, StateGraph
 
+from newsletter_core.application.graph_node_helpers import (
+    build_collect_error_state,
+    build_collect_keyword_query,
+    build_collect_success_state,
+    build_compose_error_state,
+    build_compose_missing_data_state,
+    build_compose_success_state,
+    build_process_missing_articles_state,
+    build_process_success_state,
+    build_score_error_state,
+    build_score_missing_articles_state,
+    build_score_success_state,
+    build_summarize_error_state,
+    build_summarize_missing_articles_state,
+    build_summarize_success_state,
+    filter_articles_for_processing,
+    resolve_compose_html,
+    resolve_graph_domain_slug,
+    resolve_graph_keywords_slug,
+    resolve_scoring_domain,
+    resolve_summary_chain_style,
+    sort_articles_by_graph_date_desc,
+)
 from newsletter_core.application.graph_workflow import (
     NewsletterState,
     build_generation_info,
@@ -76,32 +99,25 @@ def collect_articles_node(
 
     try:
         # 기존 Serper API 방식 사용
-        keyword_str = ", ".join(state["keywords"])
+        keyword_str = build_collect_keyword_query(state["keywords"])
         articles = search_news_articles.invoke(
             {"keywords": keyword_str, "num_results": 10}
         )
 
         logger.info(f"Serper API에서 {len(articles)}개 기사 수집 완료")
 
-        step_times = state.get("step_times", {})
-        step_times["collect_articles"] = time.time() - start_time
-        return {
-            **state,
-            "collected_articles": articles,
-            "status": "processing",  # Next status is processing
-            "step_times": step_times,
-        }
+        return build_collect_success_state(
+            state,
+            articles=articles,
+            elapsed=time.time() - start_time,
+        )
     except Exception as e:
         logger.error(f"[red]Error during article collection: {e}[/red]")
-        step_times = state.get("step_times", {})
-        step_times["collect_articles"] = time.time() - start_time
-        return {
-            **state,
-            "collected_articles": [],  # Ensure it's an empty list on error
-            "error": f"기사 수집 중 오류 발생: {str(e)}",
-            "status": "error",
-            "step_times": step_times,
-        }
+        return build_collect_error_state(
+            state,
+            error_message=f"기사 수집 중 오류 발생: {str(e)}",
+            elapsed=time.time() - start_time,
+        )
 
 
 # New node for processing articles
@@ -119,12 +135,7 @@ def process_articles_node(state: NewsletterState) -> NewsletterState:
         logger.warning(
             "[yellow]Warning: No articles found to process. Check if collection was successful.[/yellow]"
         )
-        return {
-            **state,
-            "processed_articles": [],
-            "status": "error",
-            "error": "수집된 기사가 없습니다.",
-        }
+        return build_process_missing_articles_state(state)
 
     logger.info(
         f"Processing {len(collected_articles)} articles with {state.get('news_period_days', 7)} day filter..."
@@ -132,12 +143,7 @@ def process_articles_node(state: NewsletterState) -> NewsletterState:
 
     # Save raw articles with unified naming
     try:
-        domain_value = state.get("domain")
-        domain_str = (
-            domain_value.replace(" ", "_")
-            if isinstance(domain_value, str) and domain_value
-            else "general"
-        )
+        domain_str = resolve_graph_domain_slug(state)
 
         # 중간 파일용 파일명 생성 (단순히 타임스탬프 + 설명적 이름 사용)
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -152,39 +158,11 @@ def process_articles_node(state: NewsletterState) -> NewsletterState:
     except Exception as e:
         logger.warning(f"Warning: Failed to save raw articles: {e}")
 
-    # 1. 날짜 기반 필터링
-    articles_within_date_range = []
-    articles_with_missing_date = []
-    articles_with_unparseable_date = []
-    articles_with_date = 0
-    articles_unparseable_date = 0
-    cutoff_date = datetime.now(timezone.utc) - timedelta(
-        days=state.get("news_period_days", 7)
-    )
-
     initial_count = len(collected_articles)
-
-    for article in collected_articles:
-        date_str = article.get("date")
-        if not date_str or date_str == "날짜 없음":
-            articles_with_missing_date.append(article)
-            continue
-
-        parsed_date = parse_article_date_for_graph(date_str)
-        if parsed_date is None:
-            articles_unparseable_date += 1
-            articles_with_unparseable_date.append(article)
-            continue
-
-        articles_with_date += 1
-        if parsed_date >= cutoff_date:
-            articles_within_date_range.append(article)
-
-    # Combine kept articles (recent + missing + unparseable dates)
-    filtered_articles = (
-        articles_within_date_range
-        + articles_with_missing_date
-        + articles_with_unparseable_date
+    filtered_articles = filter_articles_for_processing(
+        collected_articles,
+        news_period_days=state.get("news_period_days", 7),
+        current_time=datetime.now().astimezone(),
     )
 
     show_filter_brief(initial_count, len(filtered_articles), "날짜 필터링")
@@ -211,24 +189,16 @@ def process_articles_node(state: NewsletterState) -> NewsletterState:
         )
         processed_articles_sorted = []
     else:
-        # Article sorting
-        processed_articles_sorted = sorted(
-            deduplicated_articles,
-            key=lambda x: parse_article_date_for_graph(x.get("date", ""))
-            or datetime.min.replace(tzinfo=timezone.utc),
-            reverse=True,
+        processed_articles_sorted = sort_articles_by_graph_date_desc(
+            deduplicated_articles
         )
 
     step_result("기사 처리 완료", len(processed_articles_sorted))
-
-    step_times = state.get("step_times", {})
-    step_times["process_articles"] = time.time() - start_time
-    return {
-        **state,
-        "processed_articles": processed_articles_sorted,
-        "status": "scoring",  # Next step is scoring
-        "step_times": step_times,
-    }
+    return build_process_success_state(
+        state,
+        processed_articles=processed_articles_sorted,
+        elapsed=time.time() - start_time,
+    )
 
 
 def score_articles_node(state: NewsletterState) -> NewsletterState:
@@ -243,15 +213,10 @@ def score_articles_node(state: NewsletterState) -> NewsletterState:
     processed_articles = state.get("processed_articles", [])
     if not processed_articles:
         logger.warning("[yellow]No articles to score.[/yellow]")
-        step_times = state.get("step_times", {})
-        step_times["score_articles"] = time.time() - start_time
-        return {
-            **state,
-            "ranked_articles": [],
-            "status": "error",
-            "error": "스코어링할 기사가 없습니다.",
-            "step_times": step_times,
-        }
+        return build_score_missing_articles_state(
+            state,
+            elapsed=time.time() - start_time,
+        )
 
     try:
         from . import scoring
@@ -261,7 +226,7 @@ def score_articles_node(state: NewsletterState) -> NewsletterState:
         logger.info(f"[cyan]Using scoring weights: {scoring_weights}[/cyan]")
 
         # 도메인/주제 결정
-        domain = state.get("domain", "") or ", ".join(state.get("keywords", []))
+        domain = resolve_scoring_domain(state)
 
         # 기사 스코어링
         ranked_articles = scoring.score_articles(
@@ -272,12 +237,7 @@ def score_articles_node(state: NewsletterState) -> NewsletterState:
 
         # 파일 저장
         try:
-            domain_value = state.get("domain")
-            domain_str = (
-                domain_value.replace(" ", "_")
-                if isinstance(domain_value, str) and domain_value
-                else "general"
-            )
+            domain_str = resolve_graph_domain_slug(state)
 
             # 중간 파일용 파일명 생성 (단순히 타임스탬프 + 설명적 이름 사용)
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -292,27 +252,19 @@ def score_articles_node(state: NewsletterState) -> NewsletterState:
         except Exception as e:
             logger.warning(f"Warning: Failed to save scored articles: {e}")
 
-        step_times = state.get("step_times", {})
-        step_times["score_articles"] = time.time() - start_time
-
-        return {
-            **state,
-            "ranked_articles": ranked_articles,
-            "status": "scoring_complete",
-            "step_times": step_times,
-        }
+        return build_score_success_state(
+            state,
+            ranked_articles=ranked_articles,
+            elapsed=time.time() - start_time,
+        )
 
     except Exception as e:
         logger.error(f"Error during article scoring: {e}")
-        step_times = state.get("step_times", {})
-        step_times["score_articles"] = time.time() - start_time
-        return {
-            **state,
-            "ranked_articles": [],
-            "status": "error",
-            "error": f"기사 스코어링 중 오류: {str(e)}",
-            "step_times": step_times,
-        }
+        return build_score_error_state(
+            state,
+            error_message=f"기사 스코어링 중 오류: {str(e)}",
+            elapsed=time.time() - start_time,
+        )
 
 
 def summarize_articles_node(state: NewsletterState) -> NewsletterState:
@@ -327,20 +279,13 @@ def summarize_articles_node(state: NewsletterState) -> NewsletterState:
     ranked_articles = state.get("ranked_articles", [])
     if not ranked_articles:
         logger.warning("[yellow]No articles to summarize.[/yellow]")
-        step_times = state.get("step_times", {})
-        step_times["summarize"] = time.time() - start_time
-        return {
-            **state,
-            "newsletter_html": None,
-            "status": "error",
-            "error": "요약할 기사가 없습니다.",
-            "step_times": step_times,
-        }
+        return build_summarize_missing_articles_state(
+            state,
+            elapsed=time.time() - start_time,
+        )
 
     try:
-        # 사용할 체인 결정
-        template_style = state.get("template_style", "detailed")
-        is_compact = template_style == "compact"
+        template_style, is_compact = resolve_summary_chain_style(state)
         newsletter_chain = get_newsletter_chain(is_compact=is_compact)
 
         # 체인 실행을 위한 데이터 준비
@@ -373,17 +318,13 @@ def summarize_articles_node(state: NewsletterState) -> NewsletterState:
             generated_at=datetime.now(),
         )
 
-        step_times = state.get("step_times", {})
-        step_times["summarize"] = time.time() - start_time
-
-        return {
-            **state,
-            "newsletter_html": newsletter_html,
-            "category_summaries": category_summaries,
-            "newsletter_topic": newsletter_topic,
-            "status": "summarizing_complete",
-            "step_times": step_times,
-        }
+        return build_summarize_success_state(
+            state,
+            newsletter_html=newsletter_html,
+            category_summaries=category_summaries,
+            newsletter_topic=newsletter_topic,
+            elapsed=time.time() - start_time,
+        )
 
     except Exception as e:
         logger.error(f"Error during article summarization: {e}")
@@ -391,15 +332,11 @@ def summarize_articles_node(state: NewsletterState) -> NewsletterState:
 
         logger.debug(f"Traceback: {traceback.format_exc()}")
 
-        step_times = state.get("step_times", {})
-        step_times["summarize"] = time.time() - start_time
-        return {
-            **state,
-            "newsletter_html": None,
-            "status": "error",
-            "error": f"기사 요약 중 오류: {str(e)}",
-            "step_times": step_times,
-        }
+        return build_summarize_error_state(
+            state,
+            error_message=f"기사 요약 중 오류: {str(e)}",
+            elapsed=time.time() - start_time,
+        )
 
 
 def compose_newsletter_node(state: NewsletterState) -> NewsletterState:
@@ -416,35 +353,21 @@ def compose_newsletter_node(state: NewsletterState) -> NewsletterState:
 
     if not category_summaries and not newsletter_html:
         logger.warning("[yellow]No category summaries to compose newsletter.[/yellow]")
-        step_times = state.get("step_times", {})
-        step_times["compose"] = time.time() - start_time
-        return {
-            **state,
-            "status": "error",
-            "error": "구성할 뉴스레터 데이터가 없습니다.",
-            "step_times": step_times,
-        }
+        return build_compose_missing_data_state(
+            state,
+            elapsed=time.time() - start_time,
+        )
 
     try:
         # 이미 체인에서 HTML이 생성된 경우 그대로 사용
         if newsletter_html:
             logger.info("[cyan]Using pre-generated HTML from chains[/cyan]")
-            final_html = newsletter_html
-        else:
-            # Fallback: 기존 로직으로 HTML 생성 (현재는 체인이 담당)
-            final_html = "<html><body>Newsletter generation failed</body></html>"
+        final_html = resolve_compose_html(newsletter_html)
 
         # 파일 저장
         try:
-            keywords_str = (
-                "_".join(state["keywords"]) if state["keywords"] else "unknown"
-            )
-            domain_value = state.get("domain")
-            domain_str = (
-                domain_value.replace(" ", "_")
-                if isinstance(domain_value, str) and domain_value
-                else "general"
-            )
+            keywords_str = resolve_graph_keywords_slug(state)
+            domain_str = resolve_graph_domain_slug(state)
             template_style = state.get("template_style", "detailed")
 
             # generate_unified_newsletter_filename이 이미 전체 경로를 반환함
@@ -464,26 +387,19 @@ def compose_newsletter_node(state: NewsletterState) -> NewsletterState:
         except Exception as e:
             logger.error(f"Error saving newsletter: {e}")
 
-        step_times = state.get("step_times", {})
-        step_times["compose"] = time.time() - start_time
-
-        return {
-            **state,
-            "newsletter_html": final_html,
-            "status": "complete",
-            "step_times": step_times,
-        }
+        return build_compose_success_state(
+            state,
+            newsletter_html=final_html,
+            elapsed=time.time() - start_time,
+        )
 
     except Exception as e:
         logger.error(f"Error composing newsletter: {e}")
-        step_times = state.get("step_times", {})
-        step_times["compose"] = time.time() - start_time
-        return {
-            **state,
-            "status": "error",
-            "error": f"뉴스레터 구성 중 오류: {str(e)}",
-            "step_times": step_times,
-        }
+        return build_compose_error_state(
+            state,
+            error_message=f"뉴스레터 구성 중 오류: {str(e)}",
+            elapsed=time.time() - start_time,
+        )
 
 
 def handle_error(state: NewsletterState) -> NewsletterState:

--- a/newsletter_core/application/graph_node_helpers.py
+++ b/newsletter_core/application/graph_node_helpers.py
@@ -1,0 +1,346 @@
+"""Node-level transformation helpers for the legacy newsletter graph."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, cast
+
+from newsletter_core.application.graph_workflow import (
+    NewsletterState,
+    parse_graph_article_date,
+)
+
+ArticleRecord = Dict[str, Any]
+
+_COMPOSE_FALLBACK_HTML = "<html><body>Newsletter generation failed</body></html>"
+
+
+def _with_step_time(
+    state: NewsletterState,
+    *,
+    step_name: str,
+    elapsed: float,
+    updates: Dict[str, Any],
+) -> NewsletterState:
+    step_times = dict(state.get("step_times", {}))
+    step_times[step_name] = elapsed
+
+    updated_state = dict(state)
+    updated_state.update(updates)
+    updated_state["step_times"] = step_times
+    return cast(NewsletterState, updated_state)
+
+
+def build_collect_keyword_query(keywords: List[str]) -> str:
+    """Build the legacy Serper query string from graph keywords."""
+    return ", ".join(keywords)
+
+
+def resolve_graph_domain_slug(state: NewsletterState) -> str:
+    """Resolve a stable domain slug for legacy intermediate output names."""
+    domain_value = state.get("domain")
+    if isinstance(domain_value, str) and domain_value:
+        return domain_value.replace(" ", "_")
+    return "general"
+
+
+def resolve_graph_keywords_slug(state: NewsletterState) -> str:
+    """Resolve a stable keyword slug for legacy output names."""
+    keywords = state.get("keywords", [])
+    return "_".join(keywords) if keywords else "unknown"
+
+
+def build_collect_success_state(
+    state: NewsletterState,
+    *,
+    articles: List[ArticleRecord],
+    elapsed: float,
+) -> NewsletterState:
+    """Update graph state after successful article collection."""
+    return _with_step_time(
+        state,
+        step_name="collect_articles",
+        elapsed=elapsed,
+        updates={
+            "collected_articles": articles,
+            "status": "processing",
+        },
+    )
+
+
+def build_collect_error_state(
+    state: NewsletterState,
+    *,
+    error_message: str,
+    elapsed: float,
+) -> NewsletterState:
+    """Update graph state after collection failure."""
+    return _with_step_time(
+        state,
+        step_name="collect_articles",
+        elapsed=elapsed,
+        updates={
+            "collected_articles": [],
+            "error": error_message,
+            "status": "error",
+        },
+    )
+
+
+def filter_articles_for_processing(
+    collected_articles: List[ArticleRecord],
+    *,
+    news_period_days: int,
+    current_time: datetime,
+) -> List[ArticleRecord]:
+    """Keep recent articles while preserving legacy missing-date fallbacks."""
+    articles_within_date_range: List[ArticleRecord] = []
+    articles_with_missing_date: List[ArticleRecord] = []
+    articles_with_unparseable_date: List[ArticleRecord] = []
+    cutoff_date = current_time - timedelta(days=news_period_days)
+
+    for article in collected_articles:
+        date_str = article.get("date")
+        if not date_str or date_str == "날짜 없음":
+            articles_with_missing_date.append(article)
+            continue
+
+        parsed_date = parse_graph_article_date(date_str)
+        if parsed_date is None:
+            articles_with_unparseable_date.append(article)
+            continue
+
+        if parsed_date >= cutoff_date:
+            articles_within_date_range.append(article)
+
+    return (
+        articles_within_date_range
+        + articles_with_missing_date
+        + articles_with_unparseable_date
+    )
+
+
+def sort_articles_by_graph_date_desc(
+    articles: List[ArticleRecord],
+) -> List[ArticleRecord]:
+    """Sort articles by parsed graph date, newest first."""
+    return sorted(
+        articles,
+        key=lambda article: parse_graph_article_date(article.get("date", ""))
+        or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+
+
+def build_process_missing_articles_state(state: NewsletterState) -> NewsletterState:
+    """Preserve the legacy early error state when no articles were collected."""
+    return cast(
+        NewsletterState,
+        {
+            **state,
+            "processed_articles": [],
+            "status": "error",
+            "error": "수집된 기사가 없습니다.",
+        },
+    )
+
+
+def build_process_success_state(
+    state: NewsletterState,
+    *,
+    processed_articles: List[ArticleRecord],
+    elapsed: float,
+) -> NewsletterState:
+    """Update graph state after processing completes."""
+    return _with_step_time(
+        state,
+        step_name="process_articles",
+        elapsed=elapsed,
+        updates={
+            "processed_articles": processed_articles,
+            "status": "scoring",
+        },
+    )
+
+
+def build_score_missing_articles_state(
+    state: NewsletterState,
+    *,
+    elapsed: float,
+) -> NewsletterState:
+    """Update graph state when scoring has no input articles."""
+    return _with_step_time(
+        state,
+        step_name="score_articles",
+        elapsed=elapsed,
+        updates={
+            "ranked_articles": [],
+            "status": "error",
+            "error": "스코어링할 기사가 없습니다.",
+        },
+    )
+
+
+def resolve_scoring_domain(state: NewsletterState) -> str:
+    """Resolve the effective scoring domain without touching runtime wiring."""
+    return state.get("domain", "") or ", ".join(state.get("keywords", []))
+
+
+def build_score_success_state(
+    state: NewsletterState,
+    *,
+    ranked_articles: List[ArticleRecord],
+    elapsed: float,
+) -> NewsletterState:
+    """Update graph state after scoring completes."""
+    return _with_step_time(
+        state,
+        step_name="score_articles",
+        elapsed=elapsed,
+        updates={
+            "ranked_articles": ranked_articles,
+            "status": "scoring_complete",
+        },
+    )
+
+
+def build_score_error_state(
+    state: NewsletterState,
+    *,
+    error_message: str,
+    elapsed: float,
+) -> NewsletterState:
+    """Update graph state after scoring failure."""
+    return _with_step_time(
+        state,
+        step_name="score_articles",
+        elapsed=elapsed,
+        updates={
+            "ranked_articles": [],
+            "status": "error",
+            "error": error_message,
+        },
+    )
+
+
+def resolve_summary_chain_style(state: NewsletterState) -> tuple[str, bool]:
+    """Resolve the template style and compact-mode flag for the summary node."""
+    template_style = state.get("template_style", "detailed")
+    return template_style, template_style == "compact"
+
+
+def build_summarize_missing_articles_state(
+    state: NewsletterState,
+    *,
+    elapsed: float,
+) -> NewsletterState:
+    """Update graph state when summarize has no ranked articles."""
+    return _with_step_time(
+        state,
+        step_name="summarize",
+        elapsed=elapsed,
+        updates={
+            "newsletter_html": None,
+            "status": "error",
+            "error": "요약할 기사가 없습니다.",
+        },
+    )
+
+
+def build_summarize_success_state(
+    state: NewsletterState,
+    *,
+    newsletter_html: str,
+    category_summaries: Dict[str, Any],
+    newsletter_topic: str,
+    elapsed: float,
+) -> NewsletterState:
+    """Update graph state after summary generation succeeds."""
+    return _with_step_time(
+        state,
+        step_name="summarize",
+        elapsed=elapsed,
+        updates={
+            "newsletter_html": newsletter_html,
+            "category_summaries": category_summaries,
+            "newsletter_topic": newsletter_topic,
+            "status": "summarizing_complete",
+        },
+    )
+
+
+def build_summarize_error_state(
+    state: NewsletterState,
+    *,
+    error_message: str,
+    elapsed: float,
+) -> NewsletterState:
+    """Update graph state after summary generation fails."""
+    return _with_step_time(
+        state,
+        step_name="summarize",
+        elapsed=elapsed,
+        updates={
+            "newsletter_html": None,
+            "status": "error",
+            "error": error_message,
+        },
+    )
+
+
+def resolve_compose_html(newsletter_html: Optional[str]) -> str:
+    """Resolve the final compose HTML while preserving the legacy fallback."""
+    return newsletter_html or _COMPOSE_FALLBACK_HTML
+
+
+def build_compose_missing_data_state(
+    state: NewsletterState,
+    *,
+    elapsed: float,
+) -> NewsletterState:
+    """Update graph state when compose has no HTML or summaries to use."""
+    return _with_step_time(
+        state,
+        step_name="compose",
+        elapsed=elapsed,
+        updates={
+            "status": "error",
+            "error": "구성할 뉴스레터 데이터가 없습니다.",
+        },
+    )
+
+
+def build_compose_success_state(
+    state: NewsletterState,
+    *,
+    newsletter_html: str,
+    elapsed: float,
+) -> NewsletterState:
+    """Update graph state after compose succeeds."""
+    return _with_step_time(
+        state,
+        step_name="compose",
+        elapsed=elapsed,
+        updates={
+            "newsletter_html": newsletter_html,
+            "status": "complete",
+        },
+    )
+
+
+def build_compose_error_state(
+    state: NewsletterState,
+    *,
+    error_message: str,
+    elapsed: float,
+) -> NewsletterState:
+    """Update graph state after compose fails."""
+    return _with_step_time(
+        state,
+        step_name="compose",
+        elapsed=elapsed,
+        updates={
+            "status": "error",
+            "error": error_message,
+        },
+    )

--- a/tests/unit_tests/test_config_import_side_effects.py
+++ b/tests/unit_tests/test_config_import_side_effects.py
@@ -19,6 +19,7 @@ def _clear_module_cache() -> None:
         "newsletter.settings",
         "newsletter.cli",
         "newsletter.graph",
+        "newsletter_core.application.graph_node_helpers",
         "newsletter.llm_factory",
         "newsletter_core.application.graph_workflow",
         "newsletter_core.public.settings",
@@ -236,4 +237,20 @@ def test_graph_workflow_helper_import_does_not_call_load_dotenv(
     monkeypatch.setattr(dotenv, "load_dotenv", _fake_load_dotenv)
     _clear_module_cache()
     importlib.import_module("newsletter_core.application.graph_workflow")
+    assert calls["count"] == 0
+
+
+@pytest.mark.unit
+def test_graph_node_helper_import_does_not_call_load_dotenv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"count": 0}
+
+    def _fake_load_dotenv(*_args, **_kwargs):
+        calls["count"] += 1
+        return False
+
+    monkeypatch.setattr(dotenv, "load_dotenv", _fake_load_dotenv)
+    _clear_module_cache()
+    importlib.import_module("newsletter_core.application.graph_node_helpers")
     assert calls["count"] == 0

--- a/tests/unit_tests/test_graph_node_helpers.py
+++ b/tests/unit_tests/test_graph_node_helpers.py
@@ -1,0 +1,293 @@
+"""Unit and delegation tests for extracted graph node helpers."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import newsletter.graph as graph_module
+from newsletter_core.application import graph_node_helpers
+
+
+def _make_state(**overrides):
+    state = {
+        "keywords": ["AI"],
+        "news_period_days": 7,
+        "domain": "AI",
+        "template_style": "compact",
+        "email_compatible": False,
+        "collected_articles": None,
+        "processed_articles": None,
+        "ranked_articles": None,
+        "article_summaries": None,
+        "category_summaries": None,
+        "newsletter_topic": "AI",
+        "newsletter_html": None,
+        "error": None,
+        "status": "collecting",
+        "start_time": 1.0,
+        "step_times": {},
+        "total_time": None,
+    }
+    state.update(overrides)
+    return state
+
+
+@pytest.mark.unit
+def test_collect_query_and_slug_helpers_preserve_legacy_format() -> None:
+    state = _make_state(domain="AI Mobility", keywords=["AI", "Battery"])
+
+    assert (
+        graph_node_helpers.build_collect_keyword_query(["AI", "Battery"])
+        == "AI, Battery"
+    )
+    assert graph_node_helpers.resolve_graph_domain_slug(state) == "AI_Mobility"
+    assert graph_node_helpers.resolve_graph_keywords_slug(state) == "AI_Battery"
+    assert (
+        graph_node_helpers.resolve_graph_domain_slug(_make_state(domain=None))
+        == "general"
+    )
+
+
+@pytest.mark.unit
+def test_filter_articles_for_processing_keeps_recent_missing_and_unparseable() -> None:
+    current_time = datetime(2026, 3, 11, 12, 0, tzinfo=timezone.utc)
+    filtered = graph_node_helpers.filter_articles_for_processing(
+        [
+            {"title": "recent", "date": "2026-03-10T10:00:00Z"},
+            {"title": "old", "date": "2026-02-20T10:00:00Z"},
+            {"title": "missing", "date": "날짜 없음"},
+            {"title": "bad", "date": "not-a-date"},
+        ],
+        news_period_days=7,
+        current_time=current_time,
+    )
+
+    assert [article["title"] for article in filtered] == ["recent", "missing", "bad"]
+
+
+@pytest.mark.unit
+def test_sort_articles_by_graph_date_desc_matches_legacy_ordering() -> None:
+    sorted_articles = graph_node_helpers.sort_articles_by_graph_date_desc(
+        [
+            {"title": "older", "date": "2026-03-09T09:00:00Z"},
+            {"title": "missing", "date": "날짜 없음"},
+            {"title": "newer", "date": "2026-03-10T09:00:00Z"},
+        ]
+    )
+
+    assert [article["title"] for article in sorted_articles] == [
+        "newer",
+        "older",
+        "missing",
+    ]
+
+
+@pytest.mark.unit
+def test_state_builders_preserve_node_status_and_step_times() -> None:
+    collect_state = graph_node_helpers.build_collect_success_state(
+        _make_state(), articles=[{"title": "A"}], elapsed=1.2
+    )
+    score_error_state = graph_node_helpers.build_score_error_state(
+        _make_state(status="scoring"),
+        error_message="broken",
+        elapsed=2.5,
+    )
+    summarize_state = graph_node_helpers.build_summarize_success_state(
+        _make_state(status="scoring_complete"),
+        newsletter_html="<html>ok</html>",
+        category_summaries={"sections": []},
+        newsletter_topic="AI Weekly",
+        elapsed=3.5,
+    )
+    compose_state = graph_node_helpers.build_compose_success_state(
+        _make_state(status="summarizing_complete"),
+        newsletter_html="<html>done</html>",
+        elapsed=4.0,
+    )
+
+    assert collect_state["status"] == "processing"
+    assert collect_state["step_times"]["collect_articles"] == 1.2
+    assert score_error_state["status"] == "error"
+    assert score_error_state["error"] == "broken"
+    assert score_error_state["step_times"]["score_articles"] == 2.5
+    assert summarize_state["status"] == "summarizing_complete"
+    assert summarize_state["newsletter_topic"] == "AI Weekly"
+    assert summarize_state["step_times"]["summarize"] == 3.5
+    assert compose_state["status"] == "complete"
+    assert compose_state["newsletter_html"] == "<html>done</html>"
+    assert compose_state["step_times"]["compose"] == 4.0
+
+
+@pytest.mark.unit
+def test_summary_and_compose_resolution_helpers_match_legacy_defaults() -> None:
+    assert graph_node_helpers.resolve_scoring_domain(_make_state(domain=None)) == "AI"
+    assert graph_node_helpers.resolve_summary_chain_style(_make_state()) == (
+        "compact",
+        True,
+    )
+    assert graph_node_helpers.resolve_summary_chain_style(
+        _make_state(template_style="detailed")
+    ) == ("detailed", False)
+    assert (
+        graph_node_helpers.resolve_compose_html("<html>ok</html>") == "<html>ok</html>"
+    )
+    assert (
+        graph_node_helpers.resolve_compose_html(None)
+        == "<html><body>Newsletter generation failed</body></html>"
+    )
+
+
+@pytest.mark.unit
+def test_collect_articles_node_delegates_keyword_and_state_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = {}
+    fake_tools = ModuleType("newsletter.tools")
+    fake_tools.search_news_articles = SimpleNamespace(
+        invoke=lambda payload: [{"title": "A", "payload": payload}]
+    )
+
+    monkeypatch.setitem(sys.modules, "newsletter.tools", fake_tools)
+
+    def _fake_keyword_query(keywords):
+        captured["keywords"] = keywords
+        return "AI"
+
+    monkeypatch.setattr(
+        graph_module, "build_collect_keyword_query", _fake_keyword_query
+    )
+
+    def _fake_collect_success(state, *, articles, elapsed):
+        captured["articles"] = articles
+        captured["elapsed"] = elapsed
+        return _make_state(
+            collected_articles=articles,
+            status="processing",
+            step_times={"collect_articles": elapsed},
+        )
+
+    monkeypatch.setattr(
+        graph_module,
+        "build_collect_success_state",
+        _fake_collect_success,
+    )
+
+    result = graph_module.collect_articles_node(_make_state())
+
+    assert captured["keywords"] == ["AI"]
+    assert result["status"] == "processing"
+    assert result["collected_articles"][0]["title"] == "A"
+
+
+@pytest.mark.unit
+def test_process_articles_node_delegates_filter_sort_and_state_helpers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    captured = {}
+    fake_article_filter = ModuleType("newsletter.article_filter")
+    fake_article_filter.remove_duplicate_articles = lambda articles: articles
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setitem(sys.modules, "newsletter.article_filter", fake_article_filter)
+
+    def _fake_filter(articles, *, news_period_days, current_time):
+        captured["filter"] = (
+            articles,
+            news_period_days,
+            current_time.tzinfo is not None,
+        )
+        return [{"title": "filtered", "date": "2026-03-10T09:00:00Z"}]
+
+    def _fake_sort(articles):
+        captured["sort"] = articles
+        return [{"title": "sorted", "date": "2026-03-10T09:00:00Z"}]
+
+    def _fake_success(state, *, processed_articles, elapsed):
+        captured["success"] = (processed_articles, elapsed)
+        return _make_state(
+            processed_articles=processed_articles,
+            status="scoring",
+            step_times={"process_articles": elapsed},
+        )
+
+    monkeypatch.setattr(graph_module, "filter_articles_for_processing", _fake_filter)
+    monkeypatch.setattr(graph_module, "sort_articles_by_graph_date_desc", _fake_sort)
+    monkeypatch.setattr(graph_module, "build_process_success_state", _fake_success)
+
+    result = graph_module.process_articles_node(
+        _make_state(
+            collected_articles=[{"title": "raw", "date": "2026-03-10T09:00:00Z"}]
+        )
+    )
+
+    assert captured["filter"][1] == 7
+    assert captured["filter"][2] is True
+    assert captured["sort"] == [{"title": "filtered", "date": "2026-03-10T09:00:00Z"}]
+    assert result["processed_articles"] == [
+        {"title": "sorted", "date": "2026-03-10T09:00:00Z"}
+    ]
+    assert result["status"] == "scoring"
+
+
+@pytest.mark.unit
+def test_summarize_articles_node_delegates_style_and_success_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_chain = MagicMock()
+    fake_chain.invoke.return_value = {"html": "<html>ok</html>"}
+    captured = {}
+
+    def _fake_resolve_style(state):
+        captured["style_state"] = state
+        return ("compact", True)
+
+    monkeypatch.setattr(
+        graph_module, "resolve_summary_chain_style", _fake_resolve_style
+    )
+    monkeypatch.setattr(
+        graph_module, "get_newsletter_chain", lambda is_compact: fake_chain
+    )
+    monkeypatch.setattr(
+        graph_module,
+        "normalize_summary_chain_result",
+        lambda result, **kwargs: (
+            "<html>ok</html>",
+            {"sections": [], "structured_data": {}},
+            "AI",
+        ),
+    )
+
+    def _fake_success(
+        state, *, newsletter_html, category_summaries, newsletter_topic, elapsed
+    ):
+        captured["success"] = (
+            newsletter_html,
+            category_summaries,
+            newsletter_topic,
+            elapsed,
+        )
+        return _make_state(
+            newsletter_html=newsletter_html,
+            category_summaries=category_summaries,
+            newsletter_topic=newsletter_topic,
+            status="summarizing_complete",
+            step_times={"summarize": elapsed},
+        )
+
+    monkeypatch.setattr(graph_module, "build_summarize_success_state", _fake_success)
+
+    result = graph_module.summarize_articles_node(
+        _make_state(
+            ranked_articles=[{"title": "A"}],
+            status="scoring_complete",
+        )
+    )
+
+    assert captured["style_state"]["template_style"] == "compact"
+    assert result["newsletter_html"] == "<html>ok</html>"
+    assert result["status"] == "summarizing_complete"


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Extract IO-free node transformation and state-update helpers from `newsletter/graph.py` into `newsletter_core/application/graph_node_helpers.py`.
- Reduce legacy graph responsibility while preserving LangGraph wiring, workflow ordering, node semantics, and runtime behavior.

## Scope
### In Scope
- Move collect/process/score/summarize/compose node helper logic into `newsletter_core`
- Delegate legacy graph nodes to the new helper boundary
- Add helper unit tests, delegation regression tests, and import-time side-effect coverage
- Update architecture docs for the new graph helper boundary

### Out of Scope
- LangGraph runtime wiring redesign
- External service or file IO extraction
- `newsletter/tools.py`, `newsletter/llm_factory.py`, `web/routes_generation.py`, scheduler, web, release, or packaging changes

## Delivery Unit
- RR: #322
- Delivery Unit ID: DU-20260311-graph-node-helper-extraction
- Merge Boundary: graph node helper extraction only (`newsletter/graph.py` -> `newsletter_core/application/graph_node_helpers.py` delegation)
- Rollback Boundary: revert commit `f59c05b`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): graph helper, graph regression, and import-side-effect coverage

### Commands and Results
```bash
.local/venv/bin/python -m pytest tests/unit_tests/test_graph_workflow_helpers.py -q
# 19 passed

.local/venv/bin/python -m pytest tests/unit_tests/test_graph_node_helpers.py -q
# 8 passed

.local/venv/bin/python -m pytest tests/unit_tests/test_config_import_side_effects.py -q
# 10 passed

TESTING=1 MOCK_MODE=1 GEMINI_API_KEY=dummy OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy .local/venv/bin/python -m pytest tests/test_graph_date_parser.py tests/test_newsletter_mocked.py tests/contract/test_generation_facade.py tests/api_tests/test_compact_newsletter_api.py -q
# 14 passed, 7 skipped

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: graph node helper delegation regressions inside collect/process/score/summarize/compose nodes
- Rollback: revert squash merge or revert commit `f59c05b` to restore the prior helper placement

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: not applicable
- Outbox/send_key 중복 방지 결과: not applicable
- import-time side effect 제거 여부: no new import-time side effects introduced; helper import is covered by regression tests

## Not Run (with reason)
- None
