### PR TITLE
chore(governance): harden delivery lifecycle gates

### DIFF
--- a/.github/ISSUE_TEMPLATE/review-request.yml
+++ b/.github/ISSUE_TEMPLATE/review-request.yml
@@ -74,3 +74,12 @@ body:
       placeholder: docs/workflow-template-standard
     validations:
       required: true
+
+  - type: input
+    id: planned_base_branch
+    attributes:
+      label: Planned Base Branch
+      description: "작업 시작 시 계획한 base branch. 실제 현재 PR base 의 정본은 GitHub PR metadata/UI 입니다."
+      placeholder: main
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE/release_integration.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_integration.md
@@ -14,6 +14,12 @@
 ### Out of Scope
 -
 
+## Delivery Unit
+RR: #<n>
+Delivery Unit ID:
+Merge Boundary:
+Rollback Boundary:
+
 ## Test & Evidence
 - [ ] `make check`
 - [ ] `make check-full`

--- a/.github/PULL_REQUEST_TEMPLATE/repo_hygiene.md
+++ b/.github/PULL_REQUEST_TEMPLATE/repo_hygiene.md
@@ -16,6 +16,12 @@
 - Commits in this PR:
   - `<hash> <summary>`
 
+## Delivery Unit
+RR: #<n>
+Delivery Unit ID:
+Merge Boundary:
+Rollback Boundary:
+
 ## Test & Evidence
 - [ ] `make check`
 - [ ] `make check-full`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,10 +11,10 @@
 - <item>
 
 ## Delivery Unit
-- RR: #<issue-number>
-- Delivery Unit ID: DU-YYYYMMDD-<topic>
-- Merge Boundary:
-- Rollback Boundary:
+RR: #<n>
+Delivery Unit ID:
+Merge Boundary:
+Rollback Boundary:
 
 ## Test & Evidence
 - [ ] `make check`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,35 @@ Global execution behavior is in `~/.codex/AGENTS.md`.
 If guidance conflicts, follow this file for this repository.
 Instruction layout reference: `docs/dev/CODEX_INSTRUCTION_LAYOUT.md`.
 
+## Mandatory Delivery Gate
+- Before modifying repo-tracked files, the first response must include `[DELIVERY_CHECK]`.
+- Required first-output fields:
+  - `Mode`
+  - `RR Reference`
+  - `Branch`
+  - `Base branch`
+  - `Working tree safe`
+  - `Proceed / Stop`
+- Required fields depend on `Mode`:
+  - `analysis-only`: `RR Reference`, `Branch`, `Base branch` may be `n/a`
+  - `local-change-only`: `RR Reference` and `Base branch` may be `n/a`; `Branch` is required when repo-tracked edits are made inside a git repository
+  - `rr-branch-commit-pr`: `RR Reference`, `Branch`, `Base branch` must be non-empty
+- Human-facing delivery blocks use `RR Reference: #<n>`.
+- `Proceed` means "proceed within the declared mode constraints"; `analysis-only` may still be `Proceed`.
+- `Working tree safe` means no unrelated modified/untracked files, or unrelated changes are explicitly listed and declared out of scope. If not safe, `Proceed` must be `Stop`.
+- Handoff minimum before reporting task completion:
+  - changed files
+  - tests run
+  - `RR Reference`
+  - `Delivery Unit ID` (if applicable)
+  - branch
+  - commit list
+  - PR link/draft artifact
+  - rollback point
+  - current CI status if available
+- Handoff and close-out are separate. `AGENTS.md` is authoritative for start-of-task behavior, handoff minimum, and the distinction between handoff and close-out. `docs/dev/CI_CD_GUIDE.md` is authoritative for detailed close-out and contributor workflow.
+- Silence is not permission to skip workflow.
+
 ## Non-negotiables
 - Default to `MOCK_MODE` for local tests and smoke runs unless explicitly testing real APIs.
 - Keep Flask + Postmark as the canonical web runtime stack.

--- a/docs/dev/AGENT_SKILL_REQUEST_PLAYBOOK.md
+++ b/docs/dev/AGENT_SKILL_REQUEST_PLAYBOOK.md
@@ -32,9 +32,13 @@ Use it when you need skill-specific request wording rather than the base RR/PR p
 
 ```text
 Handle this as a PR-sized unit of work.
+- Delivery mode: rr-branch-commit-pr
+- RR Reference: #<n>
 - Goal: <goal>
 - Scope: <in-scope / out-of-scope>
 - Branch: <type>/<scope>-<topic>
+- Base branch: <base-branch>
+- First output must begin with [DELIVERY_CHECK]
 - Required gates: make check, make check-full, make repo-audit
 - Deliverables: commit hashes, PR link, CI status, rollback note
 - Working style: small-batch (target <=300 LOC and <=8 files per PR when practical)

--- a/docs/dev/CI_CD_GUIDE.md
+++ b/docs/dev/CI_CD_GUIDE.md
@@ -159,6 +159,7 @@ python scripts/repo_audit.py \
 2. PR 본문 필수 섹션
 - `## Summary (what / why)`
 - `## Scope`
+- `## Delivery Unit`
 - `## Test & Evidence`
 - `## Risk & Rollback`
 - `## Ops-Safety Addendum (if touching protected paths)`
@@ -168,6 +169,143 @@ python scripts/repo_audit.py \
 - 형식: `<type>(<scope>): <summary>`
 - summary 최대 72자
 
+## Delivery Lifecycle Authorities
+
+- `AGENTS.md` 는 start-of-task behavior, handoff minimum, handoff와 close-out의 구분에 대한 정본입니다.
+- PR templates + workflows + `scripts/ci/validate_delivery_unit.py` 는 machine-checked literals 와 PR body shape 의 정본입니다.
+- `docs/dev/CI_CD_GUIDE.md` 는 detailed close-out 과 contributor workflow 의 정본입니다.
+
+운영 truth 는 아래처럼 분리합니다.
+
+- PR body literals are machine-checked.
+- PR metadata is the system-of-record for the actual current base branch.
+- RR template stores planned branch info, not live PR state.
+
+## Delivery Start Gate
+
+작업 시작 전 첫 응답은 항상 아래 블록으로 시작합니다.
+
+```text
+[DELIVERY_CHECK]
+- Mode:
+- RR Reference:
+- Branch:
+- Base branch:
+- Working tree safe:
+- Proceed / Stop:
+```
+
+- human-facing delivery block 에서는 `RR Reference: #<n>` 형식을 사용합니다.
+- machine-checked PR body 에서는 exact literal `RR: #<n>` 만 허용합니다.
+- `Proceed` means "proceed within the declared mode constraints."
+- `analysis-only` 도 수정 금지 상태로 `Proceed` 일 수 있습니다.
+- `Working tree safe` 는 아래 둘 중 하나일 때만 `yes` 입니다.
+  - unrelated modified/untracked files 가 없음
+  - unrelated changes 가 명시적으로 열거되고 이번 작업 out-of-scope 로 선언됨
+
+Required fields depend on `Mode`.
+
+- `analysis-only`
+  - `RR Reference`, `Branch`, `Base branch` may be `n/a`
+- `local-change-only`
+  - `RR Reference` and `Base branch` may be `n/a`
+  - when repo-tracked edits are made inside a git repository, `Branch` must report the current branch
+- `rr-branch-commit-pr`
+  - `RR Reference`, `Branch`, `Base branch` must be non-empty
+
+`Proceed` must be `Stop` only when a field required for the declared mode is missing or invalid.
+
+## Delivery Handoff and Close-out
+
+handoff 와 close-out 은 같은 시점의 완료 조건이 아닙니다.
+
+- Task handoff complete
+  - merge 전에도 정상 완료 가능
+  - minimum:
+    - changed files
+    - tests run
+    - `RR Reference`
+    - `Delivery Unit ID`
+    - branch
+    - commit list
+    - PR link or PR draft artifact
+    - rollback point
+    - current CI status if available
+- RR close-out complete
+  - merge 후 lifecycle 종료
+  - minimum:
+    - merge result
+    - final CI status if available
+    - RR close status (`auto-closed` / `still open` / `close failed`)
+
+상태 보고는 아래 인터페이스를 기준으로 유지합니다.
+
+```text
+[LIFECYCLE_STATUS]
+- Stage:
+- RR Reference:
+- Delivery Unit ID:
+- Changed files:
+- Branch:
+- Base branch at start:
+- Commits:
+- PR:
+- Tests:
+- CI status:
+- Merge result:
+- RR close status:
+- Rollback point:
+```
+
+- allowed stages:
+  - `analysis-only`
+  - `local-change-only`
+  - `pr-draft-ready`
+  - `pr-open`
+  - `merged`
+  - `rr-closed`
+- `n/a` is allowed only for fields not required by the declared Stage.
+
+Stage minimums:
+
+- `analysis-only` / `local-change-only`
+  - `Stage`
+  - `Changed files`
+  - `Tests` (if any)
+  - `Rollback point` or `n/a` if no repo change
+- `pr-draft-ready` / `pr-open`
+  - `RR Reference`
+  - `Delivery Unit ID`
+  - `Changed files`
+  - `Branch`
+  - `Commits`
+  - `PR`
+  - `Tests`
+  - `Rollback point`
+- `merged` / `rr-closed`
+  - `RR Reference`
+  - `Delivery Unit ID`
+  - `Changed files`
+  - `PR`
+  - `Merge result`
+  - `RR close status`
+  - `Rollback point`
+
+## Machine-checked PR Body Literals
+
+아래 값은 paraphrase 하지 않습니다.
+
+- `## Delivery Unit`
+- `RR: #<n>`
+- `Delivery Unit ID: <id>`
+- `Merge Boundary:`
+- `Rollback Boundary:`
+
+placeholder 규칙:
+
+- Template placeholders must be replaced before `pr-open` or `merged`.
+- Placeholder text is not a valid machine value.
+
 ## Contributor Workflow Standard
 
 기여자 workflow 정본은 이 섹션을 기준으로 유지합니다.
@@ -176,6 +314,8 @@ python scripts/repo_audit.py \
 - GitHub RR 템플릿: `.github/ISSUE_TEMPLATE/review-request.yml`
 - RR 1건은 기본적으로 PR 1건과 1:1로 대응합니다.
 - `Delivery Unit ID` 를 RR과 PR 모두에 유지합니다.
+- RR 템플릿의 `Planned Base Branch` 는 계획값입니다.
+- 실제 현재 PR base branch 의 정본은 GitHub PR metadata/UI 입니다.
 
 2. 브랜치 네이밍
 - 기본 패턴: `<type>/<scope>-<topic>`
@@ -188,7 +328,9 @@ python scripts/repo_audit.py \
 
 4. PR 본문
 - `.github/pull_request_template.md` 의 필수 섹션을 모두 채웁니다.
-- `## Delivery Unit` 섹션에 `RR`, `Delivery Unit ID`, merge/rollback boundary를 명시합니다.
+- `## Delivery Unit` 섹션에는 exact literal `RR: #<n>` 를 사용합니다.
+- `## Delivery Unit` 섹션에 `Delivery Unit ID`, `Merge Boundary:`, `Rollback Boundary:` 를 모두 채웁니다.
+- placeholder 문구(`#<n>`, `<id>` 등)는 `pr-open` 또는 `merged` 전에 실제 값으로 치환해야 합니다.
 
 5. Merge 정책
 - 기본 merge 방식: squash merge
@@ -201,9 +343,13 @@ python scripts/repo_audit.py \
 
 ```text
 이번 작업은 PR 단위로 끝까지 진행해줘.
+- Delivery mode: rr-branch-commit-pr
+- RR Reference: #<n>
 - 목표: <목표>
 - 범위: <in-scope / out-of-scope>
 - 브랜치: <type>/<scope>-<topic>
+- Base branch: <base-branch>
+- First output must begin with [DELIVERY_CHECK]
 - 필수 게이트: `python -m scripts.devtools.dev_entrypoint check`, `python -m scripts.devtools.dev_entrypoint check --full`
 - 선택 게이트: make repo-audit (구조/정책 변경 시)
 - 산출물: 커밋 해시, PR 링크, CI 상태, merge 결과, 롤백 메모

--- a/scripts/ci/validate_delivery_unit.py
+++ b/scripts/ci/validate_delivery_unit.py
@@ -9,12 +9,10 @@ import re
 import sys
 import urllib.error
 import urllib.request
-from typing import Any, Iterable, Tuple
+from typing import Any, Iterable
 
-RR_PATTERN = re.compile(r"RR\s*:\s*#(\d+)", re.IGNORECASE)
-DELIVERY_UNIT_PATTERN = re.compile(
-    r"Delivery Unit ID\s*:\s*([A-Za-z0-9._-]+)", re.IGNORECASE
-)
+RR_VALUE_PATTERN = re.compile(r"#(\d+)")
+PLACEHOLDER_PATTERN = re.compile(r"<[^>\n]+>")
 
 EXEMPT_COMMIT_COUNT_LABELS = {"docs-only", "trivial", "hotfix"}
 MIN_COMMITS = 1
@@ -66,12 +64,74 @@ def _github_paginate(url: str, token: str) -> list[dict[str, Any]]:
     return entries
 
 
-def _extract_rr_and_du(pr_body: str) -> Tuple[int | None, str | None]:
-    rr_match = RR_PATTERN.search(pr_body or "")
-    du_match = DELIVERY_UNIT_PATTERN.search(pr_body or "")
+def _extract_field_value(pr_body: str, label: str) -> str | None:
+    pattern = re.compile(
+        rf"(?im)^[ \t]*[-*]?[ \t]*{re.escape(label)}[ \t]*:[ \t]*(.*?)\s*$"
+    )
+    match = pattern.search(pr_body or "")
+    if not match:
+        return None
+    return match.group(1).strip()
 
-    rr_number = int(rr_match.group(1)) if rr_match else None
-    delivery_unit = du_match.group(1).strip() if du_match else None
+
+def _looks_like_placeholder(value: str | None) -> bool:
+    if not value:
+        return False
+    return bool(PLACEHOLDER_PATTERN.search(value.strip()))
+
+
+def _validate_delivery_unit_fields(
+    pr_body: str,
+) -> tuple[list[str], int | None, str | None]:
+    errors: list[str] = []
+    rr_number: int | None = None
+    delivery_unit: str | None = None
+
+    if "## Delivery Unit" not in pr_body:
+        errors.append("Missing PR section: `## Delivery Unit`.")
+
+    rr_value = _extract_field_value(pr_body, "RR")
+    if rr_value is None:
+        errors.append("Missing `RR: #<number>` in `## Delivery Unit` section.")
+    elif _looks_like_placeholder(rr_value):
+        errors.append(
+            "Placeholder `RR: #<n>` must be replaced in `## Delivery Unit` section."
+        )
+    else:
+        rr_match = RR_VALUE_PATTERN.fullmatch(rr_value)
+        if rr_match is None:
+            errors.append("Invalid `RR: #<number>` in `## Delivery Unit` section.")
+        else:
+            rr_number = int(rr_match.group(1))
+
+    delivery_unit_value = _extract_field_value(pr_body, "Delivery Unit ID")
+    if delivery_unit_value is None or not delivery_unit_value:
+        errors.append("Missing `Delivery Unit ID: <id>` in `## Delivery Unit` section.")
+    elif _looks_like_placeholder(delivery_unit_value):
+        errors.append(
+            "Placeholder `Delivery Unit ID:` value must be replaced in "
+            "`## Delivery Unit` section."
+        )
+    else:
+        delivery_unit = delivery_unit_value
+
+    for label in ("Merge Boundary", "Rollback Boundary"):
+        value = _extract_field_value(pr_body, label)
+        if value is None or not value:
+            errors.append(
+                f"Missing non-empty `{label}:` in `## Delivery Unit` section."
+            )
+        elif _looks_like_placeholder(value):
+            errors.append(
+                f"Placeholder `{label}:` value must be replaced in "
+                "`## Delivery Unit` section."
+            )
+
+    return errors, rr_number, delivery_unit
+
+
+def _extract_rr_and_du(pr_body: str) -> tuple[int | None, str | None]:
+    _, rr_number, delivery_unit = _validate_delivery_unit_fields(pr_body or "")
     return rr_number, delivery_unit
 
 
@@ -114,22 +174,8 @@ def main() -> int:
         print("No pull_request payload found in event.")
         return 1
 
-    if "## Delivery Unit" not in pr_body:
-        errors.append("Missing PR section: `## Delivery Unit`.")
-
-    rr_number, delivery_unit = _extract_rr_and_du(pr_body)
-    if rr_number is None:
-        errors.append("Missing `RR: #<number>` in `## Delivery Unit` section.")
-    if not delivery_unit:
-        errors.append("Missing `Delivery Unit ID: <id>` in `## Delivery Unit` section.")
-    if not re.search(r"Merge Boundary\s*:\s*\S+", pr_body, re.IGNORECASE):
-        errors.append(
-            "Missing non-empty `Merge Boundary:` in `## Delivery Unit` section."
-        )
-    if not re.search(r"Rollback Boundary\s*:\s*\S+", pr_body, re.IGNORECASE):
-        errors.append(
-            "Missing non-empty `Rollback Boundary:` in `## Delivery Unit` section."
-        )
+    body_errors, rr_number, delivery_unit = _validate_delivery_unit_fields(pr_body)
+    errors.extend(body_errors)
 
     owner, repo = repository.split("/", 1)
     api_base = f"https://api.github.com/repos/{owner}/{repo}"

--- a/tests/contract/test_delivery_governance_truth.py
+++ b/tests/contract/test_delivery_governance_truth.py
@@ -1,0 +1,88 @@
+"""Contract tests for delivery gate and RR lifecycle documentation truth."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_text(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_agents_declares_delivery_gate_and_authority_boundaries() -> None:
+    agents = _read_text("AGENTS.md")
+
+    required_entries = [
+        "## Mandatory Delivery Gate",
+        "[DELIVERY_CHECK]",
+        "local-change-only",
+        "Branch` is required when repo-tracked edits are made inside a git repository",
+        "RR Reference: #<n>",
+        "Delivery Unit ID",
+        "changed files",
+        "Silence is not permission to skip workflow.",
+        "AGENTS.md` is authoritative for start-of-task behavior, handoff minimum, and the distinction between handoff and close-out.",
+    ]
+
+    for entry in required_entries:
+        assert entry in agents
+
+
+def test_ci_cd_guide_tracks_delivery_lifecycle_truth() -> None:
+    ci_guide = _read_text("docs/dev/CI_CD_GUIDE.md")
+
+    required_entries = [
+        "## Delivery Lifecycle Authorities",
+        "## Delivery Start Gate",
+        "## Delivery Handoff and Close-out",
+        "## Machine-checked PR Body Literals",
+        "## Delivery Unit",
+        "RR: #<n>",
+        "Delivery Unit ID: <id>",
+        "Merge Boundary:",
+        "Rollback Boundary:",
+        "RR Reference: #<n>",
+        "PR metadata is the system-of-record for the actual current base branch.",
+        "n/a` is allowed only for fields not required by the declared Stage.",
+        "Template placeholders must be replaced before `pr-open` or `merged`.",
+    ]
+
+    for entry in required_entries:
+        assert entry in ci_guide
+
+
+def test_rr_and_pr_templates_expose_delivery_unit_slots() -> None:
+    rr_template = _read_text(".github/ISSUE_TEMPLATE/review-request.yml")
+    base_pr_template = _read_text(".github/pull_request_template.md")
+    repo_hygiene_template = _read_text(".github/PULL_REQUEST_TEMPLATE/repo_hygiene.md")
+    release_integration_template = _read_text(
+        ".github/PULL_REQUEST_TEMPLATE/release_integration.md"
+    )
+    playbook = _read_text("docs/dev/AGENT_SKILL_REQUEST_PLAYBOOK.md")
+
+    assert "label: Planned Base Branch" in rr_template
+
+    for template in (
+        base_pr_template,
+        repo_hygiene_template,
+        release_integration_template,
+    ):
+        assert "## Delivery Unit" in template
+        assert "RR: #<n>" in template
+        assert "Delivery Unit ID:" in template
+        assert "Merge Boundary:" in template
+        assert "Rollback Boundary:" in template
+
+    for entry in (
+        "Delivery mode: rr-branch-commit-pr",
+        "RR Reference: #<n>",
+        "Base branch: <base-branch>",
+        "First output must begin with [DELIVERY_CHECK]",
+    ):
+        assert entry in playbook

--- a/tests/unit_tests/test_validate_delivery_unit.py
+++ b/tests/unit_tests/test_validate_delivery_unit.py
@@ -1,0 +1,90 @@
+"""Unit tests for delivery unit validator helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "ci"))
+
+import validate_delivery_unit as delivery_validator  # noqa: E402
+
+
+def test_extract_field_value_supports_plain_and_bulleted_lines() -> None:
+    pr_body = """
+## Delivery Unit
+RR: #123
+- Delivery Unit ID: DU-20260316-doc-governance
+Merge Boundary: squash
+Rollback Boundary: revert
+"""
+
+    assert delivery_validator._extract_field_value(pr_body, "RR") == "#123"
+    assert (
+        delivery_validator._extract_field_value(pr_body, "Delivery Unit ID")
+        == "DU-20260316-doc-governance"
+    )
+
+
+def test_looks_like_placeholder_detects_angle_bracket_tokens() -> None:
+    assert delivery_validator._looks_like_placeholder("#<n>")
+    assert delivery_validator._looks_like_placeholder("DU-YYYYMMDD-<topic>")
+    assert not delivery_validator._looks_like_placeholder("#123")
+    assert not delivery_validator._looks_like_placeholder("DU-20260316-governance")
+
+
+def test_validate_delivery_unit_fields_accepts_filled_template() -> None:
+    pr_body = """
+## Delivery Unit
+RR: #42
+Delivery Unit ID: DU-20260316-delivery-governance
+Merge Boundary: squash merge
+Rollback Boundary: revert-merge-sha
+"""
+
+    (
+        errors,
+        rr_number,
+        delivery_unit,
+    ) = delivery_validator._validate_delivery_unit_fields(pr_body)
+
+    assert errors == []
+    assert rr_number == 42
+    assert delivery_unit == "DU-20260316-delivery-governance"
+
+
+def test_validate_delivery_unit_fields_rejects_placeholders_and_empty_values() -> None:
+    pr_body = """
+## Delivery Unit
+RR: #<n>
+Delivery Unit ID:
+Merge Boundary: <merge-boundary>
+Rollback Boundary:
+"""
+
+    (
+        errors,
+        rr_number,
+        delivery_unit,
+    ) = delivery_validator._validate_delivery_unit_fields(pr_body)
+
+    assert rr_number is None
+    assert delivery_unit is None
+    assert (
+        "Placeholder `RR: #<n>` must be replaced in `## Delivery Unit` section."
+        in errors
+    )
+    assert "Missing `Delivery Unit ID: <id>` in `## Delivery Unit` section." in errors
+    assert (
+        "Placeholder `Merge Boundary:` value must be replaced in "
+        "`## Delivery Unit` section." in errors
+    )
+    assert (
+        "Missing non-empty `Rollback Boundary:` in `## Delivery Unit` section."
+        in errors
+    )


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Align repository delivery governance docs, templates, validator behavior, and tests so delivery start gates and lifecycle handoff rules stay machine-checkable.

## Scope
### In Scope
- Delivery gate guidance in `AGENTS.md` and `docs/dev/CI_CD_GUIDE.md`
- RR/PR template alignment
- Delivery unit validator tightening
- Governance truth/unit tests

### Out of Scope
- Runtime/platform adapter work
- Packaging/runtime path behavior
- Build script changes
- Support-policy changes

## Delivery Unit
RR: #365
Delivery Unit ID: DU-20260316-governance-delivery-hardening
Merge Boundary: squash merge this governance-only bundle as a single PR
Rollback Boundary: revert the governance hardening commit on this branch

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): targeted governance pytest commands

### Commands and Results
```bash
.local/venv/bin/python -m black scripts/ci/validate_delivery_unit.py tests/contract/test_delivery_governance_truth.py tests/contract/test_ci_workflow_truth.py tests/unit_tests/test_validate_delivery_unit.py
.local/venv/bin/python -m isort --profile black scripts/ci/validate_delivery_unit.py tests/unit_tests/test_validate_delivery_unit.py
COVERAGE_FILE=.local/coverage/governance_validator .local/venv/bin/python -m pytest tests/unit_tests/test_validate_delivery_unit.py -q
COVERAGE_FILE=.local/coverage/governance_truth .local/venv/bin/python -m pytest tests/contract/test_delivery_governance_truth.py -q
COVERAGE_FILE=.local/coverage/ci_workflow_truth .local/venv/bin/python -m pytest tests/contract/test_ci_workflow_truth.py -q
make check
make check-full
```

## Risk & Rollback
- Risk: existing open PRs with placeholder or empty `## Delivery Unit` values may now fail validator checks sooner.
- Rollback: revert the governance hardening commit and close RR/PR artifacts.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: n/a
- Outbox/send_key 중복 방지 결과: n/a
- import-time side effect 제거 여부: n/a

## Not Run (with reason)
- Merge-result and RR close-out verification are deferred until after this PR actually merges.

## Rollout Note
- Validator hardening may fail existing open PRs that still contain placeholders or empty `## Delivery Unit` fields.
- Existing open PRs should verify exact Delivery Unit literals and non-empty values before re-running CI.
