### PR TITLE
Extract request parsing and response shaping helpers from legacy web/routes_generation.py into a bounded helper layer

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,6 +53,7 @@ class LLMFactory:
 - `newsletter/llm_factory.py` 는 fallback/singleton entrypoint와 legacy import path 호환을 담당하는 thin compatibility boundary로 유지됩니다.
 - `newsletter/tools.py` 는 여전히 legacy integration surface이지만, Serper 입력 정규화/결과 shaping과 theme/filename 순수 helper는 `newsletter_core/application/tools_support.py` 로, request plan/response orchestration/aggregation helper는 `newsletter_core/application/tools_search_flow.py` 로, raw Serper request execution/status normalization은 `newsletter_core/infrastructure/tools_search_runtime.py` 로 이동했고 HTML/file/LLM/app-context glue만 legacy wrapper에 남깁니다.
 - `newsletter/graph.py` 는 여전히 legacy runtime shell이지만, state 초기화, branch routing, summary result normalization, final result shaping은 `newsletter_core/application/graph_workflow.py` 로, collect/process/score/summarize/compose node 내부의 transformation/state-update helper는 `newsletter_core/application/graph_node_helpers.py` 로, summarize invocation plan/result handoff와 compose/theme resolution 같은 invocation-adjacent composition helper는 `newsletter_core/application/graph_composition.py` 로 이동했고 node IO/file/runtime glue와 LangGraph wiring만 legacy 경계에 남깁니다.
+- `web/routes_generation.py` 는 여전히 Flask wiring, request/app context, DB/task side-effect 경계를 담당하는 legacy route shell이지만, request parsing/validation, preview/schedule option normalization, sync response shaping 같은 route-adjacent helper는 `web/generation_route_support.py` 로 이동해 endpoint 의미와 HTTP semantics는 유지한 채 hotspot 책임을 줄입니다.
 
 ### 0.3. 자동 Fallback 시스템
 

--- a/tests/unit_tests/test_generation_route_support.py
+++ b/tests/unit_tests/test_generation_route_support.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from flask import Flask
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+import generation_route_support  # noqa: E402
+import routes_generation  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def _build_generation_app(
+    database_path: str,
+    *,
+    newsletter_cli: Any | None = None,
+    in_memory_tasks: dict[str, Any] | None = None,
+    task_queue: Any = None,
+    redis_conn: Any = None,
+) -> Flask:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    routes_generation.register_generation_routes(
+        app=app,
+        database_path=database_path,
+        newsletter_cli=object() if newsletter_cli is None else newsletter_cli,
+        in_memory_tasks={} if in_memory_tasks is None else in_memory_tasks,
+        task_queue=task_queue,
+        redis_conn=redis_conn,
+    )
+    return app
+
+
+def test_validate_generate_request_normalizes_keywords_list() -> None:
+    validated = generation_route_support.validate_generate_request(
+        {
+            "keywords": ["AI", "robotics"],
+            "email": "reader@example.com",
+            "period": 14,
+        }
+    )
+
+    assert validated.keywords == "AI, robotics"
+    assert validated.email == "reader@example.com"
+
+
+def test_build_generate_request_context_preserves_log_fields() -> None:
+    validated = generation_route_support.validate_generate_request(
+        {"keywords": "AI", "email": "reader@example.com"}
+    )
+
+    context = generation_route_support.build_generate_request_context(validated)
+
+    assert context.email == "reader@example.com"
+    assert context.send_email is True
+    assert context.has_keywords is True
+    assert context.has_domain is False
+
+
+def test_parse_preview_request_preserves_topic_fallback_and_validation() -> None:
+    preview = generation_route_support.parse_preview_request(
+        {"topic": "AI", "template_style": "compact"}
+    )
+
+    assert preview.keywords == "AI"
+    assert preview.period == 14
+    assert preview.template_style == "compact"
+
+    with pytest.raises(ValueError, match="Invalid period"):
+        generation_route_support.parse_preview_request({"keywords": "AI", "period": 9})
+
+    with pytest.raises(ValueError, match="Missing required parameter"):
+        generation_route_support.parse_preview_request({"keywords": ""})
+
+
+def test_build_generation_invoke_plan_prefers_keywords_then_domain() -> None:
+    keyword_options = generation_route_support.build_sync_generation_options(
+        {"keywords": "AI", "domain": "mobility", "period": 7}
+    )
+    keyword_plan = generation_route_support.build_generation_invoke_plan(
+        keyword_options
+    )
+
+    assert keyword_plan.mode == "keywords"
+    assert keyword_plan.kwargs == {
+        "keywords": "AI",
+        "template_style": "compact",
+        "email_compatible": False,
+        "period": 7,
+    }
+
+    domain_options = generation_route_support.build_sync_generation_options(
+        {"domain": "mobility"}
+    )
+    domain_plan = generation_route_support.build_generation_invoke_plan(domain_options)
+
+    assert domain_plan.mode == "domain"
+    assert domain_plan.kwargs["domain"] == "mobility"
+
+
+def test_build_sync_generation_response_preserves_contract() -> None:
+    response = generation_route_support.build_sync_generation_response(
+        {
+            "status": "success",
+            "content": "<html>ok</html>",
+            "title": "AI Weekly",
+            "generation_stats": {"articles": 4},
+            "input_params": {"keywords": "AI"},
+            "error": None,
+        },
+        using_real_cli=True,
+        template_style="compact",
+        email_compatible=False,
+        period=14,
+        email_sent=True,
+    )
+
+    assert response == {
+        "status": "success",
+        "html_content": "<html>ok</html>",
+        "title": "AI Weekly",
+        "generation_stats": {"articles": 4},
+        "input_params": {"keywords": "AI"},
+        "error": None,
+        "sent": True,
+        "email_sent": True,
+        "subject": "AI Weekly",
+        "html_size": len("<html>ok</html>"),
+        "processing_info": {
+            "using_real_cli": True,
+            "template_style": "compact",
+            "email_compatible": False,
+            "period_days": 14,
+        },
+    }
+
+
+def test_build_status_and_history_helpers_preserve_payload_shape() -> None:
+    row = (
+        '{"keywords":"AI"}',
+        '{"sent": true, "approval_status": "approved"}',
+        "completed",
+        "generate:123",
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+
+    status_response = generation_route_support.build_status_response_from_row(
+        "job-1",
+        row,
+        parse_params=json.loads,
+        parse_result=json.loads,
+    )
+
+    assert status_response["params"] == {"keywords": "AI"}
+    assert status_response["sent"] is True
+    assert status_response["approval_status"] == "approved"
+
+    history_entry = generation_route_support.build_history_entry(
+        (
+            "job-1",
+            '{"keywords":"AI"}',
+            '{"status":"success"}',
+            "2026-03-12T00:00:00Z",
+            "completed",
+            "generate:123",
+            "pending",
+            None,
+            None,
+            None,
+            None,
+        ),
+        parse_params=json.loads,
+        parse_result=json.loads,
+    )
+
+    assert history_entry["id"] == "job-1"
+    assert history_entry["params"] == {"keywords": "AI"}
+    assert history_entry["result"] == {"status": "success"}
+
+
+def test_parse_schedule_create_request_builds_normalized_params() -> None:
+    request = generation_route_support.parse_schedule_create_request(
+        {
+            "keywords": ["AI", "robotics"],
+            "email": "schedule@example.com",
+            "rrule": "FREQ=WEEKLY;BYDAY=MO;BYHOUR=9;BYMINUTE=0",
+            "require_approval": True,
+        }
+    )
+
+    assert request.rrule == "FREQ=WEEKLY;BYDAY=MO;BYHOUR=9;BYMINUTE=0"
+    assert request.params == {
+        "keywords": ["AI", "robotics"],
+        "domain": None,
+        "email": "schedule@example.com",
+        "template_style": "compact",
+        "email_compatible": True,
+        "period": 14,
+        "send_email": True,
+        "require_approval": True,
+    }
+    assert request.is_test is False
+    assert request.expires_at is None
+
+
+def test_generate_route_delegates_request_context_helpers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _build_generation_app(str(tmp_path / "storage.db"))
+    observed: dict[str, Any] = {}
+
+    def fake_validate_generate_request(data: dict[str, Any]) -> SimpleNamespace:
+        observed["validated_payload"] = data
+        return SimpleNamespace(email="reader@example.com", domain=None, keywords="AI")
+
+    def fake_build_generate_request_context(
+        validated_data: Any,
+    ) -> generation_route_support.GenerateRequestContext:
+        observed["validated_data"] = validated_data
+        return generation_route_support.GenerateRequestContext(
+            email="reader@example.com",
+            send_email=True,
+            has_domain=False,
+            has_keywords=True,
+        )
+
+    def fake_resolve_generation_job(
+        **kwargs: Any,
+    ) -> routes_generation.GenerationJobResolution:
+        observed["resolution_payload"] = kwargs["payload"]
+        return routes_generation.GenerationJobResolution(
+            job_id="job_123",
+            deduplicated=False,
+            stored_status="pending",
+            idempotency_key="generate:abc",
+            effective_idempotency_key="generate:abc",
+        )
+
+    def fake_dispatch_generation_job(**kwargs: Any) -> dict[str, Any]:
+        observed["dispatch_send_email"] = kwargs["send_email"]
+        return {
+            "job_id": "job_123",
+            "status": "processing",
+            "deduplicated": False,
+            "idempotency_key": "generate:abc",
+        }
+
+    monkeypatch.setattr(
+        routes_generation, "validate_generate_request", fake_validate_generate_request
+    )
+    monkeypatch.setattr(
+        routes_generation,
+        "build_generate_request_context",
+        fake_build_generate_request_context,
+    )
+    monkeypatch.setattr(
+        routes_generation, "_resolve_generation_job", fake_resolve_generation_job
+    )
+    monkeypatch.setattr(
+        routes_generation, "_dispatch_generation_job", fake_dispatch_generation_job
+    )
+
+    with app.test_client() as client:
+        response = client.post(
+            "/api/generate",
+            json={"keywords": "AI", "email": "reader@example.com"},
+        )
+
+    assert response.status_code == 202
+    assert observed["validated_payload"] == {
+        "keywords": "AI",
+        "email": "reader@example.com",
+    }
+    assert observed["dispatch_send_email"] is True
+
+
+def test_preview_route_delegates_preview_request_parsing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cli_calls: dict[str, Any] = {}
+
+    class FakeCLI:
+        def generate_newsletter(self, **kwargs: Any) -> dict[str, Any]:
+            cli_calls["kwargs"] = kwargs
+            return {"status": "success", "content": "<html>preview</html>"}
+
+    observed: dict[str, Any] = {}
+
+    def fake_parse_preview_request(
+        data: dict[str, Any],
+    ) -> generation_route_support.PreviewRequestOptions:
+        observed["query"] = data
+        return generation_route_support.PreviewRequestOptions(
+            keywords="AI",
+            period=7,
+            template_style="compact",
+        )
+
+    monkeypatch.setattr(
+        routes_generation, "parse_preview_request", fake_parse_preview_request
+    )
+
+    app = _build_generation_app(
+        str(tmp_path / "storage.db"),
+        newsletter_cli=FakeCLI(),
+    )
+
+    with app.test_client() as client:
+        response = client.get("/newsletter?topic=ignored")
+
+    assert response.status_code == 200
+    assert observed["query"] == {"topic": "ignored"}
+    assert cli_calls["kwargs"] == {
+        "keywords": "AI",
+        "template_style": "compact",
+        "email_compatible": False,
+        "period": 7,
+    }
+
+
+def test_schedule_create_route_delegates_request_parsing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    observed: dict[str, Any] = {}
+
+    def fake_parse_schedule_create_request(
+        data: dict[str, Any] | None,
+    ) -> generation_route_support.ScheduleCreateOptions:
+        observed["payload"] = data
+        return generation_route_support.ScheduleCreateOptions(
+            rrule="FREQ=WEEKLY;BYDAY=MO;BYHOUR=9;BYMINUTE=0",
+            params={
+                "keywords": "AI",
+                "domain": None,
+                "email": "schedule@example.com",
+                "template_style": "compact",
+                "email_compatible": True,
+                "period": 14,
+                "send_email": True,
+                "require_approval": False,
+            },
+            is_test=False,
+            expires_at=None,
+        )
+
+    monkeypatch.setattr(
+        routes_generation,
+        "parse_schedule_create_request",
+        fake_parse_schedule_create_request,
+    )
+
+    app = _build_generation_app(str(tmp_path / "storage.db"))
+
+    with app.test_client() as client:
+        response = client.post(
+            "/api/schedule",
+            json={
+                "keywords": "AI",
+                "email": "schedule@example.com",
+                "rrule": "FREQ=WEEKLY;BYDAY=MO;BYHOUR=9;BYMINUTE=0",
+            },
+        )
+
+    assert response.status_code == 201
+    assert observed["payload"] == {
+        "keywords": "AI",
+        "email": "schedule@example.com",
+        "rrule": "FREQ=WEEKLY;BYDAY=MO;BYHOUR=9;BYMINUTE=0",
+    }

--- a/tests/unit_tests/test_web_import_side_effects.py
+++ b/tests/unit_tests/test_web_import_side_effects.py
@@ -4,6 +4,7 @@ import importlib
 import sys
 from types import ModuleType
 
+import dotenv
 import pytest
 from flask import Flask
 
@@ -123,3 +124,24 @@ def test_generation_facade_import_is_lazy_for_legacy_modules() -> None:
         _restore_module("newsletter_core.public.generation", previous_generation)
         _restore_module("newsletter.graph", previous_graph)
         _restore_module("newsletter.tools", previous_tools)
+
+
+@pytest.mark.unit
+def test_generation_route_support_import_does_not_call_load_dotenv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"count": 0}
+
+    def _fake_load_dotenv(*_args, **_kwargs) -> bool:
+        calls["count"] += 1
+        return False
+
+    monkeypatch.setattr(dotenv, "load_dotenv", _fake_load_dotenv)
+    previous = _pop_module("web.generation_route_support")
+    previous_top_level = _pop_module("generation_route_support")
+    try:
+        importlib.import_module("web.generation_route_support")
+        assert calls["count"] == 0
+    finally:
+        _restore_module("web.generation_route_support", previous)
+        _restore_module("generation_route_support", previous_top_level)

--- a/web/generation_route_support.py
+++ b/web/generation_route_support.py
@@ -1,0 +1,309 @@
+"""Bounded request/response helpers for generation routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Mapping
+
+if TYPE_CHECKING:
+    from web.types import GenerateNewsletterRequest
+else:
+    try:
+        from types import GenerateNewsletterRequest
+    except ImportError:
+        from web.types import GenerateNewsletterRequest  # pragma: no cover
+
+
+@dataclass(frozen=True)
+class GenerateRequestContext:
+    email: str | None
+    send_email: bool
+    has_domain: bool
+    has_keywords: bool
+
+
+@dataclass(frozen=True)
+class PreviewRequestOptions:
+    keywords: str
+    period: int
+    template_style: str
+
+
+@dataclass(frozen=True)
+class SyncGenerationOptions:
+    keywords: Any
+    domain: Any
+    template_style: str
+    email_compatible: bool
+    period: int
+    email: str
+    preview_only: bool
+
+
+@dataclass(frozen=True)
+class GenerationInvokePlan:
+    mode: str
+    kwargs: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ScheduleCreateOptions:
+    rrule: str
+    params: dict[str, Any]
+    is_test: bool
+    expires_at: str | None
+
+
+def validate_generate_request(data: dict[str, Any]) -> GenerateNewsletterRequest:
+    """Validate generation request payload without runtime dynamic loading."""
+    return GenerateNewsletterRequest(**data)
+
+
+def build_generate_request_context(
+    validated_data: GenerateNewsletterRequest,
+) -> GenerateRequestContext:
+    return GenerateRequestContext(
+        email=validated_data.email,
+        send_email=bool(validated_data.email),
+        has_domain=bool(validated_data.domain),
+        has_keywords=bool(validated_data.keywords),
+    )
+
+
+def build_generate_response(
+    *, job_id: str, status: str, deduplicated: bool, idempotency_key: str
+) -> dict[str, Any]:
+    return {
+        "job_id": job_id,
+        "status": status,
+        "deduplicated": deduplicated,
+        "idempotency_key": idempotency_key,
+    }
+
+
+def parse_preview_request(query_params: Mapping[str, Any]) -> PreviewRequestOptions:
+    topic = str(query_params.get("topic", "") or "")
+    keywords = query_params["keywords"] if "keywords" in query_params else topic
+    template_style = str(query_params.get("template_style", "compact") or "compact")
+
+    period_raw = query_params.get("period", 14)
+    try:
+        period = int(period_raw)
+    except (TypeError, ValueError):
+        period = 14
+
+    if period not in {1, 7, 14, 30}:
+        raise ValueError("Invalid period. Must be one of: 1, 7, 14, 30 days")
+    if not keywords:
+        raise ValueError("Missing required parameter: topic or keywords")
+
+    return PreviewRequestOptions(
+        keywords=str(keywords),
+        period=period,
+        template_style=template_style,
+    )
+
+
+def build_sync_generation_options(data: Mapping[str, Any]) -> SyncGenerationOptions:
+    return SyncGenerationOptions(
+        keywords=data.get("keywords", ""),
+        domain=data.get("domain", ""),
+        template_style=data.get("template_style", "compact"),
+        email_compatible=data.get("email_compatible", False),
+        period=data.get("period", 14),
+        email=data.get("email", ""),
+        preview_only=bool(data.get("preview_only", False)),
+    )
+
+
+def build_generation_invoke_plan(
+    options: SyncGenerationOptions,
+) -> GenerationInvokePlan:
+    shared_kwargs = {
+        "template_style": options.template_style,
+        "email_compatible": options.email_compatible,
+        "period": options.period,
+    }
+    if options.keywords:
+        return GenerationInvokePlan(
+            mode="keywords",
+            kwargs={"keywords": options.keywords, **shared_kwargs},
+        )
+    if options.domain:
+        return GenerationInvokePlan(
+            mode="domain",
+            kwargs={"domain": options.domain, **shared_kwargs},
+        )
+    raise ValueError("Either keywords or domain must be provided")
+
+
+def build_sync_email_subject(
+    *,
+    result_title: str | None,
+    keywords: Any,
+    domain: Any,
+) -> str:
+    if keywords:
+        return f"Newsletter: {keywords}"
+    if domain:
+        return f"Newsletter: {domain} Insights"
+    return result_title or "Newsletter"
+
+
+def build_sync_generation_response(
+    result: Mapping[str, Any],
+    *,
+    using_real_cli: bool,
+    template_style: str,
+    email_compatible: bool,
+    period: int,
+    email_sent: bool,
+) -> dict[str, Any]:
+    html_content = result.get("content", "")
+    title = result.get("title", "Newsletter")
+    return {
+        "status": result.get("status", "error"),
+        "html_content": html_content,
+        "title": title,
+        "generation_stats": result.get("generation_stats", {}),
+        "input_params": result.get("input_params", {}),
+        "error": result.get("error"),
+        "sent": email_sent,
+        "email_sent": email_sent,
+        "subject": title,
+        "html_size": len(html_content),
+        "processing_info": {
+            "using_real_cli": using_real_cli,
+            "template_style": template_style,
+            "email_compatible": email_compatible,
+            "period_days": period,
+        },
+    }
+
+
+def build_status_response_from_task(
+    job_id: str, task: Mapping[str, Any]
+) -> dict[str, Any]:
+    response = {
+        "job_id": job_id,
+        "status": task["status"],
+        "sent": task.get("sent", False),
+        "idempotency_key": task.get("idempotency_key"),
+    }
+
+    result = task.get("result")
+    if isinstance(result, dict):
+        response["result"] = result
+        response["sent"] = result.get("sent", False)
+        response["approval_status"] = result.get("approval_status")
+        response["delivery_status"] = result.get("delivery_status")
+    elif result is not None:
+        response["result"] = result
+
+    if "error" in task:
+        response["error"] = task["error"]
+    return response
+
+
+def build_status_response_from_row(
+    job_id: str,
+    row: tuple[Any, ...],
+    *,
+    parse_params: Callable[[str | None], Any],
+    parse_result: Callable[[str | None], Any],
+) -> dict[str, Any]:
+    (
+        params,
+        result,
+        status,
+        idempotency_key,
+        approval_status,
+        delivery_status,
+        approved_at,
+        rejected_at,
+        approval_note,
+    ) = row
+    response = {
+        "job_id": job_id,
+        "status": status,
+        "params": parse_params(params),
+        "sent": False,
+        "idempotency_key": idempotency_key,
+        "approval_status": approval_status,
+        "delivery_status": delivery_status,
+        "approved_at": approved_at,
+        "rejected_at": rejected_at,
+        "approval_note": approval_note,
+    }
+
+    result_data = parse_result(result)
+    if isinstance(result_data, dict):
+        response["result"] = result_data
+        response["sent"] = result_data.get("sent", False)
+        if response["approval_status"] is None:
+            response["approval_status"] = result_data.get("approval_status")
+        if response["delivery_status"] is None:
+            response["delivery_status"] = result_data.get("delivery_status")
+    elif result_data is not None:
+        response["result"] = result_data
+
+    return response
+
+
+def build_history_entry(
+    row: tuple[Any, ...],
+    *,
+    parse_params: Callable[[str | None], Any],
+    parse_result: Callable[[str | None], Any],
+) -> dict[str, Any]:
+    (
+        job_id,
+        params,
+        result,
+        created_at,
+        status,
+        idempotency_key,
+        approval_status,
+        delivery_status,
+        approved_at,
+        rejected_at,
+        approval_note,
+    ) = row
+    return {
+        "id": job_id,
+        "params": parse_params(params),
+        "result": parse_result(result),
+        "created_at": created_at,
+        "status": status,
+        "idempotency_key": idempotency_key,
+        "approval_status": approval_status,
+        "delivery_status": delivery_status,
+        "approved_at": approved_at,
+        "rejected_at": rejected_at,
+        "approval_note": approval_note,
+    }
+
+
+def parse_schedule_create_request(
+    data: Mapping[str, Any] | None
+) -> ScheduleCreateOptions:
+    if not data or not data.get("rrule") or not data.get("email"):
+        raise ValueError("Missing required fields: rrule, email")
+    if not data.get("keywords") and not data.get("domain"):
+        raise ValueError("Either keywords or domain is required")
+
+    return ScheduleCreateOptions(
+        rrule=str(data["rrule"]),
+        params={
+            "keywords": data.get("keywords"),
+            "domain": data.get("domain"),
+            "email": data["email"],
+            "template_style": data.get("template_style", "compact"),
+            "email_compatible": data.get("email_compatible", True),
+            "period": data.get("period", 14),
+            "send_email": True,
+            "require_approval": bool(data.get("require_approval", False)),
+        },
+        is_test=bool(data.get("is_test", False)),
+        expires_at=data.get("expires_at"),
+    )

--- a/web/routes_generation.py
+++ b/web/routes_generation.py
@@ -65,7 +65,36 @@ try:
 except ImportError:
     from web.analytics import record_schedule_event  # pragma: no cover
 
-from web.types import GenerateNewsletterRequest
+try:
+    from generation_route_support import (
+        build_generate_request_context,
+        build_generate_response,
+        build_generation_invoke_plan,
+        build_history_entry,
+        build_status_response_from_row,
+        build_status_response_from_task,
+        build_sync_email_subject,
+        build_sync_generation_options,
+        build_sync_generation_response,
+        parse_preview_request,
+        parse_schedule_create_request,
+        validate_generate_request,
+    )
+except ImportError:
+    from web.generation_route_support import (  # pragma: no cover
+        build_generate_request_context,
+        build_generate_response,
+        build_generation_invoke_plan,
+        build_history_entry,
+        build_status_response_from_row,
+        build_status_response_from_task,
+        build_sync_email_subject,
+        build_sync_generation_options,
+        build_sync_generation_response,
+        parse_preview_request,
+        parse_schedule_create_request,
+        validate_generate_request,
+    )
 
 logger = logging.getLogger("web.routes_generation")
 
@@ -86,22 +115,6 @@ class ScheduleRunResolution:
     immediate_job_id: str
     idempotency_key: str
     effective_idempotency_key: str | None
-
-
-def _validate_generate_request(data: dict[str, Any]) -> GenerateNewsletterRequest:
-    """Validate generation request payload without runtime dynamic loading."""
-    return GenerateNewsletterRequest(**data)
-
-
-def _build_generate_response(
-    *, job_id: str, status: str, deduplicated: bool, idempotency_key: str
-) -> dict[str, Any]:
-    return {
-        "job_id": job_id,
-        "status": status,
-        "deduplicated": deduplicated,
-        "idempotency_key": idempotency_key,
-    }
 
 
 def _resolve_generation_job(
@@ -162,7 +175,7 @@ def _dispatch_generation_job(
             database_path,
             job_id=resolution.job_id,
         )
-        return _build_generate_response(
+        return build_generate_response(
             job_id=resolution.job_id,
             status="queued",
             deduplicated=False,
@@ -189,7 +202,7 @@ def _dispatch_generation_job(
         )
         thread.start()
 
-    return _build_generate_response(
+    return build_generate_response(
         job_id=resolution.job_id,
         status="processing",
         deduplicated=False,
@@ -276,21 +289,19 @@ def register_generation_routes(
                 return jsonify({"error": "No data provided"}), 400
 
             try:
-                validated_data = _validate_generate_request(data)
+                validated_data = validate_generate_request(data)
             except Exception as e:
                 log_exception(logger, "generate.request.invalid", e)
                 return jsonify({"error": f"Invalid request: {str(e)}"}), 400
 
-            # Extract email for sending
-            email = validated_data.email
-            send_email = bool(email)
+            request_context = build_generate_request_context(validated_data)
             log_info(
                 logger,
                 "generate.request.received",
-                has_domain=bool(validated_data.domain),
-                has_keywords=bool(validated_data.keywords),
-                email=email,
-                send_email=send_email,
+                has_domain=request_context.has_domain,
+                has_keywords=request_context.has_keywords,
+                email=request_context.email,
+                send_email=request_context.send_email,
             )
             log_debug(logger, "generate.request.payload", payload=data)
 
@@ -311,7 +322,7 @@ def register_generation_routes(
             if resolution.deduplicated:
                 return (
                     jsonify(
-                        _build_generate_response(
+                        build_generate_response(
                             job_id=resolution.job_id,
                             status=resolution.stored_status,
                             deduplicated=True,
@@ -325,7 +336,7 @@ def register_generation_routes(
                 app=app,
                 payload=data,
                 resolution=resolution,
-                send_email=send_email,
+                send_email=request_context.send_email,
                 database_path=DATABASE_PATH,
                 in_memory_tasks=in_memory_tasks,
                 task_queue=resolve_task_queue(),
@@ -344,43 +355,26 @@ def register_generation_routes(
     def get_newsletter():
         """Generate newsletter directly with GET parameters"""
         try:
-            # 파라미터 추출
-            topic = request.args.get("topic", "")
-            keywords = request.args.get("keywords", topic)  # topic을 keywords로도 받음
-            period = request.args.get("period", 14, type=int)
-            template_style = request.args.get("template_style", "compact")
-
-            # 기간 파라미터 검증
-            if period not in [1, 7, 14, 30]:
-                return (
-                    jsonify(
-                        {"error": "Invalid period. Must be one of: 1, 7, 14, 30 days"}
-                    ),
-                    400,
-                )
-
-            # 키워드가 없으면 에러
-            if not keywords:
-                return (
-                    jsonify({"error": "Missing required parameter: topic or keywords"}),
-                    400,
-                )
+            try:
+                preview_request = parse_preview_request(request.args.to_dict(flat=True))
+            except ValueError as exc:
+                return jsonify({"error": str(exc)}), 400
 
             log_info(
                 logger,
                 "newsletter.preview.requested",
-                keywords=keywords,
-                period=period,
-                template_style=template_style,
+                keywords=preview_request.keywords,
+                period=preview_request.period,
+                template_style=preview_request.template_style,
             )
 
             # 뉴스레터 생성
             active_newsletter_cli = resolve_newsletter_cli()
             result = active_newsletter_cli.generate_newsletter(
-                keywords=keywords,
-                template_style=template_style,
+                keywords=preview_request.keywords,
+                template_style=preview_request.template_style,
                 email_compatible=False,
-                period=period,
+                period=preview_request.period,
             )
 
             if result["status"] == "success":
@@ -414,55 +408,29 @@ def register_generation_routes(
                 cli_type=type(active_newsletter_cli).__name__,
             )
 
-            # Extract parameters
-            keywords = data.get("keywords", "")
-            domain = data.get("domain", "")
-            template_style = data.get("template_style", "compact")
-            email_compatible = data.get("email_compatible", False)
-            period = data.get("period", 14)
-            email = data.get("email", "")  # 이메일 주소 추가
+            options = build_sync_generation_options(data)
 
             log_debug(
                 logger,
                 "generate.sync.parameters",
-                keywords=keywords,
-                domain=domain,
-                template_style=template_style,
-                email_compatible=email_compatible,
-                period=period,
-                email=email,
+                keywords=options.keywords,
+                domain=options.domain,
+                template_style=options.template_style,
+                email_compatible=options.email_compatible,
+                period=options.period,
+                email=options.email,
             )
 
             # Use newsletter CLI with proper parameters
             try:
-                if keywords:
-                    log_info(
-                        logger,
-                        "generate.sync.invoke",
-                        mode="keywords",
-                        cli_type=type(active_newsletter_cli).__name__,
-                    )
-                    result = active_newsletter_cli.generate_newsletter(
-                        keywords=keywords,
-                        template_style=template_style,
-                        email_compatible=email_compatible,
-                        period=period,
-                    )
-                elif domain:
-                    log_info(
-                        logger,
-                        "generate.sync.invoke",
-                        mode="domain",
-                        cli_type=type(active_newsletter_cli).__name__,
-                    )
-                    result = active_newsletter_cli.generate_newsletter(
-                        domain=domain,
-                        template_style=template_style,
-                        email_compatible=email_compatible,
-                        period=period,
-                    )
-                else:
-                    raise ValueError("Either keywords or domain must be provided")
+                invoke_plan = build_generation_invoke_plan(options)
+                log_info(
+                    logger,
+                    "generate.sync.invoke",
+                    mode=invoke_plan.mode,
+                    cli_type=type(active_newsletter_cli).__name__,
+                )
+                result = active_newsletter_cli.generate_newsletter(**invoke_plan.kwargs)
 
                 log_info(
                     logger,
@@ -492,20 +460,8 @@ def register_generation_routes(
                 if isinstance(active_newsletter_cli, RealNewsletterCLI):
                     log_info(logger, "generate.sync.fallback_mock")
                     mock_cli = MockNewsletterCLI()
-                    if keywords:
-                        result = mock_cli.generate_newsletter(
-                            keywords=keywords,
-                            template_style=template_style,
-                            email_compatible=email_compatible,
-                            period=period,
-                        )
-                    else:
-                        result = mock_cli.generate_newsletter(
-                            domain=domain,
-                            template_style=template_style,
-                            email_compatible=email_compatible,
-                            period=period,
-                        )
+                    fallback_plan = build_generation_invoke_plan(options)
+                    result = mock_cli.generate_newsletter(**fallback_plan.kwargs)
                     log_info(
                         logger,
                         "generate.sync.fallback_result",
@@ -514,9 +470,13 @@ def register_generation_routes(
 
             # 이메일 발송 기능 추가
             email_sent = False
-            if email and result.get("content") and not data.get("preview_only"):
+            if options.email and result.get("content") and not options.preview_only:
                 try:
-                    log_info(logger, "generate.sync.email_sending", email=email)
+                    log_info(
+                        logger,
+                        "generate.sync.email_sending",
+                        email=options.email,
+                    )
                     # 이메일 발송 - try-except로 import 처리
                     try:
                         import mail
@@ -536,45 +496,41 @@ def register_generation_routes(
                             )
 
                     # 제목 생성
-                    subject = result.get("title", "Newsletter")
-                    if keywords:
-                        subject = f"Newsletter: {keywords}"
-                    elif domain:
-                        subject = f"Newsletter: {domain} Insights"
+                    subject = build_sync_email_subject(
+                        result_title=result.get("title"),
+                        keywords=options.keywords,
+                        domain=options.domain,
+                    )
 
                     # 이메일 발송
-                    send_email_func(to=email, subject=subject, html=result["content"])
+                    send_email_func(
+                        to=options.email,
+                        subject=subject,
+                        html=result["content"],
+                    )
                     email_sent = True
-                    log_info(logger, "generate.sync.email_sent", email=email)
+                    log_info(
+                        logger,
+                        "generate.sync.email_sent",
+                        email=options.email,
+                    )
                 except Exception as e:
                     log_exception(
                         logger,
                         "generate.sync.email_failed",
                         e,
-                        email=email,
+                        email=options.email,
                     )
                     # 이메일 발송 실패해도 뉴스레터 생성은 성공으로 처리
 
-            response = {
-                "status": result.get("status", "error"),
-                "html_content": result.get("content", ""),
-                "title": result.get("title", "Newsletter"),
-                "generation_stats": result.get("generation_stats", {}),
-                "input_params": result.get("input_params", {}),
-                "error": result.get("error"),
-                "sent": email_sent,
-                "email_sent": email_sent,
-                "subject": result.get("title", "Newsletter"),  # compatibility alias
-                "html_size": len(result.get("content", "")),
-                "processing_info": {
-                    "using_real_cli": isinstance(
-                        active_newsletter_cli, RealNewsletterCLI
-                    ),
-                    "template_style": template_style,
-                    "email_compatible": email_compatible,
-                    "period_days": period,
-                },
-            }
+            response = build_sync_generation_response(
+                result,
+                using_real_cli=isinstance(active_newsletter_cli, RealNewsletterCLI),
+                template_style=options.template_style,
+                email_compatible=options.email_compatible,
+                period=options.period,
+                email_sent=email_sent,
+            )
 
             log_info(
                 logger,
@@ -636,29 +592,6 @@ def register_generation_routes(
             )
             return None
 
-    def _build_status_response_from_task(
-        job_id: str, task: dict[str, Any]
-    ) -> dict[str, Any]:
-        response = {
-            "job_id": job_id,
-            "status": task["status"],
-            "sent": task.get("sent", False),
-            "idempotency_key": task.get("idempotency_key"),
-        }
-
-        result = task.get("result")
-        if isinstance(result, dict):
-            response["result"] = result
-            response["sent"] = result.get("sent", False)
-            response["approval_status"] = result.get("approval_status")
-            response["delivery_status"] = result.get("delivery_status")
-        elif result is not None:
-            response["result"] = result
-
-        if "error" in task:
-            response["error"] = task["error"]
-        return response
-
     def _load_job_status_row(job_id: str) -> tuple[Any, ...] | None:
         conn = sqlite3.connect(DATABASE_PATH)
         try:
@@ -684,50 +617,6 @@ def register_generation_routes(
         finally:
             conn.close()
 
-    def _build_status_response_from_row(
-        job_id: str, row: tuple[Any, ...]
-    ) -> dict[str, Any]:
-        (
-            params,
-            result,
-            status,
-            idempotency_key,
-            approval_status,
-            delivery_status,
-            approved_at,
-            rejected_at,
-            approval_note,
-        ) = row
-        response = {
-            "job_id": job_id,
-            "status": status,
-            "params": _parse_optional_json(
-                params, job_id=job_id, field_name="status.params"
-            ),
-            "sent": False,
-            "idempotency_key": idempotency_key,
-            "approval_status": approval_status,
-            "delivery_status": delivery_status,
-            "approved_at": approved_at,
-            "rejected_at": rejected_at,
-            "approval_note": approval_note,
-        }
-
-        result_data = _parse_optional_json(
-            result, job_id=job_id, field_name="status.result"
-        )
-        if isinstance(result_data, dict):
-            response["result"] = result_data
-            response["sent"] = result_data.get("sent", False)
-            if response["approval_status"] is None:
-                response["approval_status"] = result_data.get("approval_status")
-            if response["delivery_status"] is None:
-                response["delivery_status"] = result_data.get("delivery_status")
-        elif result_data is not None:
-            response["result"] = result_data
-
-        return response
-
     def _load_recent_history_rows(limit: int = 20) -> list[tuple[Any, ...]]:
         conn = sqlite3.connect(DATABASE_PATH)
         try:
@@ -749,38 +638,6 @@ def register_generation_routes(
         finally:
             conn.close()
 
-    def _build_history_entry(row: tuple[Any, ...]) -> dict[str, Any]:
-        (
-            job_id,
-            params,
-            result,
-            created_at,
-            status,
-            idempotency_key,
-            approval_status,
-            delivery_status,
-            approved_at,
-            rejected_at,
-            approval_note,
-        ) = row
-        return {
-            "id": job_id,
-            "params": _parse_optional_json(
-                params, job_id=job_id, field_name="history.params"
-            ),
-            "result": _parse_optional_json(
-                result, job_id=job_id, field_name="history.result"
-            ),
-            "created_at": created_at,
-            "status": status,
-            "idempotency_key": idempotency_key,
-            "approval_status": approval_status,
-            "delivery_status": delivery_status,
-            "approved_at": approved_at,
-            "rejected_at": rejected_at,
-            "approval_note": approval_note,
-        }
-
     def _compute_schedule_next_run(rrule_str: str) -> datetime:
         from dateutil.rrule import rrulestr
 
@@ -790,18 +647,6 @@ def register_generation_routes(
         if not next_run:
             raise ValueError("Invalid RRULE: no future occurrences")
         return to_utc(next_run)
-
-    def _build_schedule_params(data: dict[str, Any]) -> dict[str, Any]:
-        return {
-            "keywords": data.get("keywords"),
-            "domain": data.get("domain"),
-            "email": data["email"],
-            "template_style": data.get("template_style", "compact"),
-            "email_compatible": data.get("email_compatible", True),
-            "period": data.get("period", 14),
-            "send_email": True,
-            "require_approval": bool(data.get("require_approval", False)),
-        }
 
     def _list_active_schedules() -> list[dict[str, Any]]:
         conn = sqlite3.connect(DATABASE_PATH)
@@ -934,7 +779,7 @@ def register_generation_routes(
         """Get status of a newsletter generation job"""
         if job_id in in_memory_tasks:
             return jsonify(
-                _build_status_response_from_task(job_id, in_memory_tasks[job_id])
+                build_status_response_from_task(job_id, in_memory_tasks[job_id])
             )
 
         row = _load_job_status_row(job_id)
@@ -942,7 +787,22 @@ def register_generation_routes(
         if not row:
             return jsonify({"error": "Job not found"}), 404
 
-        return jsonify(_build_status_response_from_row(job_id, row))
+        return jsonify(
+            build_status_response_from_row(
+                job_id,
+                row,
+                parse_params=lambda raw: _parse_optional_json(
+                    raw,
+                    job_id=job_id,
+                    field_name="status.params",
+                ),
+                parse_result=lambda raw: _parse_optional_json(
+                    raw,
+                    job_id=job_id,
+                    field_name="status.result",
+                ),
+            )
+        )
 
     @app.route("/api/history")
     def get_history():
@@ -954,7 +814,22 @@ def register_generation_routes(
             log_exception(logger, "history.load_failed", e)
             return jsonify({"error": f"Database error: {str(e)}"}), 500
 
-        history = [_build_history_entry(row) for row in rows]
+        history = [
+            build_history_entry(
+                row,
+                parse_params=lambda raw, job_id=row[0]: _parse_optional_json(
+                    raw,
+                    job_id=job_id,
+                    field_name="history.params",
+                ),
+                parse_result=lambda raw, job_id=row[0]: _parse_optional_json(
+                    raw,
+                    job_id=job_id,
+                    field_name="history.result",
+                ),
+            )
+            for row in rows
+        ]
         log_info(logger, "history.returned", count=len(history))
         return jsonify(history)
 
@@ -962,24 +837,18 @@ def register_generation_routes(
     def create_schedule():
         """Create a recurring newsletter schedule"""
         data = request.get_json()
+        try:
+            schedule_request = parse_schedule_create_request(data)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
-        if not data or not data.get("rrule") or not data.get("email"):
-            return jsonify({"error": "Missing required fields: rrule, email"}), 400
-
-        # Keywords나 domain 중 하나는 필수
-        if not data.get("keywords") and not data.get("domain"):
-            return jsonify({"error": "Either keywords or domain is required"}), 400
-
-        rrule_str = data["rrule"]
+        rrule_str = schedule_request.rrule
         try:
             next_run_utc = _compute_schedule_next_run(rrule_str)
         except Exception as e:
             return jsonify({"error": f"Invalid RRULE: {str(e)}"}), 400
 
         schedule_id = str(uuid.uuid4())
-        schedule_params = _build_schedule_params(data)
-        is_test = bool(data.get("is_test", False))
-        expires_at = data.get("expires_at")
 
         conn = sqlite3.connect(DATABASE_PATH)
         cursor = conn.cursor()
@@ -990,11 +859,11 @@ def register_generation_routes(
             """,
             (
                 schedule_id,
-                json.dumps(schedule_params),
+                json.dumps(schedule_request.params),
                 rrule_str,
                 to_iso_utc(next_run_utc),
-                int(is_test),
-                expires_at,
+                int(schedule_request.is_test),
+                schedule_request.expires_at,
             ),
         )
         conn.commit()
@@ -1007,10 +876,12 @@ def register_generation_routes(
             status="scheduled",
             payload={
                 "rrule": rrule_str,
-                "email": data["email"],
-                "is_test": is_test,
-                "require_approval": bool(data.get("require_approval", False)),
-                "expires_at": expires_at,
+                "email": schedule_request.params["email"],
+                "is_test": schedule_request.is_test,
+                "require_approval": bool(
+                    schedule_request.params.get("require_approval", False)
+                ),
+                "expires_at": schedule_request.expires_at,
             },
         )
 


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Extract route-adjacent request parsing, normalization, validation, and response shaping helpers from `web/routes_generation.py` into a bounded helper layer.
- Keep Flask wiring, request/app context, DB/task side effects, and external runtime glue in the legacy route module while shrinking the hotspot without changing API semantics.

## Scope
### In Scope
- Add `web/generation_route_support.py` for generation route request/response helpers.
- Delegate preview, sync generation, status/history, and schedule-create helper logic from `web/routes_generation.py`.
- Add helper regression coverage and import-time side-effect coverage.
- Update architecture notes for the new bounded helper layer.

### Out of Scope
- Flask wiring redesign.
- DB/session/app context extraction.
- Background task, approval, or scheduler semantics changes.
- `newsletter/graph.py`, `newsletter/tools.py`, `newsletter/llm_factory.py` refactors.

## Delivery Unit
- RR: #326
- Delivery Unit ID: DU-20260312-routes-generation-helper-extraction
- Merge Boundary: request/response helper extraction for `web/routes_generation.py` only
- Rollback Boundary: revert this PR to restore inline helpers in `web/routes_generation.py`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed)

### Commands and Results
```bash
.local/venv/bin/python -m pytest tests/unit_tests/test_generation_route_support.py -q
# 10 passed

.local/venv/bin/python -m pytest tests/unit_tests/test_config_import_side_effects.py tests/unit_tests/test_web_import_side_effects.py -q
# 15 passed

TESTING=1 MOCK_MODE=1 GEMINI_API_KEY=dummy OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy .local/venv/bin/python -m pytest tests/api_tests/test_compact_newsletter_api.py tests/contract/test_generation_facade.py -q
# 4 passed, 7 skipped

TESTING=1 MOCK_MODE=1 GEMINI_API_KEY=dummy OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy .local/venv/bin/python -m pytest tests/test_web_api.py -q
# 21 passed, 1 skipped

TESTING=1 MOCK_MODE=1 GEMINI_API_KEY=dummy OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy .local/venv/bin/python -m pytest tests/integration/test_schedule_execution.py -q
# 8 skipped (RUN_INTEGRATION_TESTS not enabled locally)

TESTING=1 MOCK_MODE=1 GEMINI_API_KEY=dummy OPENAI_API_KEY=dummy ANTHROPIC_API_KEY=dummy .local/venv/bin/python -m pytest tests/unit_tests/test_schedule_time_sync.py tests/contract/test_web_email_routes_contract.py -q
# 11 passed

make check
# PASS

make check-full
# PASS
```

## Risk & Rollback
- Risk: route-level validation and response assembly now delegate through a new helper module.
- Rollback: revert this PR to restore the previous inline helper implementation in `web/routes_generation.py`.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: unchanged; idempotency resolution and enqueue paths remain in `web/routes_generation.py`.
- Outbox/send_key 중복 방지 결과: unchanged; email/send orchestration was not modified.
- import-time side effect 제거 여부: yes; added import regression coverage for `web.generation_route_support` and avoided new runtime dynamic loading.

## Not Run (with reason)
- `tests/integration/test_schedule_execution.py` executed locally but all cases were skipped because `RUN_INTEGRATION_TESTS=1` is not enabled in the local environment.
