### PR TITLE
docs(readme): simplify quick demo input

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -23,25 +23,8 @@
 **입력**
 
 ```text
-Title: Maintainer Communication Brief
-Topic: Maintainer workflow automation
-Date: 2026-03-19
-Issue: 14
-Tagline: Turn weekly project activity into a concise update teams can actually use.
-Audience: Prepared for contributors, internal stakeholders, and partner teams.
-
-[Top Stories]
-- Release notes drafts now start from merged pull requests | The weekly changelog is pre-assembled from merged PR metadata, leaving maintainers with a short editorial pass instead of a full rewrite. | Project activity · 2026-03-19
-
-[Project Delivery]
-Intro: Updates that reduce repetitive maintainer coordination work.
-- Weekly digest draft is prepared from project activity and issue labels | Release workflow · 2026-03-19
-
-[Definitions]
-- Idempotency key | A stable request identifier used to prevent duplicate jobs or duplicate email sends.
-
-[Things to Watch]
-- If GitHub issue and pull request summaries are added next, maintainers can publish weekly updates with much less manual editing.
+도메인: 자동차
+키워드: 자율주행, ADAS, Tesla FSD, Waymo
 ```
 
 **출력**

--- a/README.md
+++ b/README.md
@@ -23,25 +23,8 @@ Static preview of the default `compact` output shape.
 **Input**
 
 ```text
-Title: Maintainer Communication Brief
-Topic: Maintainer workflow automation
-Date: 2026-03-19
-Issue: 14
-Tagline: Turn weekly project activity into a concise update teams can actually use.
-Audience: Prepared for contributors, internal stakeholders, and partner teams.
-
-[Top Stories]
-- Release notes drafts now start from merged pull requests | The weekly changelog is pre-assembled from merged PR metadata, leaving maintainers with a short editorial pass instead of a full rewrite. | Project activity · 2026-03-19
-
-[Project Delivery]
-Intro: Updates that reduce repetitive maintainer coordination work.
-- Weekly digest draft is prepared from project activity and issue labels | Release workflow · 2026-03-19
-
-[Definitions]
-- Idempotency key | A stable request identifier used to prevent duplicate jobs or duplicate email sends.
-
-[Things to Watch]
-- If GitHub issue and pull request summaries are added next, maintainers can publish weekly updates with much less manual editing.
+Domain: Automotive
+Keywords: autonomous driving, ADAS, Tesla FSD, Waymo
 ```
 
 **Output**


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Simplify the root README Quick Demo input examples so they reflect the public interface instead of a pseudo-structured source document.

## Scope
### In Scope
- Replace the Quick Demo input block in `README.md` with a short domain/keywords example
- Replace the Quick Demo input block in `README.ko.md` with the matching short domain/keywords example

### Out of Scope
- Runtime, CLI, API, or template behavior changes
- Any README sections outside the Quick Demo input block
- Unrelated local changes in the original working tree

## Delivery Unit
RR: #378
Delivery Unit ID: DU-20260319-quick-demo-input
Merge Boundary: docs-only README input example adjustment in the root bilingual landing pages
Rollback Boundary: revert commit `15c10ab`

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [ ] GitHub required checks green before merge
- [x] Additional tests (if needed): quick content verification of the `Quick Demo` input blocks in both READMEs

### Commands and Results
```bash
python3 -m scripts.devtools.dev_entrypoint bootstrap
PATH="$(pwd)/.local/venv/bin:$PATH" MOCK_MODE=1 make check
PATH="$(pwd)/.local/venv/bin:$PATH" MOCK_MODE=1 make check-full
python3 - <<'PY'
from pathlib import Path
for name in ['README.md','README.ko.md']:
    text = Path(name).read_text(encoding='utf-8')
    start = text.index('**Input**' if name == 'README.md' else '**입력**')
    end = text.index('**Output**' if name == 'README.md' else '**출력**')
    print(text[start:end].strip())
PY
```

## Risk & Rollback
- Risk: very low; docs-only input example wording change
- Rollback: revert commit `15c10ab` or the PR squash merge commit

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: not applicable
- Outbox/send_key 중복 방지 결과: not applicable
- import-time side effect 제거 여부: none introduced

## Not Run (with reason)
- No additional ops-safety tests were required because no protected runtime paths were changed.
