### PR TITLE
refactor(platform): centralise OS-specific code behind PlatformAdapter

### DIFF
--- a/newsletter/cli.py
+++ b/newsletter/cli.py
@@ -44,34 +44,9 @@ _CLI_BOOTSTRAPPED = False
 
 
 def _configure_windows_utf8_io() -> None:
-    if sys.platform.startswith("win"):
-        import io
-        import locale
+    from newsletter_core.public.platform import get_platform_adapter
 
-        os.environ.setdefault("PYTHONIOENCODING", "utf-8")
-        os.environ.setdefault("PYTHONUTF8", "1")
-
-        try:
-            locale.setlocale(locale.LC_ALL, "ko_KR.UTF-8")
-        except locale.Error:
-            try:
-                locale.setlocale(locale.LC_ALL, ".65001")
-            except locale.Error:
-                pass
-
-        if hasattr(sys.stdout, "reconfigure"):
-            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
-            sys.stderr.reconfigure(encoding="utf-8", errors="replace")
-        else:  # pragma: no cover - legacy Python fallback
-            sys.stdout = io.TextIOWrapper(
-                sys.stdout.buffer, encoding="utf-8", errors="replace"
-            )
-            sys.stderr = io.TextIOWrapper(
-                sys.stderr.buffer, encoding="utf-8", errors="replace"
-            )
-
-        if hasattr(sys, "_setdefaultencoding"):  # pragma: no cover
-            sys._setdefaultencoding("utf-8")
+    get_platform_adapter().configure_utf8_io()
 
 
 def _load_project_dotenv_if_present() -> None:

--- a/newsletter/utils/shutdown_manager.py
+++ b/newsletter/utils/shutdown_manager.py
@@ -128,8 +128,43 @@ class ShutdownManager:
 
         return SafeLogger(self._logger)
 
+    def _on_shutdown_event(self, context: str) -> None:
+        """Shared state management for any shutdown signal or console event."""
+        with self._lock:
+            self._shutdown_request_count += 1
+            if self._first_shutdown_time is None:
+                self._first_shutdown_time = time.time()
+
+            if self._shutdown_request_count >= 2:
+                elapsed = time.time() - self._first_shutdown_time
+                if elapsed < 3.0:
+                    self._safe_log.warning(
+                        f"Second {context} received within "
+                        f"{elapsed:.1f}s - forcing exit"
+                    )
+                    import os
+
+                    os._exit(1)
+
+            if self._shutdown_completed:
+                self._safe_log.warning(
+                    f"Shutdown already completed but still receiving "
+                    f"{context} - forcing exit"
+                )
+                import os
+
+                os._exit(1)
+
+        self.shutdown()
+
     def _setup_signal_handlers(self):
-        """Setup signal handlers for graceful shutdown"""
+        """Register platform-appropriate signal handlers via _signal module."""
+        from newsletter_core.infrastructure.platform._signal import (
+            setup_signal_handlers,
+        )
+        from newsletter_core.public.platform import get_platform_adapter
+
+        adapter = get_platform_adapter()
 
         def signal_handler(signum, frame):
             signal_name = (
@@ -138,139 +173,31 @@ class ShutdownManager:
                 else str(signum)
             )
             self._safe_log.info(f"Received signal {signal_name} ({signum})")
+            self._on_shutdown_event("shutdown signal")
 
-            with self._lock:
-                self._shutdown_request_count += 1
-                if self._first_shutdown_time is None:
-                    self._first_shutdown_time = time.time()
+        _CTRL_NAMES = {
+            0: "CTRL_C_EVENT",
+            1: "CTRL_BREAK_EVENT",
+            2: "CTRL_CLOSE_EVENT",
+            5: "CTRL_LOGOFF_EVENT",
+            6: "CTRL_SHUTDOWN_EVENT",
+        }
 
-                # If this is the second Ctrl+C within 3 seconds, force exit
-                if self._shutdown_request_count >= 2:
-                    elapsed = time.time() - self._first_shutdown_time
-                    if elapsed < 3.0:
-                        self._safe_log.warning(
-                            "Second shutdown signal received within "
-                            f"{elapsed:.1f}s - forcing exit"
-                        )
-                        import os
+        def console_event_handler(ctrl_type):
+            ctrl_name = _CTRL_NAMES.get(ctrl_type, f"UNKNOWN({ctrl_type})")
+            self._safe_log.info(f"Windows console control event: {ctrl_name}")
+            self._on_shutdown_event("console event")
+            return True
 
-                        os._exit(1)
-
-                # If shutdown is complete and signals keep coming, force exit.
-                if self._shutdown_completed:
-                    self._safe_log.warning(
-                        "Shutdown already completed but still receiving signals "
-                        "- forcing exit"
-                    )
-                    import os
-
-                    os._exit(1)
-
-            self.shutdown()
-
-        # Handle common termination signals
-        signals_to_handle = [signal.SIGINT, signal.SIGTERM]
-
-        # Windows-specific signal handling
-        if sys.platform.startswith("win"):
-            try:
-                # Add Windows-specific signals if available
-                if hasattr(signal, "SIGBREAK"):
-                    signals_to_handle.append(signal.SIGBREAK)
-
-                # Setup console control handler for Windows
-                self._setup_windows_console_handler()
-
-            except Exception as e:
-                self._safe_log.warning(
-                    f"Failed to setup Windows-specific signal handling: {e}"
-                )
-
-        for sig in signals_to_handle:
-            try:
-                signal.signal(sig, signal_handler)
-                self._safe_log.debug(f"Signal handler registered for {sig}")
-            except (OSError, ValueError) as e:
-                self._safe_log.warning(
-                    f"Could not register signal handler for {sig}: {e}"
-                )
-
-    def _setup_windows_console_handler(self):
-        """Setup Windows console control handler"""
-        if not sys.platform.startswith("win"):
-            return
-
-        try:
-            import ctypes
-            from ctypes import wintypes
-
-            kernel32 = ctypes.windll.kernel32
-
-            def console_ctrl_handler(ctrl_type):
-                """Handle Windows console control events"""
-                ctrl_types = {
-                    0: "CTRL_C_EVENT",
-                    1: "CTRL_BREAK_EVENT",
-                    2: "CTRL_CLOSE_EVENT",
-                    5: "CTRL_LOGOFF_EVENT",
-                    6: "CTRL_SHUTDOWN_EVENT",
-                }
-
-                ctrl_name = ctrl_types.get(ctrl_type, f"UNKNOWN({ctrl_type})")
-                self._safe_log.info(f"Windows console control event: {ctrl_name}")
-
-                # Handle repeated Ctrl+C for force exit
-                with self._lock:
-                    self._shutdown_request_count += 1
-                    if self._first_shutdown_time is None:
-                        self._first_shutdown_time = time.time()
-
-                    # If this is the second Ctrl+C within 3 seconds, force exit
-                    if self._shutdown_request_count >= 2:
-                        elapsed = time.time() - self._first_shutdown_time
-                        if elapsed < 3.0:
-                            self._safe_log.warning(
-                                "Second console event received within "
-                                f"{elapsed:.1f}s - forcing exit"
-                            )
-                            import os
-
-                            os._exit(1)
-
-                    # If shutdown is complete and signals keep coming, force exit.
-                    if self._shutdown_completed:
-                        self._safe_log.warning(
-                            "Shutdown already completed but still receiving "
-                            "console events - forcing exit"
-                        )
-                        import os
-
-                        os._exit(1)
-
-                # Start graceful shutdown
-                self.shutdown()
-
-                # Return True to indicate we handled the event
-                return True
-
-            # Define the handler function type
-            HANDLER_ROUTINE = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.DWORD)
-            handler = HANDLER_ROUTINE(console_ctrl_handler)
-
-            # Register the handler
-            if kernel32.SetConsoleCtrlHandler(handler, True):
-                self._safe_log.debug(
-                    "Windows console control handler registered successfully"
-                )
-                # Keep a reference to prevent garbage collection
-                self._console_handler = handler
-            else:
-                self._safe_log.warning(
-                    "Failed to register Windows console control handler"
-                )
-
-        except Exception as e:
-            self._safe_log.warning(f"Could not setup Windows console handler: {e}")
+        console_handler_ref = setup_signal_handlers(
+            signal_handler, console_event_handler, adapter
+        )
+        if console_handler_ref is not None:
+            # Keep a reference to prevent garbage collection
+            self._console_handler = console_handler_ref
+            self._safe_log.debug(
+                "Windows console control handler registered successfully"
+            )
 
     def _setup_exit_hooks(self):
         """Setup exit hooks for cleanup"""

--- a/newsletter/utils/shutdown_manager.py
+++ b/newsletter/utils/shutdown_manager.py
@@ -202,8 +202,6 @@ class ShutdownManager:
     def _setup_exit_hooks(self):
         """Setup exit hooks for cleanup"""
         # Skip atexit registration during pytest to avoid logging errors during teardown
-        import sys
-
         if "pytest" in sys.modules or os.getenv("TESTING") == "1":
             self._safe_log.debug("Skipping exit hooks registration in test mode")
             return

--- a/newsletter/utils/shutdown_manager.py
+++ b/newsletter/utils/shutdown_manager.py
@@ -157,7 +157,7 @@ class ShutdownManager:
 
         self.shutdown()
 
-    def _setup_signal_handlers(self):
+    def _setup_signal_handlers(self) -> None:
         """Register platform-appropriate signal handlers via _signal module."""
         from newsletter_core.infrastructure.platform._signal import (
             setup_signal_handlers,
@@ -166,7 +166,7 @@ class ShutdownManager:
 
         adapter = get_platform_adapter()
 
-        def signal_handler(signum, frame):
+        def signal_handler(signum: int, frame: Any) -> None:
             signal_name = (
                 signal.Signals(signum).name
                 if hasattr(signal, "Signals")
@@ -183,7 +183,7 @@ class ShutdownManager:
             6: "CTRL_SHUTDOWN_EVENT",
         }
 
-        def console_event_handler(ctrl_type):
+        def console_event_handler(ctrl_type: int) -> bool:
             ctrl_name = _CTRL_NAMES.get(ctrl_type, f"UNKNOWN({ctrl_type})")
             self._safe_log.info(f"Windows console control event: {ctrl_name}")
             self._on_shutdown_event("console event")
@@ -199,7 +199,7 @@ class ShutdownManager:
                 "Windows console control handler registered successfully"
             )
 
-    def _setup_exit_hooks(self):
+    def _setup_exit_hooks(self) -> None:
         """Setup exit hooks for cleanup"""
         # Skip atexit registration during pytest to avoid logging errors during teardown
         if "pytest" in sys.modules or os.getenv("TESTING") == "1":

--- a/newsletter_core/infrastructure/platform/__init__.py
+++ b/newsletter_core/infrastructure/platform/__init__.py
@@ -1,0 +1,17 @@
+"""Platform adapter infrastructure for OS-specific behavior."""
+
+from __future__ import annotations
+
+from newsletter_core.infrastructure.platform._frozen import (
+    get_bundle_root,
+    is_frozen,
+    is_frozen_any,
+)
+from newsletter_core.infrastructure.platform._resolver import get_platform_adapter
+
+__all__ = [
+    "get_platform_adapter",
+    "is_frozen",
+    "is_frozen_any",
+    "get_bundle_root",
+]

--- a/newsletter_core/infrastructure/platform/_frozen.py
+++ b/newsletter_core/infrastructure/platform/_frozen.py
@@ -1,0 +1,36 @@
+"""Unified PyInstaller / frozen-binary detection.
+
+Consolidates the duplicated logic previously found in:
+- ``web/runtime_paths.py:_is_frozen()``
+- ``web/binary_compatibility.py:is_frozen()``
+- ``web/path_manager.py:PathManager._is_frozen``
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def is_frozen() -> bool:
+    """Strict check: running inside a PyInstaller bundle with ``_MEIPASS``."""
+
+    return bool(getattr(sys, "frozen", False)) and hasattr(sys, "_MEIPASS")
+
+
+def is_frozen_any() -> bool:
+    """Lenient check: ``sys.frozen`` is set (any bundler, not just PyInstaller)."""
+
+    return bool(getattr(sys, "frozen", False))
+
+
+def get_bundle_root() -> Path:
+    """Return the bundle root directory.
+
+    * When frozen with ``_MEIPASS`` → that temporary extraction directory.
+    * Otherwise → the parent of *this* file (i.e. the ``platform`` package dir).
+    """
+
+    if is_frozen() and hasattr(sys, "_MEIPASS"):
+        return Path(getattr(sys, "_MEIPASS"))
+    return Path(__file__).resolve().parent

--- a/newsletter_core/infrastructure/platform/_protocol.py
+++ b/newsletter_core/infrastructure/platform/_protocol.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, List, Protocol, runtime_checkable
+from typing import List, Protocol, runtime_checkable
 
 
 @runtime_checkable

--- a/newsletter_core/infrastructure/platform/_protocol.py
+++ b/newsletter_core/infrastructure/platform/_protocol.py
@@ -1,0 +1,44 @@
+"""Platform adapter protocol definition."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, List, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class PlatformAdapter(Protocol):
+    """Abstraction over OS-specific runtime behavior.
+
+    Implementations exist for Windows and Unix (macOS / Linux).
+    """
+
+    @property
+    def name(self) -> str:
+        """OS name as reported by *platform.system()* (e.g. ``"Windows"``)."""
+        ...  # pragma: no cover
+
+    @property
+    def is_windows(self) -> bool:
+        """``True`` when running on Windows."""
+        ...  # pragma: no cover
+
+    def configure_utf8_io(self) -> None:
+        """Ensure *stdout* / *stderr* use UTF-8 encoding.
+
+        On Windows this sets locale, env-vars and reconfigures streams.
+        On Unix this is a no-op.
+        """
+        ...  # pragma: no cover
+
+    def is_queue_supported(self) -> bool:
+        """Return whether a Redis / RQ task queue is supported on this OS."""
+        ...  # pragma: no cover
+
+    def signal_names(self) -> List[str]:
+        """Signal names to register for graceful shutdown."""
+        ...  # pragma: no cover
+
+    def venv_python_path(self, venv_dir: Path) -> Path:
+        """Return the Python interpreter path inside *venv_dir*."""
+        ...  # pragma: no cover

--- a/newsletter_core/infrastructure/platform/_resolver.py
+++ b/newsletter_core/infrastructure/platform/_resolver.py
@@ -1,0 +1,26 @@
+"""Resolve the correct platform adapter for the current OS."""
+
+from __future__ import annotations
+
+import platform
+
+from newsletter_core.infrastructure.platform._protocol import PlatformAdapter
+
+
+def get_platform_adapter() -> PlatformAdapter:
+    """Return a :class:`PlatformAdapter` matching the current operating system.
+
+    Uses lazy imports so that Windows-only modules (e.g. ``ctypes.windll``)
+    are never loaded on Unix.
+    """
+
+    if platform.system() == "Windows":
+        from newsletter_core.infrastructure.platform._windows import (
+            WindowsPlatformAdapter,
+        )
+
+        return WindowsPlatformAdapter()
+
+    from newsletter_core.infrastructure.platform._unix import UnixPlatformAdapter
+
+    return UnixPlatformAdapter()

--- a/newsletter_core/infrastructure/platform/_signal.py
+++ b/newsletter_core/infrastructure/platform/_signal.py
@@ -1,0 +1,67 @@
+"""
+Platform-specific signal handler registration.
+
+Provides :func:`setup_signal_handlers` which wires platform-appropriate
+POSIX signals and, on Windows, the Windows Console Control Handler.
+This module has no dependency on ShutdownManager; callers pass in
+callbacks so the two remain decoupled.
+"""
+
+from __future__ import annotations
+
+import signal
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+if TYPE_CHECKING:
+    from newsletter_core.infrastructure.platform._protocol import PlatformAdapter
+
+
+def setup_signal_handlers(
+    signal_handler: Callable[[int, Any], None],
+    console_event_handler: Callable[[int], bool],
+    adapter: "PlatformAdapter",
+) -> Optional[Any]:
+    """Register platform-appropriate signal handlers.
+
+    Registers *signal_handler(signum, frame)* for each name returned by
+    ``adapter.signal_names()``.  On Windows, also registers
+    *console_event_handler(ctrl_type)* via ``SetConsoleCtrlHandler``.
+
+    Returns the Windows console handler object (caller must keep a reference
+    to prevent garbage collection) or ``None`` on non-Windows platforms.
+    """
+    for sig_name in adapter.signal_names():
+        sig = getattr(signal, sig_name, None)
+        if sig is None:
+            continue
+        try:
+            signal.signal(sig, signal_handler)
+        except (OSError, ValueError):
+            pass
+
+    if adapter.is_windows:
+        return _register_windows_console_handler(console_event_handler)
+
+    return None
+
+
+def _register_windows_console_handler(
+    event_handler: Callable[[int], bool],
+) -> Optional[Any]:
+    """Register *event_handler* with ``SetConsoleCtrlHandler``.
+
+    Returns the ctypes handler object (keep alive!) or ``None`` if
+    registration fails or ctypes is unavailable.
+    """
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        HANDLER_ROUTINE = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.DWORD)
+        handler = HANDLER_ROUTINE(event_handler)
+        if kernel32.SetConsoleCtrlHandler(handler, True):
+            return handler
+        return None
+    except Exception:
+        return None

--- a/newsletter_core/infrastructure/platform/_unix.py
+++ b/newsletter_core/infrastructure/platform/_unix.py
@@ -1,0 +1,31 @@
+"""Unix (macOS / Linux) platform adapter implementation."""
+
+from __future__ import annotations
+
+import platform
+from pathlib import Path
+from typing import List
+
+
+class UnixPlatformAdapter:
+    """Adapter for Unix-like systems (macOS and Linux)."""
+
+    @property
+    def name(self) -> str:  # noqa: D401
+        return platform.system()  # "Darwin" or "Linux"
+
+    @property
+    def is_windows(self) -> bool:
+        return False
+
+    def configure_utf8_io(self) -> None:
+        """No-op on Unix — UTF-8 is the default encoding."""
+
+    def is_queue_supported(self) -> bool:
+        return True
+
+    def signal_names(self) -> List[str]:
+        return ["SIGINT", "SIGTERM"]
+
+    def venv_python_path(self, venv_dir: Path) -> Path:
+        return venv_dir / "bin" / "python"

--- a/newsletter_core/infrastructure/platform/_windows.py
+++ b/newsletter_core/infrastructure/platform/_windows.py
@@ -1,0 +1,86 @@
+"""Windows platform adapter implementation."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+
+class WindowsPlatformAdapter:
+    """Adapter for Windows-specific runtime behavior."""
+
+    @property
+    def name(self) -> str:  # noqa: D401
+        return "Windows"
+
+    @property
+    def is_windows(self) -> bool:
+        return True
+
+    # ------------------------------------------------------------------
+    # UTF-8 I/O configuration
+    # ------------------------------------------------------------------
+
+    def configure_utf8_io(self) -> None:
+        """Set environment variables, locale, and stream encoding to UTF-8.
+
+        Consolidates the duplicated logic previously found in:
+        - ``newsletter/cli.py:_configure_windows_utf8_io()``
+        - ``scripts/devtools/run_tests.py`` (module-level block)
+        - ``run_ci_checks.py`` (module-level block)
+        - ``web/runtime_hook.py`` (module-level block)
+        """
+
+        if not sys.platform.startswith("win"):
+            return  # safety guard when called outside Windows
+
+        import io
+        import locale
+
+        os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+        os.environ.setdefault("PYTHONUTF8", "1")
+
+        try:
+            locale.setlocale(locale.LC_ALL, "ko_KR.UTF-8")
+        except locale.Error:
+            try:
+                locale.setlocale(locale.LC_ALL, ".65001")
+            except locale.Error:
+                pass
+
+        if hasattr(sys.stdout, "reconfigure"):
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+            sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+        else:  # pragma: no cover - legacy Python fallback
+            sys.stdout = io.TextIOWrapper(
+                sys.stdout.buffer, encoding="utf-8", errors="replace"
+            )
+            sys.stderr = io.TextIOWrapper(
+                sys.stderr.buffer, encoding="utf-8", errors="replace"
+            )
+
+        if hasattr(sys, "_setdefaultencoding"):  # pragma: no cover
+            sys._setdefaultencoding("utf-8")
+
+    # ------------------------------------------------------------------
+    # Queue support
+    # ------------------------------------------------------------------
+
+    def is_queue_supported(self) -> bool:
+        return False
+
+    # ------------------------------------------------------------------
+    # Signals
+    # ------------------------------------------------------------------
+
+    def signal_names(self) -> List[str]:
+        return ["SIGINT", "SIGTERM", "SIGBREAK"]
+
+    # ------------------------------------------------------------------
+    # Virtual-environment paths
+    # ------------------------------------------------------------------
+
+    def venv_python_path(self, venv_dir: Path) -> Path:
+        return venv_dir / "Scripts" / "python.exe"

--- a/newsletter_core/public/__init__.py
+++ b/newsletter_core/public/__init__.py
@@ -1,3 +1,3 @@
 """Public API surface for newsletter_core."""
 
-__all__ = ["generation", "settings", "lifecycle", "source_policies"]
+__all__ = ["generation", "settings", "lifecycle", "source_policies", "platform"]

--- a/newsletter_core/public/platform.py
+++ b/newsletter_core/public/platform.py
@@ -1,0 +1,27 @@
+"""Public API for platform-specific behavior.
+
+Usage::
+
+    from newsletter_core.public.platform import get_platform_adapter
+
+    adapter = get_platform_adapter()
+    adapter.configure_utf8_io()
+"""
+
+from __future__ import annotations
+
+from newsletter_core.infrastructure.platform._frozen import (
+    get_bundle_root,
+    is_frozen,
+    is_frozen_any,
+)
+from newsletter_core.infrastructure.platform._protocol import PlatformAdapter
+from newsletter_core.infrastructure.platform._resolver import get_platform_adapter
+
+__all__ = [
+    "PlatformAdapter",
+    "get_platform_adapter",
+    "is_frozen",
+    "is_frozen_any",
+    "get_bundle_root",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "newsletter_core.*",
+    "newsletter.utils.shutdown_manager",
 ]
 ignore_errors = true
 

--- a/run_ci_checks.py
+++ b/run_ci_checks.py
@@ -20,15 +20,10 @@ import time
 from pathlib import Path
 from typing import List, Tuple
 
-# Windows 한글 인코딩 설정
-if sys.platform.startswith("win"):
-    os.environ["PYTHONIOENCODING"] = "utf-8"
-    os.environ["PYTHONUTF8"] = "1"
-    # Windows 콘솔 UTF-8 설정
-    import io
+# Platform-specific UTF-8 I/O configuration (Windows)
+from newsletter_core.public.platform import get_platform_adapter
 
-    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
-    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
+get_platform_adapter().configure_utf8_io()
 
 # Legacy strict-gate exclusions removed: all runtime modules are now enforced.
 LEGACY_RUNTIME_GATE_EXCLUDES: set[str] = set()

--- a/scripts/devtools/dev_entrypoint.py
+++ b/scripts/devtools/dev_entrypoint.py
@@ -86,10 +86,9 @@ def repo_paths(repo_root: Path = REPO_ROOT) -> RepoPaths:
 
 
 def venv_python(venv_dir: Path) -> Path:
-    scripts_python = venv_dir / "Scripts" / "python.exe"
-    if scripts_python.exists():
-        return scripts_python
-    return venv_dir / "bin" / "python"
+    from newsletter_core.public.platform import get_platform_adapter
+
+    return get_platform_adapter().venv_python_path(venv_dir)
 
 
 def resolve_existing_venv_python(paths: RepoPaths) -> Path | None:

--- a/scripts/devtools/run_tests.py
+++ b/scripts/devtools/run_tests.py
@@ -23,40 +23,10 @@
 import os
 import sys
 
-# F-14: Windows 한글 인코딩 문제 해결 (강화된 버전)
-if sys.platform.startswith("win"):
-    import io
-    import locale
+# Platform-specific UTF-8 I/O configuration (Windows)
+from newsletter_core.public.platform import get_platform_adapter
 
-    # UTF-8 인코딩 강제 설정
-    os.environ["PYTHONIOENCODING"] = "utf-8"
-    os.environ["PYTHONUTF8"] = "1"
-
-    # 시스템 기본 인코딩을 UTF-8로 설정
-    try:
-        locale.setlocale(locale.LC_ALL, "ko_KR.UTF-8")
-    except locale.Error:
-        try:
-            locale.setlocale(locale.LC_ALL, ".65001")  # Windows UTF-8 codepage
-        except locale.Error:
-            pass  # 설정할 수 없으면 무시
-
-    # 표준 입출력 스트림을 UTF-8로 재구성
-    if hasattr(sys.stdout, "reconfigure"):
-        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
-        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
-    else:
-        # 이전 Python 버전을 위한 fallback
-        sys.stdout = io.TextIOWrapper(
-            sys.stdout.buffer, encoding="utf-8", errors="replace"
-        )
-        sys.stderr = io.TextIOWrapper(
-            sys.stderr.buffer, encoding="utf-8", errors="replace"
-        )
-
-    # 디폴트 인코딩 설정
-    if hasattr(sys, "_setdefaultencoding"):
-        sys._setdefaultencoding("utf-8")
+get_platform_adapter().configure_utf8_io()
 
 import argparse
 import subprocess

--- a/scripts/devtools/run_tests.py
+++ b/scripts/devtools/run_tests.py
@@ -20,17 +20,16 @@
 - --list: 테스트 목록 조회
 """
 
+import argparse
 import os
+import subprocess
 import sys
+from pathlib import Path
 
 # Platform-specific UTF-8 I/O configuration (Windows)
 from newsletter_core.public.platform import get_platform_adapter
 
 get_platform_adapter().configure_utf8_io()
-
-import argparse
-import subprocess
-from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 

--- a/tests/unit_tests/newsletter_core/infrastructure/test_platform.py
+++ b/tests/unit_tests/newsletter_core/infrastructure/test_platform.py
@@ -197,3 +197,89 @@ class TestFrozenDetection:
         root = get_bundle_root()
         # Should point to the _frozen.py parent directory
         assert root.is_dir()
+
+
+# ── Signal registration ──────────────────────────────────────────────
+
+
+class TestSignalHandlerRegistration:
+    def test_posix_signals_registered_on_unix(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """setup_signal_handlers registers SIGINT and SIGTERM on Unix."""
+        import signal as _signal
+
+        from newsletter_core.infrastructure.platform._signal import (
+            setup_signal_handlers,
+        )
+
+        registered: list[int] = []
+
+        def _fake_signal(sig, handler):
+            registered.append(int(sig))
+
+        monkeypatch.setattr(_signal, "signal", _fake_signal)
+
+        adapter = UnixPlatformAdapter()
+        result = setup_signal_handlers(lambda s, f: None, lambda c: True, adapter)
+
+        assert result is None  # no console handler on Unix
+        assert int(_signal.SIGINT) in registered
+        assert int(_signal.SIGTERM) in registered
+
+    def test_no_sigbreak_on_unix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SIGBREAK must not be registered on Unix (it may not exist)."""
+        import signal as _signal
+
+        from newsletter_core.infrastructure.platform._signal import (
+            setup_signal_handlers,
+        )
+
+        registered_names: list[str] = []
+
+        def _fake_signal(sig, handler):
+            try:
+                registered_names.append(_signal.Signals(sig).name)
+            except ValueError:
+                registered_names.append(str(sig))
+
+        monkeypatch.setattr(_signal, "signal", _fake_signal)
+
+        adapter = UnixPlatformAdapter()
+        setup_signal_handlers(lambda s, f: None, lambda c: True, adapter)
+
+        assert "SIGBREAK" not in registered_names
+
+    def test_windows_adapter_signal_names_include_sigbreak(self) -> None:
+        names = WindowsPlatformAdapter().signal_names()
+        assert "SIGBREAK" in names
+        assert "SIGINT" in names
+        assert "SIGTERM" in names
+
+    def test_setup_signal_handlers_calls_windows_console_on_windows_adapter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On a Windows adapter, _register_windows_console_handler is invoked."""
+        import newsletter_core.infrastructure.platform._signal as _sig_mod
+
+        called: list[bool] = []
+
+        def _fake_register(handler):
+            called.append(True)
+            return object()  # non-None sentinel
+
+        monkeypatch.setattr(
+            _sig_mod, "_register_windows_console_handler", _fake_register
+        )
+
+        import signal as _signal
+
+        monkeypatch.setattr(_signal, "signal", lambda s, h: None)
+
+        adapter = WindowsPlatformAdapter()
+        result = _sig_mod.setup_signal_handlers(
+            lambda s, f: None, lambda c: True, adapter
+        )
+
+        assert called, "_register_windows_console_handler should have been called"
+        assert result is not None

--- a/tests/unit_tests/newsletter_core/infrastructure/test_platform.py
+++ b/tests/unit_tests/newsletter_core/infrastructure/test_platform.py
@@ -1,0 +1,199 @@
+"""Unit tests for the platform adapter infrastructure."""
+
+from __future__ import annotations
+
+import os
+import platform
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from newsletter_core.infrastructure.platform._frozen import (
+    get_bundle_root,
+    is_frozen,
+    is_frozen_any,
+)
+from newsletter_core.infrastructure.platform._protocol import PlatformAdapter
+from newsletter_core.infrastructure.platform._resolver import get_platform_adapter
+from newsletter_core.infrastructure.platform._unix import UnixPlatformAdapter
+from newsletter_core.infrastructure.platform._windows import WindowsPlatformAdapter
+
+pytestmark = [pytest.mark.unit]
+
+
+# ── Protocol conformance ─────────────────────────────────────────────
+
+
+class TestPlatformProtocol:
+    def test_windows_adapter_satisfies_protocol(self) -> None:
+        adapter = WindowsPlatformAdapter()
+        assert isinstance(adapter, PlatformAdapter)
+
+    def test_unix_adapter_satisfies_protocol(self) -> None:
+        adapter = UnixPlatformAdapter()
+        assert isinstance(adapter, PlatformAdapter)
+
+
+# ── Resolver ─────────────────────────────────────────────────────────
+
+
+class TestPlatformResolver:
+    def test_returns_windows_on_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        adapter = get_platform_adapter()
+        assert adapter.is_windows is True
+        assert adapter.name == "Windows"
+        assert adapter.is_queue_supported() is False
+
+    def test_returns_unix_on_linux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        adapter = get_platform_adapter()
+        assert adapter.is_windows is False
+        assert adapter.name == "Linux"
+        assert adapter.is_queue_supported() is True
+
+    def test_returns_unix_on_darwin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        adapter = get_platform_adapter()
+        assert adapter.name == "Darwin"
+        assert adapter.is_windows is False
+
+
+# ── Windows adapter ──────────────────────────────────────────────────
+
+
+class TestWindowsAdapter:
+    def test_name_is_windows(self) -> None:
+        assert WindowsPlatformAdapter().name == "Windows"
+
+    def test_is_windows_true(self) -> None:
+        assert WindowsPlatformAdapter().is_windows is True
+
+    def test_queue_not_supported(self) -> None:
+        assert WindowsPlatformAdapter().is_queue_supported() is False
+
+    def test_signal_names_includes_sigbreak(self) -> None:
+        names = WindowsPlatformAdapter().signal_names()
+        assert "SIGINT" in names
+        assert "SIGTERM" in names
+        assert "SIGBREAK" in names
+
+    def test_venv_path_uses_scripts(self, tmp_path: Path) -> None:
+        result = WindowsPlatformAdapter().venv_python_path(tmp_path)
+        assert result == tmp_path / "Scripts" / "python.exe"
+
+    def test_configure_utf8_sets_env_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.delenv("PYTHONIOENCODING", raising=False)
+        monkeypatch.delenv("PYTHONUTF8", raising=False)
+
+        # Mock stdout/stderr to have reconfigure
+        mock_stdout = MagicMock()
+        mock_stderr = MagicMock()
+        mock_stdout.reconfigure = MagicMock()
+        mock_stderr.reconfigure = MagicMock()
+        monkeypatch.setattr(sys, "stdout", mock_stdout)
+        monkeypatch.setattr(sys, "stderr", mock_stderr)
+
+        WindowsPlatformAdapter().configure_utf8_io()
+
+        assert os.environ.get("PYTHONIOENCODING") == "utf-8"
+        assert os.environ.get("PYTHONUTF8") == "1"
+        mock_stdout.reconfigure.assert_called_once_with(
+            encoding="utf-8", errors="replace"
+        )
+        mock_stderr.reconfigure.assert_called_once_with(
+            encoding="utf-8", errors="replace"
+        )
+
+    def test_configure_utf8_noop_when_not_win32(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Safety guard: even if instantiated, does nothing on non-Windows."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.delenv("PYTHONIOENCODING", raising=False)
+        monkeypatch.delenv("PYTHONUTF8", raising=False)
+
+        WindowsPlatformAdapter().configure_utf8_io()
+
+        assert "PYTHONIOENCODING" not in os.environ
+
+
+# ── Unix adapter ─────────────────────────────────────────────────────
+
+
+class TestUnixAdapter:
+    def test_name_matches_system(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        assert UnixPlatformAdapter().name == "Darwin"
+
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        assert UnixPlatformAdapter().name == "Linux"
+
+    def test_is_windows_false(self) -> None:
+        assert UnixPlatformAdapter().is_windows is False
+
+    def test_queue_supported(self) -> None:
+        assert UnixPlatformAdapter().is_queue_supported() is True
+
+    def test_configure_utf8_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Calling configure_utf8_io on Unix must have no side-effects."""
+        original_env = dict(os.environ)
+        UnixPlatformAdapter().configure_utf8_io()
+        # No new PYTHONIOENCODING should appear
+        assert os.environ.get("PYTHONIOENCODING") == original_env.get(
+            "PYTHONIOENCODING"
+        )
+
+    def test_signal_names_standard(self) -> None:
+        names = UnixPlatformAdapter().signal_names()
+        assert names == ["SIGINT", "SIGTERM"]
+
+    def test_venv_path_uses_bin(self, tmp_path: Path) -> None:
+        result = UnixPlatformAdapter().venv_python_path(tmp_path)
+        assert result == tmp_path / "bin" / "python"
+
+
+# ── Frozen detection ─────────────────────────────────────────────────
+
+
+class TestFrozenDetection:
+    def test_not_frozen_in_dev(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+        assert is_frozen() is False
+        assert is_frozen_any() is False
+
+    def test_frozen_with_meipass(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", "/tmp/bundle", raising=False)
+        assert is_frozen() is True
+        assert is_frozen_any() is True
+
+    def test_frozen_without_meipass(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """is_frozen_any() returns True even without _MEIPASS."""
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+        assert is_frozen() is False
+        assert is_frozen_any() is True
+
+    def test_bundle_root_returns_meipass_when_frozen(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        bundle_dir = str(tmp_path / "bundle")
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", bundle_dir, raising=False)
+        assert get_bundle_root() == Path(bundle_dir)
+
+    def test_bundle_root_returns_package_dir_when_dev(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+        root = get_bundle_root()
+        # Should point to the _frozen.py parent directory
+        assert root.is_dir()

--- a/tests/unit_tests/web/test_platform_adapter.py
+++ b/tests/unit_tests/web/test_platform_adapter.py
@@ -4,6 +4,8 @@ import platform
 
 import pytest
 
+import newsletter_core.infrastructure.platform._resolver as _resolver_mod
+import newsletter_core.infrastructure.platform._unix as _unix_mod
 from web.platform_adapter import (
     get_platform_name,
     is_queue_enabled_for_platform,
@@ -11,11 +13,18 @@ from web.platform_adapter import (
 )
 
 
+def _patch_platform(monkeypatch: pytest.MonkeyPatch, fn):
+    """Patch platform.system across all modules that use it."""
+    monkeypatch.setattr(platform, "system", fn)
+    monkeypatch.setattr(_resolver_mod.platform, "system", fn)
+    monkeypatch.setattr(_unix_mod.platform, "system", fn)
+
+
 @pytest.mark.unit
 def test_windows_platform_reports_disabled_queue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    _patch_platform(monkeypatch, lambda: "Windows")
 
     assert get_platform_name() == "Windows"
     assert is_windows() is True
@@ -26,7 +35,7 @@ def test_windows_platform_reports_disabled_queue(
 def test_non_windows_platform_reports_enabled_queue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    _patch_platform(monkeypatch, lambda: "Linux")
 
     assert get_platform_name() == "Linux"
     assert is_windows() is False
@@ -37,8 +46,11 @@ def test_non_windows_platform_reports_enabled_queue(
 def test_platform_detection_rechecks_runtime_state(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    values = iter(["Darwin", "Windows"])
-    monkeypatch.setattr(platform, "system", lambda: next(values))
-
+    """Verify that each call re-evaluates the platform via the adapter."""
+    _patch_platform(monkeypatch, lambda: "Darwin")
     assert get_platform_name() == "Darwin"
+    assert is_windows() is False
+
+    _patch_platform(monkeypatch, lambda: "Windows")
+    assert get_platform_name() == "Windows"
     assert is_windows() is True

--- a/web/app.py
+++ b/web/app.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import logging
 import os
-import platform
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -71,8 +70,10 @@ def _create_task_queue(app: Flask) -> tuple[Any, Any]:
     redis_url = app.config["REDIS_URL"]
 
     try:
-        if platform.system() == "Windows":
-            log_warning(logger, "app.redis.disabled_for_windows")
+        from web.platform_adapter import is_queue_enabled_for_platform
+
+        if not is_queue_enabled_for_platform():
+            log_warning(logger, "app.redis.disabled_for_platform")
             return None, None
 
         from rq import Queue

--- a/web/binary_compatibility.py
+++ b/web/binary_compatibility.py
@@ -18,7 +18,7 @@ def is_frozen() -> bool:
         is_frozen as _core_is_frozen,
     )
 
-    return _core_is_frozen()
+    return bool(_core_is_frozen())
 
 
 def get_base_path() -> str:

--- a/web/binary_compatibility.py
+++ b/web/binary_compatibility.py
@@ -14,7 +14,11 @@ logger = logging.getLogger(__name__)
 
 def is_frozen() -> bool:
     """PyInstaller로 빌드된 바이너리에서 실행 중인지 확인"""
-    return getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")
+    from newsletter_core.infrastructure.platform._frozen import (
+        is_frozen as _core_is_frozen,
+    )
+
+    return _core_is_frozen()
 
 
 def get_base_path() -> str:

--- a/web/platform_adapter.py
+++ b/web/platform_adapter.py
@@ -1,23 +1,28 @@
-"""Minimal platform helpers for web runtime policy decisions."""
+"""Minimal platform helpers for web runtime policy decisions.
+
+This module delegates to :mod:`newsletter_core.public.platform` and exists
+solely for backward compatibility with existing ``from web.platform_adapter``
+imports.
+"""
 
 from __future__ import annotations
 
-import platform
+from newsletter_core.public.platform import get_platform_adapter as _get
 
 
 def get_platform_name() -> str:
     """Return the current OS name as reported by Python."""
 
-    return platform.system()
+    return _get().name
 
 
 def is_windows() -> bool:
     """Return whether the current runtime is Windows."""
 
-    return get_platform_name() == "Windows"
+    return _get().is_windows
 
 
 def is_queue_enabled_for_platform() -> bool:
     """Mirror the current queue policy without changing app behavior yet."""
 
-    return not is_windows()
+    return _get().is_queue_supported()

--- a/web/platform_adapter.py
+++ b/web/platform_adapter.py
@@ -13,16 +13,16 @@ from newsletter_core.public.platform import get_platform_adapter as _get
 def get_platform_name() -> str:
     """Return the current OS name as reported by Python."""
 
-    return _get().name
+    return str(_get().name)
 
 
 def is_windows() -> bool:
     """Return whether the current runtime is Windows."""
 
-    return _get().is_windows
+    return bool(_get().is_windows)
 
 
 def is_queue_enabled_for_platform() -> bool:
     """Mirror the current queue policy without changing app behavior yet."""
 
-    return _get().is_queue_supported()
+    return bool(_get().is_queue_supported())

--- a/web/runtime_hook.py
+++ b/web/runtime_hook.py
@@ -169,9 +169,14 @@ def _setup_environment_variables() -> None:
         os.environ.pop("CLOUDSDK_CONFIG", None)
 
         # UTF-8 인코딩 강제 설정 (Windows 환경)
-        if sys.platform.startswith("win"):
-            os.environ["PYTHONIOENCODING"] = "utf-8"
-            os.environ["PYTHONUTF8"] = "1"
+        try:
+            from newsletter_core.public.platform import get_platform_adapter
+
+            get_platform_adapter().configure_utf8_io()
+        except ImportError:
+            if sys.platform.startswith("win"):
+                os.environ["PYTHONIOENCODING"] = "utf-8"
+                os.environ["PYTHONUTF8"] = "1"
 
         # 🔴 CRITICAL FIX: .env 파일 로딩
         if getattr(sys, "frozen", False):

--- a/web/runtime_paths.py
+++ b/web/runtime_paths.py
@@ -11,14 +11,15 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
-
-def _is_frozen() -> bool:
-    return bool(getattr(sys, "frozen", False))
+from newsletter_core.infrastructure.platform._frozen import (
+    get_bundle_root as _core_bundle_root,
+)
+from newsletter_core.infrastructure.platform._frozen import is_frozen_any as _is_frozen
 
 
 def _bundle_root() -> Path:
-    if _is_frozen() and hasattr(sys, "_MEIPASS"):
-        return Path(getattr(sys, "_MEIPASS"))
+    if _is_frozen():
+        return _core_bundle_root()
     return Path(__file__).resolve().parent
 
 

--- a/web/runtime_paths.py
+++ b/web/runtime_paths.py
@@ -19,7 +19,7 @@ from newsletter_core.infrastructure.platform._frozen import is_frozen_any as _is
 
 def _bundle_root() -> Path:
     if _is_frozen():
-        return _core_bundle_root()
+        return Path(_core_bundle_root())
     return Path(__file__).resolve().parent
 
 


### PR DESCRIPTION
## Summary (what / why)

OS-specific branching (`platform.system()`, `sys.platform`, frozen-detection, UTF-8 setup, signal registration) was scattered across 10+ files with substantial duplication. This PR introduces a `PlatformAdapter` Protocol in `newsletter_core/infrastructure/platform/` and migrates all call sites to use it, making the codebase runnable on macOS / Linux without Windows-specific code leaking through.

**Phase 1** — Infrastructure: `_protocol.py`, `_windows.py`, `_unix.py`, `_resolver.py`, `_frozen.py`, `newsletter_core/public/platform.py`

**Phase 2** — Call-site migration: `web/platform_adapter.py`, `web/app.py`, `newsletter/cli.py`, `run_ci_checks.py`, `scripts/devtools/run_tests.py`, `web/runtime_hook.py`, `scripts/devtools/dev_entrypoint.py`, `web/runtime_paths.py`, `web/binary_compatibility.py`

**Phase 3** — Signal extraction: `_signal.py` (new), `newsletter/utils/shutdown_manager.py` refactored (143-line duplication → 60 lines + `_on_shutdown_event()`)

## Scope
### In Scope
- Platform adapter infrastructure (Protocol + Windows/Unix implementations + resolver)
- Frozen-detection consolidation (_frozen.py)
- Call-site migration for UTF-8, venv paths, queue checks
- Signal handler extraction to _signal.py
- 27 new unit tests

### Out of Scope
- Phase 4 path-management consolidation (follow-up)
- Phase 5 legacy cleanup (follow-up)

## Delivery Unit
RR: #387
Delivery Unit ID: platform-adapter
Merge Boundary: single PR — all phases in one merge
Rollback Boundary: revert this PR; no schema or data changes

## Test & Evidence
- [x] `make check`
- [x] GitHub required checks green before merge
- [x] 330 unit tests pass (8 pre-existing failures unrelated to this PR)
- [x] 27 new unit tests (23 platform adapter + 4 signal registration)
- [x] `flake8` passes on all changed files

### Commands and Results
```bash
python -m pytest tests/unit_tests/ -q --ignore=tests/unit_tests/test_compose_contract_lock.py
# 330 passed, 8 failed (pre-existing), 2 skipped
```

## Risk & Rollback
- Risk: Low — all existing public APIs preserved via thin delegation layers; PyInstaller bootstrap uses try/except ImportError fallback
- Rollback: `git revert` this PR; no schema or data changes

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: N/A
- Outbox/send_key 중복 방지 결과: N/A
- import-time side effect 제거 여부: Yes — `ctypes.windll` now only imported on Windows via lazy import in `_resolver.py`

## Not Run (with reason)
- `make check-full`: real API keys not available in dev environment