### PR TITLE
fix(ci): align docs-quality required check scope

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -25,7 +25,8 @@
 
 4. `docs-quality.yml`
 - 목적: 문서 링크/스타일 품질 검증
-- 트리거: markdown 변경 `pull_request`/`push`
+- 트리거: `main`/`develop` 대상 `pull_request`/`push`
+- 동작: required check 가 항상 emit 되며, docs 관련 변경이 없으면 no-op pass 로 종료
 
 5. `ops-safety-monitor.yml`
 - 목적: 운영 안전성 점검 모니터링

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -2,16 +2,9 @@ name: Docs Quality
 
 on:
   pull_request:
-    paths:
-      - '**/*.md'
-      - 'scripts/check_markdown_*.py'
-      - '.github/workflows/docs-quality.yml'
+    branches: [ main, develop ]
   push:
-    branches: [ main ]
-    paths:
-      - '**/*.md'
-      - 'scripts/check_markdown_*.py'
-      - '.github/workflows/docs-quality.yml'
+    branches: [ main, develop ]
 
 jobs:
   docs-quality:
@@ -33,17 +26,36 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             git fetch origin "${{ github.base_ref }}" --depth=1
-            git diff --name-only --diff-filter=ACMRTUXB "origin/${{ github.base_ref }}"...HEAD -- '*.md' > /tmp/changed_md.txt
+            git diff --name-only --diff-filter=ACMRTUXB \
+              "origin/${{ github.base_ref }}"...HEAD \
+              -- '*.md' 'scripts/check_markdown_*.py' '.github/workflows/docs-quality.yml' \
+              > /tmp/docs_quality_scope.txt
+            git diff --name-only --diff-filter=ACMRTUXB \
+              "origin/${{ github.base_ref }}"...HEAD -- '*.md' \
+              > /tmp/changed_md.txt
           else
-            git diff --name-only --diff-filter=ACMRTUXB "${{ github.event.before }}" "${{ github.sha }}" -- '*.md' > /tmp/changed_md.txt
+            git diff --name-only --diff-filter=ACMRTUXB \
+              "${{ github.event.before }}" "${{ github.sha }}" \
+              -- '*.md' 'scripts/check_markdown_*.py' '.github/workflows/docs-quality.yml' \
+              > /tmp/docs_quality_scope.txt
+            git diff --name-only --diff-filter=ACMRTUXB \
+              "${{ github.event.before }}" "${{ github.sha }}" -- '*.md' \
+              > /tmp/changed_md.txt
           fi
 
           echo "files=$(tr '\n' ' ' < /tmp/changed_md.txt)" >> "$GITHUB_OUTPUT"
+          if [[ -s /tmp/docs_quality_scope.txt ]]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Check markdown links
+        if: steps.changed_md.outputs.relevant == 'true'
         run: python scripts/check_markdown_links.py
 
       - name: Check markdown style
+        if: steps.changed_md.outputs.relevant == 'true'
         shell: bash
         run: |
           if [[ -n "${{ steps.changed_md.outputs.files }}" ]]; then
@@ -51,3 +63,7 @@ jobs:
           else
             echo "No changed markdown files detected for style check."
           fi
+
+      - name: No docs-related changes detected; docs-quality satisfied.
+        if: steps.changed_md.outputs.relevant != 'true'
+        run: echo "No markdown/docs-quality inputs changed; required docs-quality check emitted as a no-op pass."

--- a/docs/dev/CI_CD_GUIDE.md
+++ b/docs/dev/CI_CD_GUIDE.md
@@ -24,7 +24,8 @@
 
 4. `docs-quality.yml`
 - Markdown 링크/스타일 품질 검증
-- 문서 변경 push/PR에서 실행
+- `main`/`develop` 대상 push/PR에서 항상 check 를 emit
+- docs 관련 변경이 없으면 no-op pass 로 종료
 
 5. `ops-safety-monitor.yml`
 - 운영 안전성 모니터링(정기/수동)

--- a/scripts/ci/validate_delivery_unit.py
+++ b/scripts/ci/validate_delivery_unit.py
@@ -106,7 +106,9 @@ def _validate_delivery_unit_fields(
 
     delivery_unit_value = _extract_field_value(pr_body, "Delivery Unit ID")
     if delivery_unit_value is None or not delivery_unit_value:
-        errors.append("Missing `Delivery Unit ID: <id>` in `## Delivery Unit` section.")
+        errors.append(
+            "Missing non-empty `Delivery Unit ID:` in `## Delivery Unit` section."
+        )
     elif _looks_like_placeholder(delivery_unit_value):
         errors.append(
             "Placeholder `Delivery Unit ID:` value must be replaced in "

--- a/tests/contract/test_ci_workflow_truth.py
+++ b/tests/contract/test_ci_workflow_truth.py
@@ -94,3 +94,26 @@ def test_release_ci_platform_manifest_tracks_new_ci_truth_files() -> None:
 
     for entry in required_entries:
         assert entry in manifest
+
+
+def test_docs_quality_workflow_always_emits_required_check_for_merge_targets() -> None:
+    workflow = _read_text(".github/workflows/docs-quality.yml")
+    ci_guide = _read_text("docs/dev/CI_CD_GUIDE.md")
+    workflow_readme = _read_text(".github/workflows/README.md")
+
+    required_entries = [
+        "name: Docs Quality",
+        "pull_request:",
+        "push:",
+        "branches: [ main, develop ]",
+        "scripts/check_markdown_*.py",
+        "steps.changed_md.outputs.relevant == 'true'",
+        "No docs-related changes detected; docs-quality satisfied.",
+    ]
+
+    for entry in required_entries:
+        assert entry in workflow
+
+    assert "paths:" not in workflow
+    assert "항상 check 를 emit" in ci_guide
+    assert "required check 가 항상 emit" in workflow_readme

--- a/tests/unit_tests/test_validate_delivery_unit.py
+++ b/tests/unit_tests/test_validate_delivery_unit.py
@@ -79,7 +79,9 @@ Rollback Boundary:
         "Placeholder `RR: #<n>` must be replaced in `## Delivery Unit` section."
         in errors
     )
-    assert "Missing `Delivery Unit ID: <id>` in `## Delivery Unit` section." in errors
+    assert (
+        "Missing non-empty `Delivery Unit ID:` in `## Delivery Unit` section." in errors
+    )
     assert (
         "Placeholder `Merge Boundary:` value must be replaced in "
         "`## Delivery Unit` section." in errors


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Align the `docs-quality` required check with its workflow trigger so merge-eligible PRs always emit the expected GitHub Actions check.
- Replay the tiny validator wording improvement that was previously stranded behind that CI wiring mismatch.

## Scope
### In Scope
- Make `.github/workflows/docs-quality.yml` emit on `main`/`develop` PRs and pushes, with a no-op pass when no docs-related inputs changed
- Update CI workflow docs and contract truth to match the new behavior
- Reapply the `Delivery Unit ID` validator wording improvement and matching unit test

### Out of Scope
- New governance rules
- Runtime/platform adapter work
- Packaging/runtime path behavior
- Branch protection settings themselves

## Delivery Unit
RR: #371
Delivery Unit ID: DU-20260319-docs-quality-trigger-scope
Merge Boundary: squash merge this governance close-out PR after required checks are green
Rollback Boundary: revert the docs-quality alignment commit on this branch

## Test & Evidence
- [x] `COVERAGE_FILE=.local/coverage/rr371_validator .local/venv/bin/python -m pytest tests/unit_tests/test_validate_delivery_unit.py -q`
- [x] `COVERAGE_FILE=.local/coverage/rr371_ci_truth .local/venv/bin/python -m pytest tests/contract/test_ci_workflow_truth.py -q`
- [x] `COVERAGE_FILE=.local/coverage/rr371_delivery_truth .local/venv/bin/python -m pytest tests/contract/test_delivery_governance_truth.py -q`
- [x] `make check`
- [x] `make check-full`

### Commands and Results
```bash
COVERAGE_FILE=.local/coverage/rr371_validator .local/venv/bin/python -m pytest tests/unit_tests/test_validate_delivery_unit.py -q
COVERAGE_FILE=.local/coverage/rr371_ci_truth .local/venv/bin/python -m pytest tests/contract/test_ci_workflow_truth.py -q
COVERAGE_FILE=.local/coverage/rr371_delivery_truth .local/venv/bin/python -m pytest tests/contract/test_delivery_governance_truth.py -q
make check
make check-full
```

## Risk & Rollback
- Risk: `docs-quality` now emits for all `main`/`develop` PRs and pushes, so docs checks will appear more often, but no-doc changes short-circuit to a no-op pass.
- Rollback: revert commit `65c243e` to restore the prior workflow trigger scope and validator wording.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: n/a
- Outbox/send_key 중복 방지 결과: n/a
- import-time side effect 제거 여부: n/a

## Not Run (with reason)
- Merge-result, final CI observation, and RR close-out verification remain deferred until this PR actually merges.