### PR TITLE
chore(governance): dogfood validator message flow

### DIFF
--- a/scripts/ci/validate_delivery_unit.py
+++ b/scripts/ci/validate_delivery_unit.py
@@ -106,7 +106,9 @@ def _validate_delivery_unit_fields(
 
     delivery_unit_value = _extract_field_value(pr_body, "Delivery Unit ID")
     if delivery_unit_value is None or not delivery_unit_value:
-        errors.append("Missing `Delivery Unit ID: <id>` in `## Delivery Unit` section.")
+        errors.append(
+            "Missing non-empty `Delivery Unit ID:` in `## Delivery Unit` section."
+        )
     elif _looks_like_placeholder(delivery_unit_value):
         errors.append(
             "Placeholder `Delivery Unit ID:` value must be replaced in "

--- a/tests/unit_tests/test_validate_delivery_unit.py
+++ b/tests/unit_tests/test_validate_delivery_unit.py
@@ -79,7 +79,9 @@ Rollback Boundary:
         "Placeholder `RR: #<n>` must be replaced in `## Delivery Unit` section."
         in errors
     )
-    assert "Missing `Delivery Unit ID: <id>` in `## Delivery Unit` section." in errors
+    assert (
+        "Missing non-empty `Delivery Unit ID:` in `## Delivery Unit` section." in errors
+    )
     assert (
         "Placeholder `Merge Boundary:` value must be replaced in "
         "`## Delivery Unit` section." in errors


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Dogfood the new governance workflow with one tiny validator/test change that improves remediation guidance for empty Delivery Unit values.

## Scope
### In Scope
- Refine one validator error message in `scripts/ci/validate_delivery_unit.py`
- Update the matching unit test assertion

### Out of Scope
- Governance docs/template changes
- Runtime/platform work
- Packaging/runtime path behavior

## Delivery Unit
RR: #367
Delivery Unit ID: DU-20260316-governance-dogfood-validator-message
Merge Boundary: squash merge this stacked dogfood PR after governance PR review
Rollback Boundary: revert the dogfood validator-message commit

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): targeted validator pytest

### Commands and Results
```bash
.local/venv/bin/python -m black scripts/ci/validate_delivery_unit.py tests/unit_tests/test_validate_delivery_unit.py
.local/venv/bin/python -m isort --profile black scripts/ci/validate_delivery_unit.py tests/unit_tests/test_validate_delivery_unit.py
COVERAGE_FILE=.local/coverage/dogfood_validator .local/venv/bin/python -m pytest tests/unit_tests/test_validate_delivery_unit.py -q
make check
make check-full
```

## Risk & Rollback
- Risk: validator/test wording alignment only.
- Rollback: revert the dogfood commit and close the stacked PR.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: n/a
- Outbox/send_key 중복 방지 결과: n/a
- import-time side effect 제거 여부: n/a

## Not Run (with reason)
- Merge-result, final CI observation, and RR close-out remain deferred until an actual merge happens.
