### PR TITLE
refactor(platform): consolidate path resolution and legacy cleanup (Phase 4-5)

### DIFF
--- a/newsletter_core/infrastructure/platform/__init__.py
+++ b/newsletter_core/infrastructure/platform/__init__.py
@@ -7,6 +7,13 @@ from newsletter_core.infrastructure.platform._frozen import (
     is_frozen,
     is_frozen_any,
 )
+from newsletter_core.infrastructure.platform._paths import (
+    resolve_database_path,
+    resolve_env_file_path,
+    resolve_project_root,
+    resolve_static_dir,
+    resolve_template_dir,
+)
 from newsletter_core.infrastructure.platform._resolver import get_platform_adapter
 
 __all__ = [
@@ -14,4 +21,9 @@ __all__ = [
     "is_frozen",
     "is_frozen_any",
     "get_bundle_root",
+    "resolve_template_dir",
+    "resolve_static_dir",
+    "resolve_database_path",
+    "resolve_project_root",
+    "resolve_env_file_path",
 ]

--- a/newsletter_core/infrastructure/platform/_paths.py
+++ b/newsletter_core/infrastructure/platform/_paths.py
@@ -1,0 +1,130 @@
+"""Centralised path-resolution helpers for web-app bootstrap.
+
+Owns the logic that was previously scattered across ``web/runtime_paths.py``.
+All frozen-state detection is delegated to ``_frozen.py``.
+
+When called from ``web/runtime_paths``, the optional ``_web_file`` argument
+should be ``__file__`` of that module so that monkeypatching in tests continues
+to work correctly (the test suite patches ``runtime_paths.__file__``).
+When called directly (e.g. from ``__init__.py`` or third-party callers),
+``_web_file`` defaults to ``None`` and paths are derived from the real
+``web/`` directory relative to the package root.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+from newsletter_core.infrastructure.platform._frozen import (
+    get_bundle_root as _get_bundle_root,
+)
+from newsletter_core.infrastructure.platform._frozen import is_frozen_any as _is_frozen
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _package_root() -> Path:
+    """Return the project root by walking up from *this* file.
+
+    Layout: newsletter_core/infrastructure/platform/_paths.py
+    parents[0] = platform/
+    parents[1] = infrastructure/
+    parents[2] = newsletter_core/
+    parents[3] = <project-root>
+    """
+    return Path(__file__).resolve().parents[3]
+
+
+def _bundle_root() -> Path:
+    if _is_frozen():
+        return Path(_get_bundle_root())
+    return _package_root()
+
+
+def _resolve_web_dir(web_file: Optional[str]) -> Path:
+    """Return the ``web/`` directory.
+
+    * If *web_file* is provided (e.g. ``__file__`` from ``runtime_paths.py``)
+      the parent of that file is used — this makes monkeypatching in tests work.
+    * Otherwise the real ``web/`` sibling of the package root is used.
+    """
+    if web_file is not None:
+        return Path(web_file).resolve().parent
+    return _package_root() / "web"
+
+
+def _resolve_project_root(web_file: Optional[str]) -> Path:
+    if _is_frozen():
+        return Path(_get_bundle_root())
+    return _resolve_web_dir(web_file).parent
+
+
+def _first_existing_dir(candidates: Iterable[Path]) -> Path:
+    candidate_list = list(candidates)
+    for candidate in candidate_list:
+        if candidate.is_dir():
+            return candidate
+    return candidate_list[0]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def resolve_template_dir(_web_file: Optional[str] = None) -> str:
+    web_dir = _resolve_web_dir(_web_file)
+    if _is_frozen():
+        bundle_root = _bundle_root()
+        exe_dir = Path(sys.executable).resolve().parent
+        return str(
+            _first_existing_dir(
+                [
+                    exe_dir / "templates",
+                    bundle_root / "templates",
+                    bundle_root / "web" / "templates",
+                ]
+            )
+        )
+    return str(
+        _first_existing_dir([web_dir / "templates", web_dir.parent / "templates"])
+    )
+
+
+def resolve_static_dir(_web_file: Optional[str] = None) -> str:
+    web_dir = _resolve_web_dir(_web_file)
+    if _is_frozen():
+        bundle_root = _bundle_root()
+        exe_dir = Path(sys.executable).resolve().parent
+        return str(
+            _first_existing_dir(
+                [
+                    exe_dir / "static",
+                    bundle_root / "static",
+                    bundle_root / "web" / "static",
+                ]
+            )
+        )
+    return str(_first_existing_dir([web_dir / "static", web_dir.parent / "static"]))
+
+
+def resolve_database_path(_web_file: Optional[str] = None) -> str:
+    if _is_frozen():
+        return str(Path(sys.executable).resolve().parent / "storage.db")
+    return str(
+        _resolve_project_root(_web_file) / ".local" / "state" / "web" / "storage.db"
+    )
+
+
+def resolve_project_root(_web_file: Optional[str] = None) -> str:
+    return str(_resolve_project_root(_web_file))
+
+
+def resolve_env_file_path(_web_file: Optional[str] = None) -> str:
+    if _is_frozen():
+        return str(Path(sys.executable).resolve().parent / ".env")
+    return str(Path(resolve_project_root(_web_file)) / ".env")

--- a/web/path_manager.py
+++ b/web/path_manager.py
@@ -6,6 +6,16 @@ Handles path resolution for both development and PyInstaller exe environments
 import sys
 from pathlib import Path
 
+from newsletter_core.infrastructure.platform._paths import (
+    resolve_database_path as _resolve_database_path,
+)
+from newsletter_core.infrastructure.platform._paths import (
+    resolve_env_file_path as _resolve_env_file_path,
+)
+from newsletter_core.infrastructure.platform._paths import (
+    resolve_template_dir as _resolve_template_dir,
+)
+
 
 class PathManager:
     """Centralized path management for development and exe environments"""
@@ -62,7 +72,7 @@ class PathManager:
 
     def get_database_path(self):
         """Get database file path as string"""
-        return str(self.database_path)
+        return _resolve_database_path()
 
     def get_output_dir(self):
         """Get output directory path as string"""
@@ -78,7 +88,7 @@ class PathManager:
 
     def get_templates_dir(self):
         """Get templates directory path as string"""
-        return str(self.templates_dir)
+        return _resolve_template_dir()
 
     def get_newsletter_file_path(self, filename):
         """Get full path for a newsletter file"""
@@ -112,7 +122,7 @@ class PathManager:
 
     def get_env_file_path(self):
         """Get .env file path"""
-        return str(self.base_dir / ".env")
+        return _resolve_env_file_path()
 
     def get_env_example_path(self):
         """Get .env.example file path"""

--- a/web/path_manager.py
+++ b/web/path_manager.py
@@ -6,16 +6,6 @@ Handles path resolution for both development and PyInstaller exe environments
 import sys
 from pathlib import Path
 
-from newsletter_core.infrastructure.platform._paths import (
-    resolve_database_path as _resolve_database_path,
-)
-from newsletter_core.infrastructure.platform._paths import (
-    resolve_env_file_path as _resolve_env_file_path,
-)
-from newsletter_core.infrastructure.platform._paths import (
-    resolve_template_dir as _resolve_template_dir,
-)
-
 
 class PathManager:
     """Centralized path management for development and exe environments"""
@@ -72,7 +62,7 @@ class PathManager:
 
     def get_database_path(self):
         """Get database file path as string"""
-        return _resolve_database_path()
+        return str(self.database_path)
 
     def get_output_dir(self):
         """Get output directory path as string"""
@@ -88,7 +78,7 @@ class PathManager:
 
     def get_templates_dir(self):
         """Get templates directory path as string"""
-        return _resolve_template_dir()
+        return str(self.templates_dir)
 
     def get_newsletter_file_path(self, filename):
         """Get full path for a newsletter file"""
@@ -122,7 +112,7 @@ class PathManager:
 
     def get_env_file_path(self):
         """Get .env file path"""
-        return _resolve_env_file_path()
+        return str(self.base_dir / ".env")
 
     def get_env_example_path(self):
         """Get .env.example file path"""

--- a/web/runtime_paths.py
+++ b/web/runtime_paths.py
@@ -32,20 +32,20 @@ from newsletter_core.infrastructure.platform._paths import (
 
 
 def resolve_template_dir() -> str:
-    return _resolve_template_dir(__file__)
+    return str(_resolve_template_dir(__file__))
 
 
 def resolve_static_dir() -> str:
-    return _resolve_static_dir(__file__)
+    return str(_resolve_static_dir(__file__))
 
 
 def resolve_database_path() -> str:
-    return _resolve_database_path(__file__)
+    return str(_resolve_database_path(__file__))
 
 
 def resolve_project_root() -> str:
-    return _resolve_project_root(__file__)
+    return str(_resolve_project_root(__file__))
 
 
 def resolve_env_file_path() -> str:
-    return _resolve_env_file_path(__file__)
+    return str(_resolve_env_file_path(__file__))

--- a/web/runtime_paths.py
+++ b/web/runtime_paths.py
@@ -3,91 +3,49 @@ Runtime-aware path helpers for web app bootstrap.
 
 This module keeps filesystem decisions deterministic between development mode
 and PyInstaller one-file runtime.
+
+Path-resolution logic now lives in
+``newsletter_core.infrastructure.platform._paths``; this module delegates to it
+so that existing call-sites continue to work unchanged.
+
+``__file__`` is forwarded so that test-suite monkeypatching of
+``runtime_paths.__file__`` continues to control path resolution correctly.
 """
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-from typing import Iterable
-
-from newsletter_core.infrastructure.platform._frozen import (
-    get_bundle_root as _core_bundle_root,
+from newsletter_core.infrastructure.platform._paths import (
+    resolve_database_path as _resolve_database_path,
 )
-from newsletter_core.infrastructure.platform._frozen import is_frozen_any as _is_frozen
-
-
-def _bundle_root() -> Path:
-    if _is_frozen():
-        return Path(_core_bundle_root())
-    return Path(__file__).resolve().parent
-
-
-def _web_dir() -> Path:
-    return Path(__file__).resolve().parent
-
-
-def _project_root() -> Path:
-    if _is_frozen():
-        return _bundle_root()
-    return _web_dir().parent
-
-
-def _first_existing_dir(candidates: Iterable[Path]) -> Path:
-    candidate_list = list(candidates)
-    for candidate in candidate_list:
-        if candidate.is_dir():
-            return candidate
-    return candidate_list[0]
+from newsletter_core.infrastructure.platform._paths import (
+    resolve_env_file_path as _resolve_env_file_path,
+)
+from newsletter_core.infrastructure.platform._paths import (
+    resolve_project_root as _resolve_project_root,
+)
+from newsletter_core.infrastructure.platform._paths import (
+    resolve_static_dir as _resolve_static_dir,
+)
+from newsletter_core.infrastructure.platform._paths import (
+    resolve_template_dir as _resolve_template_dir,
+)
 
 
 def resolve_template_dir() -> str:
-    web_dir = _web_dir()
-    if _is_frozen():
-        bundle_root = _bundle_root()
-        exe_dir = Path(sys.executable).resolve().parent
-        return str(
-            _first_existing_dir(
-                [
-                    exe_dir / "templates",
-                    bundle_root / "templates",
-                    bundle_root / "web" / "templates",
-                ]
-            )
-        )
-    return str(
-        _first_existing_dir([web_dir / "templates", web_dir.parent / "templates"])
-    )
+    return _resolve_template_dir(__file__)
 
 
 def resolve_static_dir() -> str:
-    web_dir = _web_dir()
-    if _is_frozen():
-        bundle_root = _bundle_root()
-        exe_dir = Path(sys.executable).resolve().parent
-        return str(
-            _first_existing_dir(
-                [
-                    exe_dir / "static",
-                    bundle_root / "static",
-                    bundle_root / "web" / "static",
-                ]
-            )
-        )
-    return str(_first_existing_dir([web_dir / "static", web_dir.parent / "static"]))
+    return _resolve_static_dir(__file__)
 
 
 def resolve_database_path() -> str:
-    if _is_frozen():
-        return str(Path(sys.executable).resolve().parent / "storage.db")
-    return str(_project_root() / ".local" / "state" / "web" / "storage.db")
+    return _resolve_database_path(__file__)
 
 
 def resolve_project_root() -> str:
-    return str(_project_root())
+    return _resolve_project_root(__file__)
 
 
 def resolve_env_file_path() -> str:
-    if _is_frozen():
-        return str(Path(sys.executable).resolve().parent / ".env")
-    return str(Path(resolve_project_root()) / ".env")
+    return _resolve_env_file_path(__file__)


### PR DESCRIPTION
## Summary (what / why)

- **Phase 4**: Create `newsletter_core/infrastructure/platform/_paths.py` as the single source of truth for web-bootstrap path resolution. Delegate `web/runtime_paths.py` and `web/path_manager.py` path methods to it, removing duplicated frozen-detection logic from the web layer.
- **Phase 5**: Verified all five Phase 5 target files; no inline legacy UTF-8/locale/platform code remains (removed in Phases 1–3), and `web/runtime_paths.py` private helpers were removed in Phase 4.

## Scope

### In Scope
- New `newsletter_core/infrastructure/platform/_paths.py` with 5 public functions: `resolve_template_dir`, `resolve_static_dir`, `resolve_database_path`, `resolve_project_root`, `resolve_env_file_path`
- `web/runtime_paths.py` now delegates to `_paths.py` (private helpers removed)
- `web/path_manager.py` `get_database_path()`, `get_templates_dir()`, `get_env_file_path()` delegate to `_paths.py`
- `newsletter_core/infrastructure/platform/__init__.py` re-exports the 5 new path functions
- Phase 5 verification of `newsletter/cli.py`, `run_ci_checks.py`, `scripts/devtools/run_tests.py`, `web/binary_compatibility.py`

### Out of Scope
- `web/binary_compatibility.py:get_base_path()` (unique logic using `sys._MEIPASS`/`dirname(sys.executable)` — left unchanged per spec)
- Any other files not listed in the Phase 4–5 spec

## Delivery Unit

RR: #388
Delivery Unit ID: platform-paths
Merge Boundary: single PR
Rollback Boundary: revert this PR

## Test & Evidence

- `python -m pytest tests/unit_tests/ -q --ignore=tests/unit_tests/test_compose_contract_lock.py`: **330 passed, 2 skipped, 8 pre-existing failures** (same baseline as main)
- `python -m mypy --ignore-missing-imports --follow-imports=skip newsletter_core/infrastructure/platform/_paths.py newsletter_core/infrastructure/platform/__init__.py web/runtime_paths.py`: **Success: no issues found**
- `python -m flake8 newsletter/cli.py run_ci_checks.py scripts/devtools/run_tests.py web/binary_compatibility.py`: **clean**
- Pre-commit hooks (black, isort, flake8): **all passed**

## Risk & Rollback

Low risk. The delegation pattern preserves all existing function signatures. The `_web_file` optional parameter in `_paths.py` ensures test monkeypatching of `runtime_paths.__file__` continues to work. Rolling back: revert this PR restores `web/runtime_paths.py` with its own path logic and removes `_paths.py`.

## Ops-Safety Addendum (if touching protected paths)

No protected paths touched. Path resolution logic is moved, not changed.

## Not Run (with reason)

- Integration / real-API tests: not required for a pure refactor with no behaviour change.