### PR TITLE
fix(governance): harden delivery validator enforcement

### DIFF
--- a/scripts/ci/validate_delivery_unit.py
+++ b/scripts/ci/validate_delivery_unit.py
@@ -80,6 +80,16 @@ def _looks_like_placeholder(value: str | None) -> bool:
     return bool(PLACEHOLDER_PATTERN.search(value.strip()))
 
 
+def _extract_delivery_unit_section(pr_body: str) -> str | None:
+    match = re.search(
+        r"(?ims)^##[ \t]+Delivery Unit[ \t]*\n(.*?)(?=^##[ \t]+|\Z)",
+        pr_body or "",
+    )
+    if not match:
+        return None
+    return match.group(1)
+
+
 def _validate_delivery_unit_fields(
     pr_body: str,
 ) -> tuple[list[str], int | None, str | None]:
@@ -87,10 +97,12 @@ def _validate_delivery_unit_fields(
     rr_number: int | None = None
     delivery_unit: str | None = None
 
-    if "## Delivery Unit" not in pr_body:
+    delivery_unit_section = _extract_delivery_unit_section(pr_body)
+    if delivery_unit_section is None:
         errors.append("Missing PR section: `## Delivery Unit`.")
+        delivery_unit_section = ""
 
-    rr_value = _extract_field_value(pr_body, "RR")
+    rr_value = _extract_field_value(delivery_unit_section, "RR")
     if rr_value is None:
         errors.append("Missing `RR: #<number>` in `## Delivery Unit` section.")
     elif _looks_like_placeholder(rr_value):
@@ -104,7 +116,9 @@ def _validate_delivery_unit_fields(
         else:
             rr_number = int(rr_match.group(1))
 
-    delivery_unit_value = _extract_field_value(pr_body, "Delivery Unit ID")
+    delivery_unit_value = _extract_field_value(
+        delivery_unit_section, "Delivery Unit ID"
+    )
     if delivery_unit_value is None or not delivery_unit_value:
         errors.append(
             "Missing non-empty `Delivery Unit ID:` in `## Delivery Unit` section."
@@ -118,7 +132,7 @@ def _validate_delivery_unit_fields(
         delivery_unit = delivery_unit_value
 
     for label in ("Merge Boundary", "Rollback Boundary"):
-        value = _extract_field_value(pr_body, label)
+        value = _extract_field_value(delivery_unit_section, label)
         if value is None or not value:
             errors.append(
                 f"Missing non-empty `{label}:` in `## Delivery Unit` section."
@@ -135,6 +149,42 @@ def _validate_delivery_unit_fields(
 def _extract_rr_and_du(pr_body: str) -> tuple[int | None, str | None]:
     _, rr_number, delivery_unit = _validate_delivery_unit_fields(pr_body or "")
     return rr_number, delivery_unit
+
+
+def _github_get_json(url: str, token: str) -> dict[str, Any]:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "delivery-unit-validator",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            payload = json.load(resp)
+            if not isinstance(payload, dict):
+                raise RuntimeError(f"Unexpected GitHub payload type at {url}")
+            return payload
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"GitHub API request failed: {exc.code} {exc.reason} ({url}) {body}"
+        ) from exc
+
+
+def _validate_rr_issue(issue: dict[str, Any], rr_number: int) -> list[str]:
+    if issue.get("pull_request"):
+        return [f"Referenced RR #{rr_number} is a pull request, not an issue."]
+
+    labels = {
+        label if isinstance(label, str) else (label.get("name") or "")
+        for label in issue.get("labels", [])
+    }
+    if "review-request" not in labels:
+        return [f"Referenced RR #{rr_number} must have the `review-request` label."]
+
+    return []
 
 
 def _non_merge_commit_count(commit_data: Iterable[dict[str, Any]]) -> int:
@@ -181,6 +231,14 @@ def main() -> int:
 
     owner, repo = repository.split("/", 1)
     api_base = f"https://api.github.com/repos/{owner}/{repo}"
+
+    if rr_number is not None:
+        try:
+            rr_issue = _github_get_json(f"{api_base}/issues/{rr_number}", token)
+        except RuntimeError as exc:
+            errors.append(str(exc))
+        else:
+            errors.extend(_validate_rr_issue(rr_issue, rr_number))
 
     open_prs = _github_paginate(f"{api_base}/pulls?state=open&per_page=100", token)
     conflicting_rr: list[int] = []

--- a/tests/unit_tests/test_validate_delivery_unit.py
+++ b/tests/unit_tests/test_validate_delivery_unit.py
@@ -90,3 +90,53 @@ Rollback Boundary:
         "Missing non-empty `Rollback Boundary:` in `## Delivery Unit` section."
         in errors
     )
+
+
+def test_validate_delivery_unit_fields_rejects_fields_outside_delivery_unit_section() -> (
+    None
+):
+    pr_body = """
+RR: #123
+Delivery Unit ID: DU-20260319-delivery-validator-hardening
+Merge Boundary: squash
+Rollback Boundary: revert
+
+## Delivery Unit
+(fields must not be accepted from outside this section)
+"""
+
+    (
+        errors,
+        rr_number,
+        delivery_unit,
+    ) = delivery_validator._validate_delivery_unit_fields(pr_body)
+
+    assert rr_number is None
+    assert delivery_unit is None
+    assert "Missing `RR: #<number>` in `## Delivery Unit` section." in errors
+    assert (
+        "Missing non-empty `Delivery Unit ID:` in `## Delivery Unit` section." in errors
+    )
+    assert (
+        "Missing non-empty `Merge Boundary:` in `## Delivery Unit` section." in errors
+    )
+    assert (
+        "Missing non-empty `Rollback Boundary:` in `## Delivery Unit` section."
+        in errors
+    )
+
+
+def test_validate_rr_issue_requires_review_request_label() -> None:
+    issue = {"labels": []}
+
+    errors = delivery_validator._validate_rr_issue(issue, 381)
+
+    assert errors == ["Referenced RR #381 must have the `review-request` label."]
+
+
+def test_validate_rr_issue_accepts_review_request_issue() -> None:
+    issue = {"labels": [{"name": "review-request"}]}
+
+    errors = delivery_validator._validate_rr_issue(issue, 381)
+
+    assert errors == []


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Harden delivery-unit validation so RR/Delivery Unit fields are only accepted from the exact `## Delivery Unit` section.
- Fail pre-merge when the referenced RR issue does not carry the `review-request` label, so `rr-closed` does not fail only after merge.

## Scope
### In Scope
- Restrict `scripts/ci/validate_delivery_unit.py` field parsing to the `## Delivery Unit` section body.
- Validate the referenced RR issue shape before merge.
- Add regression tests for both behaviors.

### Out of Scope
- Changes to RR close-out workflow semantics.
- Broader governance or documentation refactors.

## Delivery Unit
RR: #381
Delivery Unit ID: DU-20260319-delivery-validator-hardening
Merge Boundary: squash merge
Rollback Boundary: revert merge commit

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [ ] GitHub required checks green before merge
- [x] Additional tests (if needed):

### Commands and Results
```bash
COVERAGE_FILE=.local/coverage/rr381_validator .local/venv/bin/python -m pytest tests/unit_tests/test_validate_delivery_unit.py -q  # 7 passed
COVERAGE_FILE=.local/coverage/rr381_delivery_truth .local/venv/bin/python -m pytest tests/contract/test_delivery_governance_truth.py -q  # 3 passed
make check      # passed after Black formatting
make check-full # passed
```

## Risk & Rollback
- Risk: malformed PR bodies and non-`review-request` RR references will now fail earlier in PR policy checks.
- Rollback: revert this PR merge commit to restore the previous validator behavior.

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: n/a
- Outbox/send_key 중복 방지 결과: n/a
- import-time side effect 제거 여부: no change

## Not Run (with reason)
- No additional GitHub-only validation beyond the required PR checks; CI will cover that after PR creation.
