### PR TITLE
docs(delivery): default rr lifecycle to rr-closed

### DIFF
--- a/.github/ISSUE_TEMPLATE/review-request.yml
+++ b/.github/ISSUE_TEMPLATE/review-request.yml
@@ -27,6 +27,15 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: lifecycle_target
+    attributes:
+      label: Lifecycle Target
+      description: "기본값은 rr-closed. 더 이른 단계로 종료할 때만 다른 값을 적습니다."
+      placeholder: rr-closed
+    validations:
+      required: true
+
   - type: textarea
     id: in_scope
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,7 @@ Rollback Boundary:
 ## Test & Evidence
 - [ ] `make check`
 - [ ] `make check-full`
+- [ ] GitHub required checks green before merge
 - [ ] Additional tests (if needed):
 
 ### Commands and Results

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,18 +9,21 @@ Instruction layout reference: `docs/dev/CODEX_INSTRUCTION_LAYOUT.md`.
 - Before modifying repo-tracked files, the first response must include `[DELIVERY_CHECK]`.
 - Required first-output fields:
   - `Mode`
+  - `Lifecycle target`
   - `RR Reference`
   - `Branch`
   - `Base branch`
   - `Working tree safe`
   - `Proceed / Stop`
+- `Lifecycle target` must be one of `analysis-only`, `local-change-only`, `pr-draft-ready`, `pr-open`, `merged`, `rr-closed`.
 - Required fields depend on `Mode`:
-  - `analysis-only`: `RR Reference`, `Branch`, `Base branch` may be `n/a`
-  - `local-change-only`: `RR Reference` and `Base branch` may be `n/a`; `Branch` is required when repo-tracked edits are made inside a git repository
-  - `rr-branch-commit-pr`: `RR Reference`, `Branch`, `Base branch` must be non-empty
+  - `analysis-only`: `Lifecycle target` must be `analysis-only`; `RR Reference`, `Branch`, `Base branch` may be `n/a`
+  - `local-change-only`: `Lifecycle target` must be `local-change-only`; `RR Reference` and `Base branch` may be `n/a`; `Branch` is required when repo-tracked edits are made inside a git repository
+  - `rr-branch-commit-pr`: `RR Reference`, `Branch`, `Base branch` must be non-empty; default to `Mode: rr-branch-commit-pr` and `Lifecycle target: rr-closed` for implementation work unless the user explicitly narrows scope
 - Human-facing delivery blocks use `RR Reference: #<n>`.
 - `Proceed` means "proceed within the declared mode constraints"; `analysis-only` may still be `Proceed`.
 - `Working tree safe` means no unrelated modified/untracked files, or unrelated changes are explicitly listed and declared out of scope. If not safe, `Proceed` must be `Stop`.
+- Do not silently downgrade to `local-change-only`. If RR/base branch/permissions are missing for `rr-branch-commit-pr`, `Proceed / Stop` must be `Stop` and the missing prerequisite must be called out explicitly.
 - Handoff minimum before reporting task completion:
   - changed files
   - tests run
@@ -31,6 +34,16 @@ Instruction layout reference: `docs/dev/CODEX_INSTRUCTION_LAYOUT.md`.
   - PR link/draft artifact
   - rollback point
   - current CI status if available
+- Default completion for `rr-branch-commit-pr` with `Lifecycle target: rr-closed` requires:
+  - RR exists
+  - branch exists
+  - commit list exists
+  - PR exists
+  - local verification ran
+  - required checks are green
+  - merge completed
+  - RR close status confirmed
+  - delivery branch/worktree cleanup confirmed
 - Handoff and close-out are separate. `AGENTS.md` is authoritative for start-of-task behavior, handoff minimum, and the distinction between handoff and close-out. `docs/dev/CI_CD_GUIDE.md` is authoritative for detailed close-out and contributor workflow.
 - Silence is not permission to skip workflow.
 
@@ -90,6 +103,7 @@ Ops-safety-sensitive paths:
 
 ## Workflow Contract (RR/Branch/Commit/PR)
 - Standard flow: RR -> Branch -> Commit -> PR -> Merge.
+- Default lifecycle target for standard implementation work: `rr-closed`.
 - RR template: `.github/ISSUE_TEMPLATE/review-request.yml`
 - Branch naming: `<type>/<scope>-<topic>`
 - Commit messages follow `.gitmessage.txt`.
@@ -99,6 +113,7 @@ Ops-safety-sensitive paths:
 - Keep each PR within about 300 LOC and 8 files when possible.
 - For large refactors, lock contract tests first and split into sequential PRs.
 - Default merge strategy is squash; exceptions require explicit evidence.
+- After merge, verify RR close status and clean up only the delivery branch/worktree created for that task. Never delete unrelated branches, worktrees, or uncommitted changes.
 
 ## Skill Routing (Prefer Skills for Repetitive Playbooks)
 - Keep this file short; move repetitive procedures into `.agents/skills/*/SKILL.md`.

--- a/docs/dev/AGENT_SKILL_REQUEST_PLAYBOOK.md
+++ b/docs/dev/AGENT_SKILL_REQUEST_PLAYBOOK.md
@@ -31,18 +31,23 @@ Use it when you need skill-specific request wording rather than the base RR/PR p
 ### 1) PR-sized structure improvement request
 
 ```text
-Handle this as a PR-sized unit of work.
+Handle this as a delivery unit that closes the RR by default.
 - Delivery mode: rr-branch-commit-pr
+- Lifecycle target: rr-closed
+- Goal: 변경 반영 -> RR 생성 -> branch 생성 -> commit -> PR 생성 -> 로컬/CI 테스트 확인 -> 필요 시 수정 -> required checks green 확인 후 merge -> RR 종료 확인 -> 불필요한 branch/worktree 정리
 - RR Reference: #<n>
-- Goal: <goal>
 - Scope: <in-scope / out-of-scope>
 - Branch: <type>/<scope>-<topic>
 - Base branch: <base-branch>
 - First output must begin with [DELIVERY_CHECK]
+- If RR/base branch/permissions are missing, stop and ask for the missing prerequisite instead of falling back to local-change-only.
 - Required gates: make check, make check-full, make repo-audit
-- Deliverables: commit hashes, PR link, CI status, rollback note
+- Deliverables: commit hashes, PR link, CI status, merge result, RR close status, branch/worktree cleanup status, rollback note
 - Working style: small-batch (target <=300 LOC and <=8 files per PR when practical)
 ```
+
+- default expected end state is `rr-closed`
+- `local-change-only` may only be proposed as a fallback option
 
 ### 2) CI failure response request
 

--- a/docs/dev/CI_CD_GUIDE.md
+++ b/docs/dev/CI_CD_GUIDE.md
@@ -188,6 +188,7 @@ python scripts/repo_audit.py \
 ```text
 [DELIVERY_CHECK]
 - Mode:
+- Lifecycle target:
 - RR Reference:
 - Branch:
 - Base branch:
@@ -202,22 +203,42 @@ python scripts/repo_audit.py \
 - `Working tree safe` 는 아래 둘 중 하나일 때만 `yes` 입니다.
   - unrelated modified/untracked files 가 없음
   - unrelated changes 가 명시적으로 열거되고 이번 작업 out-of-scope 로 선언됨
+- `Lifecycle target` allowed values: `analysis-only`, `local-change-only`, `pr-draft-ready`, `pr-open`, `merged`, `rr-closed`
+- 구현 작업을 명시적으로 더 좁히지 않았다면 기본값은 `Mode: rr-branch-commit-pr` 와 `Lifecycle target: rr-closed` 입니다.
+- `local-change-only` 는 explicit opt-in/fallback 용도입니다. RR/base branch/permissions 가 없다는 이유로 자동 강등하지 않습니다.
+
+기본 구현 요청은 아래처럼 시작합니다.
+
+```text
+[DELIVERY_CHECK]
+- Mode: rr-branch-commit-pr
+- Lifecycle target: rr-closed
+- RR Reference: #<n> | pending prerequisite
+- Branch: <type>/<scope>-<topic>
+- Base branch: <base-branch>
+- Working tree safe: yes|no
+- Proceed / Stop: Proceed|Stop
+```
 
 Required fields depend on `Mode`.
 
 - `analysis-only`
+  - `Lifecycle target` must be `analysis-only`
   - `RR Reference`, `Branch`, `Base branch` may be `n/a`
 - `local-change-only`
+  - `Lifecycle target` must be `local-change-only`
   - `RR Reference` and `Base branch` may be `n/a`
   - when repo-tracked edits are made inside a git repository, `Branch` must report the current branch
 - `rr-branch-commit-pr`
+  - default `Lifecycle target` is `rr-closed` unless the request explicitly narrows to `pr-draft-ready`, `pr-open`, or `merged`
   - `RR Reference`, `Branch`, `Base branch` must be non-empty
 
-`Proceed` must be `Stop` only when a field required for the declared mode is missing or invalid.
+`Proceed` must be `Stop` when a field required for the declared mode is missing or invalid, or when RR/base branch/permissions required for `rr-branch-commit-pr` are not available yet.
 
 ## Delivery Handoff and Close-out
 
 handoff 와 close-out 은 같은 시점의 완료 조건이 아닙니다.
+기본 기대 종료 상태는 `rr-closed` 입니다. handoff 는 중간 인계 상태로 허용되지만, 명시적으로 target 을 낮추지 않았다면 기본 완료로 간주하지 않습니다.
 
 - Task handoff complete
   - merge 전에도 정상 완료 가능
@@ -243,6 +264,7 @@ handoff 와 close-out 은 같은 시점의 완료 조건이 아닙니다.
 ```text
 [LIFECYCLE_STATUS]
 - Stage:
+- Lifecycle target:
 - RR Reference:
 - Delivery Unit ID:
 - Changed files:
@@ -254,6 +276,8 @@ handoff 와 close-out 은 같은 시점의 완료 조건이 아닙니다.
 - CI status:
 - Merge result:
 - RR close status:
+- Branch cleanup:
+- Worktree clean:
 - Rollback point:
 ```
 
@@ -270,10 +294,12 @@ Stage minimums:
 
 - `analysis-only` / `local-change-only`
   - `Stage`
+  - `Lifecycle target`
   - `Changed files`
   - `Tests` (if any)
   - `Rollback point` or `n/a` if no repo change
 - `pr-draft-ready` / `pr-open`
+  - `Lifecycle target`
   - `RR Reference`
   - `Delivery Unit ID`
   - `Changed files`
@@ -283,12 +309,15 @@ Stage minimums:
   - `Tests`
   - `Rollback point`
 - `merged` / `rr-closed`
+  - `Lifecycle target`
   - `RR Reference`
   - `Delivery Unit ID`
   - `Changed files`
   - `PR`
   - `Merge result`
   - `RR close status`
+  - `Branch cleanup`
+  - `Worktree clean`
   - `Rollback point`
 
 ## Machine-checked PR Body Literals
@@ -336,23 +365,25 @@ placeholder 규칙:
 - 기본 merge 방식: squash merge
 - merge 전 조건: `python -m scripts.devtools.dev_entrypoint check --full` 및 GitHub required checks green
 - hotfix 등 예외는 `## Not Run` 에 사유를 남깁니다.
+- merge 후에는 RR close status 를 확인하고, 이번 delivery unit 이 만든 branch/worktree 만 정리합니다.
 
 ## Request Entry Patterns
 
 ### Standard RR request
 
 ```text
-이번 작업은 PR 단위로 끝까지 진행해줘.
+이번 작업은 RR close까지 끝내는 delivery unit으로 처리해줘.
 - Delivery mode: rr-branch-commit-pr
+- Lifecycle target: rr-closed
+- Goal: 변경 반영 -> RR 생성 -> branch 생성 -> commit -> PR 생성 -> 로컬/CI 테스트 확인 -> 필요 시 수정 -> required checks green 확인 후 merge -> RR 종료 확인 -> 불필요한 branch/worktree 정리
 - RR Reference: #<n>
-- 목표: <목표>
-- 범위: <in-scope / out-of-scope>
-- 브랜치: <type>/<scope>-<topic>
+- Scope: <in-scope / out-of-scope>
+- Branch: <type>/<scope>-<topic>
 - Base branch: <base-branch>
 - First output must begin with [DELIVERY_CHECK]
-- 필수 게이트: `python -m scripts.devtools.dev_entrypoint check`, `python -m scripts.devtools.dev_entrypoint check --full`
-- 선택 게이트: make repo-audit (구조/정책 변경 시)
-- 산출물: 커밋 해시, PR 링크, CI 상태, merge 결과, 롤백 메모
+- If RR/base branch/permissions are missing, stop and ask for the missing prerequisite instead of falling back to local-change-only.
+- Required gates: `python -m scripts.devtools.dev_entrypoint check`, `python -m scripts.devtools.dev_entrypoint check --full`
+- Deliverables: commit hashes, PR link, CI status, merge result, RR close status, branch/worktree cleanup status, rollback note
 ```
 
 ### CI failure request

--- a/tests/contract/test_delivery_governance_truth.py
+++ b/tests/contract/test_delivery_governance_truth.py
@@ -21,11 +21,16 @@ def test_agents_declares_delivery_gate_and_authority_boundaries() -> None:
     required_entries = [
         "## Mandatory Delivery Gate",
         "[DELIVERY_CHECK]",
+        "Lifecycle target",
         "local-change-only",
+        "default to `Mode: rr-branch-commit-pr` and `Lifecycle target: rr-closed`",
+        "Do not silently downgrade to `local-change-only`.",
         "Branch` is required when repo-tracked edits are made inside a git repository",
         "RR Reference: #<n>",
         "Delivery Unit ID",
         "changed files",
+        "required checks are green",
+        "delivery branch/worktree cleanup confirmed",
         "Silence is not permission to skip workflow.",
         "AGENTS.md` is authoritative for start-of-task behavior, handoff minimum, and the distinction between handoff and close-out.",
     ]
@@ -47,6 +52,10 @@ def test_ci_cd_guide_tracks_delivery_lifecycle_truth() -> None:
         "Delivery Unit ID: <id>",
         "Merge Boundary:",
         "Rollback Boundary:",
+        "Lifecycle target: rr-closed",
+        "Goal: 변경 반영 -> RR 생성 -> branch 생성 -> commit -> PR 생성 -> 로컬/CI 테스트 확인 -> 필요 시 수정 -> required checks green 확인 후 merge -> RR 종료 확인 -> 불필요한 branch/worktree 정리",
+        "Branch cleanup:",
+        "Worktree clean:",
         "RR Reference: #<n>",
         "PR metadata is the system-of-record for the actual current base branch.",
         "n/a` is allowed only for fields not required by the declared Stage.",
@@ -66,7 +75,12 @@ def test_rr_and_pr_templates_expose_delivery_unit_slots() -> None:
     )
     playbook = _read_text("docs/dev/AGENT_SKILL_REQUEST_PLAYBOOK.md")
 
-    assert "label: Planned Base Branch" in rr_template
+    for entry in (
+        "label: Lifecycle Target",
+        "placeholder: rr-closed",
+        "label: Planned Base Branch",
+    ):
+        assert entry in rr_template
 
     for template in (
         base_pr_template,
@@ -81,8 +95,14 @@ def test_rr_and_pr_templates_expose_delivery_unit_slots() -> None:
 
     for entry in (
         "Delivery mode: rr-branch-commit-pr",
+        "Lifecycle target: rr-closed",
+        "Goal: 변경 반영 -> RR 생성 -> branch 생성 -> commit -> PR 생성 -> 로컬/CI 테스트 확인 -> 필요 시 수정 -> required checks green 확인 후 merge -> RR 종료 확인 -> 불필요한 branch/worktree 정리",
         "RR Reference: #<n>",
         "Base branch: <base-branch>",
         "First output must begin with [DELIVERY_CHECK]",
+        "default expected end state is `rr-closed`",
+        "`local-change-only` may only be proposed as a fallback option",
     ):
         assert entry in playbook
+
+    assert "GitHub required checks green before merge" in base_pr_template


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- make rr-branch-commit-pr with lifecycle target rr-closed the documented default for implementation work
- align AGENTS, CI/CD guide, request playbook, GitHub templates, and contract tests on the same delivery contract

## Scope
### In Scope
- delivery gate protocol and lifecycle reporting wording
- canonical request/playbook wording for rr-closed delivery units
- RR/PR templates and delivery governance contract tests

### Out of Scope
- runtime or product behavior changes outside delivery workflow governance
- automation of RR/PR/merge operations beyond documenting and validating the contract

## Delivery Unit
RR: #374
Delivery Unit ID: DU-20260319-delivery-rr-closed-default
Merge Boundary: After GitHub required checks green for this PR; merge only this delivery branch
Rollback Boundary: Revert the squash merge or revert commit ebd36c5

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [x] Additional tests (if needed): `.local/venv/bin/python -m pytest tests/contract/test_delivery_governance_truth.py -q`
- [ ] GitHub required checks green before merge

### Commands and Results
```bash
.local/venv/bin/python -m pytest tests/contract/test_delivery_governance_truth.py -q
make check
make check-full
```

## Risk & Rollback
- Risk: contributors may follow outdated workflow wording if these docs/templates/tests are only partially reverted.
- Rollback: revert commit `ebd36c5` or revert the squash merge for this PR.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: n/a
- Outbox/send_key 중복 방지 결과: n/a
- import-time side effect 제거 여부: n/a

## Not Run (with reason)
- GitHub required checks are pending immediately after PR creation and must be confirmed green before merge.
