### PR TITLE
P1-T1: introduce minimal platform adapter seam

### DIFF
--- a/tests/unit_tests/web/test_platform_adapter.py
+++ b/tests/unit_tests/web/test_platform_adapter.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import platform
+
+import pytest
+
+from web.platform_adapter import (
+    get_platform_name,
+    is_queue_enabled_for_platform,
+    is_windows,
+)
+
+
+@pytest.mark.unit
+def test_windows_platform_reports_disabled_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+    assert get_platform_name() == "Windows"
+    assert is_windows() is True
+    assert is_queue_enabled_for_platform() is False
+
+
+@pytest.mark.unit
+def test_non_windows_platform_reports_enabled_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+
+    assert get_platform_name() == "Linux"
+    assert is_windows() is False
+    assert is_queue_enabled_for_platform() is True
+
+
+@pytest.mark.unit
+def test_platform_detection_rechecks_runtime_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    values = iter(["Darwin", "Windows"])
+    monkeypatch.setattr(platform, "system", lambda: next(values))
+
+    assert get_platform_name() == "Darwin"
+    assert is_windows() is True

--- a/web/platform_adapter.py
+++ b/web/platform_adapter.py
@@ -1,0 +1,23 @@
+"""Minimal platform helpers for web runtime policy decisions."""
+
+from __future__ import annotations
+
+import platform
+
+
+def get_platform_name() -> str:
+    """Return the current OS name as reported by Python."""
+
+    return platform.system()
+
+
+def is_windows() -> bool:
+    """Return whether the current runtime is Windows."""
+
+    return get_platform_name() == "Windows"
+
+
+def is_queue_enabled_for_platform() -> bool:
+    """Mirror the current queue policy without changing app behavior yet."""
+
+    return not is_windows()


### PR DESCRIPTION
# Pull Request

## Summary (what / why)
- Introduce a minimal import-safe platform adapter seam for the web runtime.
- Lock the first Phase 1 delivery unit without changing current queue behavior.

## Scope
### In Scope
- add `web/platform_adapter.py`
- add `tests/unit_tests/web/test_platform_adapter.py`

### Out of Scope
- `web/app.py` queue-policy rewiring
- P1-T2 and P1-T3
- `web/runtime_hook.py`, `web/runtime_paths.py`, `scripts/devtools/*`, `tests/contract/*`

## Delivery Unit
RR: #383
Delivery Unit ID: DU-20260331-p1-t1-platform-adapter-seam
Merge Boundary: This PR only adds the minimal platform adapter seam and its unit tests.
Rollback Boundary: Revert commit `4d10a7c` if the seam needs to be removed.

## What changed
- Added `get_platform_name()`, `is_windows()`, and `is_queue_enabled_for_platform()` in `web/platform_adapter.py`
- Added focused unit tests for Windows and non-Windows platform capability results
- Left `web/app.py` unchanged so the direct Windows queue branch stays in place for P1-T1

## What did not change
- No queue-policy extraction
- No logging changes
- No runtime hook or runtime path changes
- No build, packaging, or support-policy changes
- No contract test changes

## Test & Evidence
- [x] `make check`
- [x] `make check-full`
- [ ] GitHub required checks green before merge
- [x] Additional tests (if needed)

### Commands and Results
```bash
COVERAGE_FILE=.local/coverage/p1_t1_adapter .local/venv/bin/python -m pytest tests/unit_tests/web/test_platform_adapter.py -q  # 3 passed
COVERAGE_FILE=.local/coverage/p1_t1_webmain .local/venv/bin/python -m pytest tests/unit_tests/test_web_app_main.py -q  # 3 passed
.local/venv/bin/python -m pytest tests/unit_tests/test_web_import_side_effects.py -q --no-cov  # 6 passed
make check  # passed
make check-full  # passed
```

## Risk & Rollback
- Risk: low, because the change adds an unused seam and tests only
- Rollback: revert commit `4d10a7c`

## Risks
- The queue-policy rule still lives in `web/app.py` until P1-T2; this PR only prepares the seam.

## Deferred work
- P1-T2: move queue policy behind the adapter and remove direct OS branching from `web/app.py`
- P1-T3: add contract coverage for queue-policy and bootstrap decision behavior

## Reviewer checklist
- Confirm only two files changed and both are in-scope for P1-T1
- Confirm `web/app.py` still contains the direct Windows queue branch
- Confirm no forbidden files were touched
- Confirm targeted tests and repo gates passed

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: not changed
- Outbox/send_key 중복 방지 결과: not changed
- import-time side effect 제거 여부: no new import-time side effects introduced

## Not Run (with reason)
- none
