### PR TITLE
Extract graph composition helpers around node invocation from legacy newsletter/graph.py into newsletter_core

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,7 +52,7 @@ class LLMFactory:
 - provider SDK 생성, env/API key 접근, provider 초기화 입력 조립 같은 runtime adapter 책임은 `newsletter_core/infrastructure/llm_factory_runtime.py` 로 이동했습니다.
 - `newsletter/llm_factory.py` 는 fallback/singleton entrypoint와 legacy import path 호환을 담당하는 thin compatibility boundary로 유지됩니다.
 - `newsletter/tools.py` 는 여전히 legacy integration surface이지만, Serper 입력 정규화/결과 shaping과 theme/filename 순수 helper는 `newsletter_core/application/tools_support.py` 로, request plan/response orchestration/aggregation helper는 `newsletter_core/application/tools_search_flow.py` 로, raw Serper request execution/status normalization은 `newsletter_core/infrastructure/tools_search_runtime.py` 로 이동했고 HTML/file/LLM/app-context glue만 legacy wrapper에 남깁니다.
-- `newsletter/graph.py` 는 여전히 legacy runtime shell이지만, state 초기화, branch routing, summary result normalization, final result shaping은 `newsletter_core/application/graph_workflow.py` 로, collect/process/score/summarize/compose node 내부의 transformation/state-update helper는 `newsletter_core/application/graph_node_helpers.py` 로 이동했고 node IO/file/runtime glue와 LangGraph wiring만 legacy 경계에 남깁니다.
+- `newsletter/graph.py` 는 여전히 legacy runtime shell이지만, state 초기화, branch routing, summary result normalization, final result shaping은 `newsletter_core/application/graph_workflow.py` 로, collect/process/score/summarize/compose node 내부의 transformation/state-update helper는 `newsletter_core/application/graph_node_helpers.py` 로, summarize invocation plan/result handoff와 compose/theme resolution 같은 invocation-adjacent composition helper는 `newsletter_core/application/graph_composition.py` 로 이동했고 node IO/file/runtime glue와 LangGraph wiring만 legacy 경계에 남깁니다.
 
 ### 0.3. 자동 Fallback 시스템
 

--- a/newsletter/graph.py
+++ b/newsletter/graph.py
@@ -11,6 +11,12 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 
 from langgraph.graph import END, StateGraph
 
+from newsletter_core.application.graph_composition import (
+    build_compose_persist_plan,
+    build_summarize_result_state,
+    build_summary_invocation_plan,
+    build_theme_resolution_plan,
+)
 from newsletter_core.application.graph_node_helpers import (
     build_collect_error_state,
     build_collect_keyword_query,
@@ -25,21 +31,15 @@ from newsletter_core.application.graph_node_helpers import (
     build_score_success_state,
     build_summarize_error_state,
     build_summarize_missing_articles_state,
-    build_summarize_success_state,
     filter_articles_for_processing,
-    resolve_compose_html,
     resolve_graph_domain_slug,
-    resolve_graph_keywords_slug,
     resolve_scoring_domain,
-    resolve_summary_chain_style,
     sort_articles_by_graph_date_desc,
 )
 from newsletter_core.application.graph_workflow import (
     NewsletterState,
     build_generation_info,
     build_initial_graph_state,
-    build_newsletter_chain_payload,
-    normalize_summary_chain_result,
     parse_graph_article_date,
     resolve_generation_result,
     route_after_collect,
@@ -285,44 +285,27 @@ def summarize_articles_node(state: NewsletterState) -> NewsletterState:
         )
 
     try:
-        template_style, is_compact = resolve_summary_chain_style(state)
-        newsletter_chain = get_newsletter_chain(is_compact=is_compact)
-
-        # 체인 실행을 위한 데이터 준비
-        chain_data = build_newsletter_chain_payload(
-            state, ranked_articles, template_style
-        )
+        summary_plan = build_summary_invocation_plan(state, ranked_articles)
+        newsletter_chain = get_newsletter_chain(is_compact=summary_plan["is_compact"])
 
         logger.info(
-            f"Generating newsletter using {template_style} style for {len(ranked_articles)} articles"
+            f"Generating newsletter using {summary_plan['template_style']} style for {summary_plan['article_count']} articles"
         )
 
         # 최종 활용 기사 수 표시
         show_final_brief(len(ranked_articles))
 
         # 체인 실행
-        result = newsletter_chain.invoke(chain_data)
+        result = newsletter_chain.invoke(summary_plan["chain_payload"])
 
         if isinstance(result, str):
             logger.info("[yellow]Received HTML string (legacy format)[/yellow]")
 
-        (
-            newsletter_html,
-            category_summaries,
-            newsletter_topic,
-        ) = normalize_summary_chain_result(
-            result,
-            state=state,
-            template_style=template_style,
-            article_count=len(ranked_articles),
-            generated_at=datetime.now(),
-        )
-
-        return build_summarize_success_state(
+        return build_summarize_result_state(
             state,
-            newsletter_html=newsletter_html,
-            category_summaries=category_summaries,
-            newsletter_topic=newsletter_topic,
+            result,
+            plan=summary_plan,
+            generated_at=datetime.now(),
             elapsed=time.time() - start_time,
         )
 
@@ -362,24 +345,23 @@ def compose_newsletter_node(state: NewsletterState) -> NewsletterState:
         # 이미 체인에서 HTML이 생성된 경우 그대로 사용
         if newsletter_html:
             logger.info("[cyan]Using pre-generated HTML from chains[/cyan]")
-        final_html = resolve_compose_html(newsletter_html)
+        compose_plan = build_compose_persist_plan(state, newsletter_html)
 
         # 파일 저장
         try:
-            keywords_str = resolve_graph_keywords_slug(state)
-            domain_str = resolve_graph_domain_slug(state)
-            template_style = state.get("template_style", "detailed")
-
             # generate_unified_newsletter_filename이 이미 전체 경로를 반환함
             file_path = generate_unified_newsletter_filename(
-                domain_str, f"newsletter_{template_style}", keywords_str, "html"
+                compose_plan["domain_slug"],
+                compose_plan["file_stem"],
+                compose_plan["keywords_slug"],
+                "html",
             )
 
             # 디렉토리 존재 확인 (파일 경로에서 디렉토리 부분 추출)
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
             with open(file_path, "w", encoding="utf-8") as f:
-                f.write(final_html)
+                f.write(compose_plan["final_html"])
 
             step_result("뉴스레터 저장 완료")
             logger.info(f"[green]Newsletter saved to {file_path}[/green]")
@@ -389,7 +371,7 @@ def compose_newsletter_node(state: NewsletterState) -> NewsletterState:
 
         return build_compose_success_state(
             state,
-            newsletter_html=final_html,
+            newsletter_html=compose_plan["final_html"],
             elapsed=time.time() - start_time,
         )
 
@@ -478,12 +460,9 @@ def generate_newsletter(
 
     # 뉴스레터 주제 결정 (도메인, 단일 키워드, 또는 공통 주제)
     theme_start = time.time()
-    newsletter_topic = ""
-    if domain:
-        newsletter_topic = domain  # 도메인이 있으면 도메인 사용
-    elif len(keywords) == 1:
-        newsletter_topic = keywords[0]  # 단일 키워드면 해당 키워드 사용
-    else:
+    topic_plan = build_theme_resolution_plan(keywords, domain)
+    newsletter_topic = topic_plan["newsletter_topic"]
+    if topic_plan["requires_theme_extraction"]:
         # 여러 키워드의 공통 주제 추출
         from .tools import extract_common_theme_from_keywords
 

--- a/newsletter_core/application/graph_composition.py
+++ b/newsletter_core/application/graph_composition.py
@@ -1,0 +1,124 @@
+"""Invocation-adjacent composition helpers for the legacy newsletter graph."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, TypedDict
+
+from newsletter_core.application.graph_node_helpers import (
+    build_summarize_success_state,
+    resolve_compose_html,
+    resolve_graph_domain_slug,
+    resolve_graph_keywords_slug,
+    resolve_summary_chain_style,
+)
+from newsletter_core.application.graph_workflow import (
+    NewsletterState,
+    build_newsletter_chain_payload,
+    normalize_summary_chain_result,
+)
+
+
+class SummaryInvocationPlan(TypedDict):
+    """Pure summary invocation inputs for the legacy summarize node."""
+
+    template_style: str
+    is_compact: bool
+    article_count: int
+    chain_payload: Dict[str, Any]
+
+
+class ComposePersistPlan(TypedDict):
+    """Pure compose persistence inputs for the legacy compose node."""
+
+    final_html: str
+    domain_slug: str
+    keywords_slug: str
+    file_stem: str
+
+
+class ThemeResolutionPlan(TypedDict):
+    """Pure theme selection decision for generate_newsletter()."""
+
+    newsletter_topic: str
+    requires_theme_extraction: bool
+
+
+def build_summary_invocation_plan(
+    state: NewsletterState,
+    ranked_articles: List[Dict[str, Any]],
+) -> SummaryInvocationPlan:
+    """Assemble the summarize-node invocation inputs without invoking the chain."""
+    template_style, is_compact = resolve_summary_chain_style(state)
+    return {
+        "template_style": template_style,
+        "is_compact": is_compact,
+        "article_count": len(ranked_articles),
+        "chain_payload": build_newsletter_chain_payload(
+            state, ranked_articles, template_style
+        ),
+    }
+
+
+def build_summarize_result_state(
+    state: NewsletterState,
+    result: Any,
+    *,
+    plan: SummaryInvocationPlan,
+    generated_at: datetime,
+    elapsed: float,
+) -> NewsletterState:
+    """Convert a summary chain result into the legacy summarize-node state update."""
+    (
+        newsletter_html,
+        category_summaries,
+        newsletter_topic,
+    ) = normalize_summary_chain_result(
+        result,
+        state=state,
+        template_style=plan["template_style"],
+        article_count=plan["article_count"],
+        generated_at=generated_at,
+    )
+    return build_summarize_success_state(
+        state,
+        newsletter_html=newsletter_html,
+        category_summaries=category_summaries,
+        newsletter_topic=newsletter_topic,
+        elapsed=elapsed,
+    )
+
+
+def build_compose_persist_plan(
+    state: NewsletterState,
+    newsletter_html: Optional[str],
+) -> ComposePersistPlan:
+    """Build the non-IO compose persistence inputs around the legacy file write."""
+    template_style = state.get("template_style", "detailed")
+    return {
+        "final_html": resolve_compose_html(newsletter_html),
+        "domain_slug": resolve_graph_domain_slug(state),
+        "keywords_slug": resolve_graph_keywords_slug(state),
+        "file_stem": f"newsletter_{template_style}",
+    }
+
+
+def build_theme_resolution_plan(
+    keywords: List[str],
+    domain: Optional[str],
+) -> ThemeResolutionPlan:
+    """Resolve whether generate_newsletter() needs theme extraction."""
+    if domain:
+        return {
+            "newsletter_topic": domain,
+            "requires_theme_extraction": False,
+        }
+    if len(keywords) == 1:
+        return {
+            "newsletter_topic": keywords[0],
+            "requires_theme_extraction": False,
+        }
+    return {
+        "newsletter_topic": "",
+        "requires_theme_extraction": True,
+    }

--- a/tests/unit_tests/test_config_import_side_effects.py
+++ b/tests/unit_tests/test_config_import_side_effects.py
@@ -19,6 +19,7 @@ def _clear_module_cache() -> None:
         "newsletter.settings",
         "newsletter.cli",
         "newsletter.graph",
+        "newsletter_core.application.graph_composition",
         "newsletter_core.application.graph_node_helpers",
         "newsletter.llm_factory",
         "newsletter_core.application.graph_workflow",
@@ -253,4 +254,20 @@ def test_graph_node_helper_import_does_not_call_load_dotenv(
     monkeypatch.setattr(dotenv, "load_dotenv", _fake_load_dotenv)
     _clear_module_cache()
     importlib.import_module("newsletter_core.application.graph_node_helpers")
+    assert calls["count"] == 0
+
+
+@pytest.mark.unit
+def test_graph_composition_helper_import_does_not_call_load_dotenv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"count": 0}
+
+    def _fake_load_dotenv(*_args, **_kwargs):
+        calls["count"] += 1
+        return False
+
+    monkeypatch.setattr(dotenv, "load_dotenv", _fake_load_dotenv)
+    _clear_module_cache()
+    importlib.import_module("newsletter_core.application.graph_composition")
     assert calls["count"] == 0

--- a/tests/unit_tests/test_graph_composition_helpers.py
+++ b/tests/unit_tests/test_graph_composition_helpers.py
@@ -1,0 +1,318 @@
+"""Unit and delegation tests for extracted graph composition helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+import newsletter.cost_tracking as cost_tracking_module
+import newsletter.graph as graph_module
+from newsletter_core.application import graph_composition
+
+
+def _make_state(**overrides):
+    state = {
+        "keywords": ["AI"],
+        "news_period_days": 7,
+        "domain": "AI",
+        "template_style": "compact",
+        "email_compatible": False,
+        "collected_articles": None,
+        "processed_articles": None,
+        "ranked_articles": None,
+        "article_summaries": None,
+        "category_summaries": None,
+        "newsletter_topic": "AI",
+        "newsletter_html": None,
+        "error": None,
+        "status": "collecting",
+        "start_time": 1.0,
+        "step_times": {},
+        "total_time": None,
+    }
+    state.update(overrides)
+    return state
+
+
+@pytest.mark.unit
+def test_build_summary_invocation_plan_preserves_payload_contract() -> None:
+    plan = graph_composition.build_summary_invocation_plan(
+        _make_state(domain=None, email_compatible=True),
+        [{"title": "A"}],
+    )
+
+    assert plan == {
+        "template_style": "compact",
+        "is_compact": True,
+        "article_count": 1,
+        "chain_payload": {
+            "articles": [{"title": "A"}],
+            "keywords": ["AI"],
+            "domain": "",
+            "email_compatible": True,
+            "template_style": "compact",
+        },
+    }
+
+
+@pytest.mark.unit
+def test_build_summarize_result_state_delegates_normalization_and_state_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = {}
+
+    def _fake_normalize(result, **kwargs):
+        captured["normalize"] = (result, kwargs)
+        return "<html>ok</html>", {"sections": []}, "AI Weekly"
+
+    def _fake_success(
+        state, *, newsletter_html, category_summaries, newsletter_topic, elapsed
+    ):
+        captured["success"] = (
+            state,
+            newsletter_html,
+            category_summaries,
+            newsletter_topic,
+            elapsed,
+        )
+        return _make_state(
+            newsletter_html=newsletter_html,
+            category_summaries=category_summaries,
+            newsletter_topic=newsletter_topic,
+            status="summarizing_complete",
+            step_times={"summarize": elapsed},
+        )
+
+    monkeypatch.setattr(
+        graph_composition,
+        "normalize_summary_chain_result",
+        _fake_normalize,
+    )
+    monkeypatch.setattr(
+        graph_composition,
+        "build_summarize_success_state",
+        _fake_success,
+    )
+
+    updated = graph_composition.build_summarize_result_state(
+        _make_state(status="scoring_complete"),
+        {"html": "<html>ok</html>"},
+        plan={
+            "template_style": "compact",
+            "is_compact": True,
+            "article_count": 2,
+            "chain_payload": {"articles": []},
+        },
+        generated_at=datetime(2026, 3, 12, 9, 0, tzinfo=timezone.utc),
+        elapsed=1.7,
+    )
+
+    assert captured["normalize"][1]["template_style"] == "compact"
+    assert captured["normalize"][1]["article_count"] == 2
+    assert captured["success"][1] == "<html>ok</html>"
+    assert updated["newsletter_topic"] == "AI Weekly"
+
+
+@pytest.mark.unit
+def test_build_compose_persist_plan_preserves_legacy_filename_inputs() -> None:
+    plan = graph_composition.build_compose_persist_plan(
+        _make_state(
+            domain="AI Mobility",
+            keywords=["AI", "Battery"],
+            template_style="detailed",
+        ),
+        None,
+    )
+
+    assert plan == {
+        "final_html": "<html><body>Newsletter generation failed</body></html>",
+        "domain_slug": "AI_Mobility",
+        "keywords_slug": "AI_Battery",
+        "file_stem": "newsletter_detailed",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("keywords", "domain", "expected"),
+    [
+        (
+            ["AI"],
+            "Mobility",
+            {"newsletter_topic": "Mobility", "requires_theme_extraction": False},
+        ),
+        (["AI"], None, {"newsletter_topic": "AI", "requires_theme_extraction": False}),
+        (
+            ["AI", "Battery"],
+            None,
+            {"newsletter_topic": "", "requires_theme_extraction": True},
+        ),
+    ],
+)
+def test_build_theme_resolution_plan_matches_legacy_branching(
+    keywords, domain, expected
+) -> None:
+    assert graph_composition.build_theme_resolution_plan(keywords, domain) == expected
+
+
+@pytest.mark.unit
+def test_summarize_articles_node_delegates_invocation_plan_and_result_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_chain = MagicMock()
+    fake_chain.invoke.return_value = {"html": "<html>ok</html>"}
+    captured = {}
+    summary_plan = {
+        "template_style": "compact",
+        "is_compact": True,
+        "article_count": 1,
+        "chain_payload": {"articles": [{"title": "A"}]},
+    }
+
+    monkeypatch.setattr(
+        graph_module,
+        "build_summary_invocation_plan",
+        lambda state, ranked_articles: summary_plan,
+    )
+    monkeypatch.setattr(
+        graph_module,
+        "get_newsletter_chain",
+        lambda is_compact: fake_chain,
+    )
+
+    def _fake_result_state(state, result, *, plan, generated_at, elapsed):
+        captured["result"] = result
+        captured["plan"] = plan
+        captured["generated_at"] = generated_at
+        captured["elapsed"] = elapsed
+        return _make_state(
+            newsletter_html="<html>ok</html>",
+            category_summaries={"sections": []},
+            newsletter_topic="AI",
+            status="summarizing_complete",
+            step_times={"summarize": elapsed},
+        )
+
+    monkeypatch.setattr(
+        graph_module, "build_summarize_result_state", _fake_result_state
+    )
+
+    updated = graph_module.summarize_articles_node(
+        _make_state(
+            ranked_articles=[{"title": "A"}],
+            status="scoring_complete",
+        )
+    )
+
+    assert fake_chain.invoke.call_args.args[0] == {"articles": [{"title": "A"}]}
+    assert captured["plan"] == summary_plan
+    assert updated["newsletter_html"] == "<html>ok</html>"
+
+
+@pytest.mark.unit
+def test_compose_newsletter_node_delegates_compose_persist_plan(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    captured = {}
+    output_path = tmp_path / "newsletter.html"
+
+    def _fake_compose_plan(state, newsletter_html):
+        captured["persist_input"] = (state, newsletter_html)
+        return {
+            "final_html": "<html>persisted</html>",
+            "domain_slug": "AI",
+            "keywords_slug": "AI",
+            "file_stem": "newsletter_compact",
+        }
+
+    def _fake_success(state, *, newsletter_html, elapsed):
+        captured["success"] = (newsletter_html, elapsed)
+        return _make_state(
+            newsletter_html=newsletter_html,
+            status="complete",
+            step_times={"compose": elapsed},
+        )
+
+    monkeypatch.setattr(graph_module, "build_compose_persist_plan", _fake_compose_plan)
+    monkeypatch.setattr(
+        graph_module,
+        "generate_unified_newsletter_filename",
+        lambda domain, label, keywords, extension: str(output_path),
+    )
+    monkeypatch.setattr(graph_module, "build_compose_success_state", _fake_success)
+
+    updated = graph_module.compose_newsletter_node(
+        _make_state(
+            newsletter_html="<html>input</html>",
+            category_summaries={"sections": []},
+            status="summarizing_complete",
+        )
+    )
+
+    assert captured["persist_input"][1] == "<html>input</html>"
+    assert output_path.read_text(encoding="utf-8") == "<html>persisted</html>"
+    assert updated["newsletter_html"] == "<html>persisted</html>"
+
+
+@pytest.mark.unit
+def test_generate_newsletter_delegates_theme_resolution_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel_initial_state = _make_state(status="collecting")
+    sentinel_final_state = _make_state(
+        status="complete",
+        newsletter_html="<html>delegated</html>",
+        step_times={"collect": 0.1},
+        total_time=0.5,
+    )
+    captured = {}
+
+    class _FakeGraph:
+        def invoke(self, state):
+            assert state is sentinel_initial_state
+            return sentinel_final_state
+
+    monkeypatch.setattr(cost_tracking_module, "clear_recent_callbacks", lambda: None)
+    monkeypatch.setattr(
+        cost_tracking_module, "get_cost_summary", lambda: {"total_cost": 0.2}
+    )
+    monkeypatch.setattr(
+        graph_module,
+        "build_theme_resolution_plan",
+        lambda keywords, domain: {
+            "newsletter_topic": "Delegated Topic",
+            "requires_theme_extraction": False,
+        },
+    )
+
+    def _fake_build_initial_graph_state(**kwargs):
+        captured["initial_kwargs"] = kwargs
+        return sentinel_initial_state
+
+    monkeypatch.setattr(
+        graph_module,
+        "build_initial_graph_state",
+        _fake_build_initial_graph_state,
+    )
+    monkeypatch.setattr(graph_module, "create_newsletter_graph", lambda: _FakeGraph())
+    monkeypatch.setattr(
+        graph_module,
+        "build_generation_info",
+        lambda final_state, cost_summary: {
+            "step_times": final_state.get("step_times", {}),
+            "total_time": final_state.get("total_time"),
+            "cost_summary": cost_summary,
+        },
+    )
+    monkeypatch.setattr(
+        graph_module,
+        "resolve_generation_result",
+        lambda final_state: ("<html>delegated</html>", "success"),
+    )
+
+    result = graph_module.generate_newsletter(["AI", "Battery"], news_period_days=3)
+
+    assert captured["initial_kwargs"]["newsletter_topic"] == "Delegated Topic"
+    assert result == ("<html>delegated</html>", "success")

--- a/tests/unit_tests/test_graph_node_helpers.py
+++ b/tests/unit_tests/test_graph_node_helpers.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import sys
 from datetime import datetime, timezone
 from types import ModuleType, SimpleNamespace
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -232,62 +231,3 @@ def test_process_articles_node_delegates_filter_sort_and_state_helpers(
         {"title": "sorted", "date": "2026-03-10T09:00:00Z"}
     ]
     assert result["status"] == "scoring"
-
-
-@pytest.mark.unit
-def test_summarize_articles_node_delegates_style_and_success_helpers(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    fake_chain = MagicMock()
-    fake_chain.invoke.return_value = {"html": "<html>ok</html>"}
-    captured = {}
-
-    def _fake_resolve_style(state):
-        captured["style_state"] = state
-        return ("compact", True)
-
-    monkeypatch.setattr(
-        graph_module, "resolve_summary_chain_style", _fake_resolve_style
-    )
-    monkeypatch.setattr(
-        graph_module, "get_newsletter_chain", lambda is_compact: fake_chain
-    )
-    monkeypatch.setattr(
-        graph_module,
-        "normalize_summary_chain_result",
-        lambda result, **kwargs: (
-            "<html>ok</html>",
-            {"sections": [], "structured_data": {}},
-            "AI",
-        ),
-    )
-
-    def _fake_success(
-        state, *, newsletter_html, category_summaries, newsletter_topic, elapsed
-    ):
-        captured["success"] = (
-            newsletter_html,
-            category_summaries,
-            newsletter_topic,
-            elapsed,
-        )
-        return _make_state(
-            newsletter_html=newsletter_html,
-            category_summaries=category_summaries,
-            newsletter_topic=newsletter_topic,
-            status="summarizing_complete",
-            step_times={"summarize": elapsed},
-        )
-
-    monkeypatch.setattr(graph_module, "build_summarize_success_state", _fake_success)
-
-    result = graph_module.summarize_articles_node(
-        _make_state(
-            ranked_articles=[{"title": "A"}],
-            status="scoring_complete",
-        )
-    )
-
-    assert captured["style_state"]["template_style"] == "compact"
-    assert result["newsletter_html"] == "<html>ok</html>"
-    assert result["status"] == "summarizing_complete"

--- a/tests/unit_tests/test_graph_workflow_helpers.py
+++ b/tests/unit_tests/test_graph_workflow_helpers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -191,38 +190,6 @@ def test_resolve_generation_result_matches_legacy_tuple_contract(
         graph_workflow.resolve_generation_result(_make_state(**state_overrides))
         == expected
     )
-
-
-@pytest.mark.unit
-def test_summarize_articles_node_delegates_result_normalization(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    fake_chain = MagicMock()
-    fake_chain.invoke.return_value = {"html": "<html>ok</html>"}
-    called = {}
-
-    def _fake_normalize(result, **kwargs):
-        called["result"] = result
-        called["kwargs"] = kwargs
-        return ("<html>ok</html>", {"sections": [], "structured_data": {}}, "AI")
-
-    monkeypatch.setattr(
-        graph_module, "get_newsletter_chain", lambda is_compact: fake_chain
-    )
-    monkeypatch.setattr(graph_module, "normalize_summary_chain_result", _fake_normalize)
-
-    updated = graph_module.summarize_articles_node(
-        _make_state(
-            ranked_articles=[{"title": "A"}],
-            step_times={},
-            status="scoring_complete",
-        )
-    )
-
-    assert called["result"] == {"html": "<html>ok</html>"}
-    assert called["kwargs"]["article_count"] == 1
-    assert updated["newsletter_html"] == "<html>ok</html>"
-    assert updated["status"] == "summarizing_complete"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary (what / why)
- extract invocation-adjacent graph composition helpers from `newsletter/graph.py` into `newsletter_core`
- keep LangGraph wiring, external IO glue, and app/runtime context in the legacy shell while reducing graph hotspot responsibility

## Scope
### In Scope
- add `newsletter_core.application.graph_composition`
- delegate summary invocation payload assembly, summary result handoff, compose persist planning, and generation theme resolution planning from `newsletter/graph.py`
- add graph composition helper tests and import-time side effect regression coverage
- update architecture note for the new graph boundary

### Out of Scope
- LangGraph runtime wiring redesign
- chain invocation behavior changes
- external IO, file output, or app/runtime context extraction
- changes to `newsletter/tools.py`, `newsletter/llm_factory.py`, or `web/routes_generation.py`

## Delivery Unit
- RR: #324
- Delivery Unit ID: DU-20260312-graph-invocation-composition-extraction
- Merge Boundary: This PR only moves invocation-adjacent non-IO graph composition helpers into `newsletter_core` and keeps graph runtime wiring and external IO behavior intact.
- Rollback Boundary: Revert this PR's squash merge commit to restore the legacy graph composition helpers.

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): targeted graph helper and graph regression suites

### Commands and Results
```bash
git diff --check
# clean

.local/venv/bin/python -m pytest tests/unit_tests/test_graph_workflow_helpers.py tests/unit_tests/test_graph_node_helpers.py tests/unit_tests/test_graph_composition_helpers.py tests/unit_tests/test_config_import_side_effects.py -q
# 45 passed

TESTING=1 MOCK_MODE=1 GEMINI_API_KEY=dummy OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy .local/venv/bin/python -m pytest tests/test_graph_date_parser.py tests/test_newsletter_mocked.py tests/contract/test_generation_facade.py tests/api_tests/test_compact_newsletter_api.py -q
# 14 passed, 7 skipped

make check
# pass

make check-full
# pass
```

## Risk & Rollback
- Risk: graph summary/composition payload assembly and result handoff now delegate through `newsletter_core.application.graph_composition`.
- Rollback: revert the squash merge commit if a regression appears in graph composition behavior.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 해당 없음
- Outbox/send_key 중복 방지 결과: 해당 없음
- import-time side effect 제거 여부: 유지됨. `newsletter_core.application.graph_composition` import side-effect regression test 추가 및 통과.

## Not Run (with reason)
- Deployment pipeline: required CI 범위가 아니며 merge 후 별도 자동 실행됨.
