### PR TITLE
refactor(platform): test coverage, code review, and docs follow-up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# CLAUDE.md — Developer Guidance
+
+Repository-specific guidance for AI coding assistants working in this codebase.
+See `AGENTS.md` for the full workflow contract (RR/branch/commit/PR rules).
+
+## Platform Adapter Architecture
+
+All platform-specific code lives in `newsletter_core/infrastructure/platform/`.
+
+**Getting the adapter:**
+```python
+from newsletter_core.public.platform import get_platform_adapter
+adapter = get_platform_adapter()
+```
+
+**Module responsibilities:**
+
+| Module | Purpose |
+|---|---|
+| `_protocol.py` | `PlatformAdapter` Protocol — defines the interface (`name`, `is_windows`, `configure_utf8_io`, `is_queue_supported`, `signal_names`, `venv_python_path`) |
+| `_windows.py` | Windows implementation: UTF-8 locale/stream setup, SIGBREAK support, `Scripts/python.exe` path |
+| `_unix.py` | Unix implementation: no-op UTF-8 setup, SIGINT+SIGTERM, `bin/python` path |
+| `_resolver.py` | `get_platform_adapter()` factory with lazy imports (ctypes.windll never loads on Unix) |
+| `_frozen.py` | `is_frozen()`, `is_frozen_any()`, `get_bundle_root()` — replaces duplicate inline freeze checks |
+| `_signal.py` | `setup_signal_handlers()` — replaces platform branch in ShutdownManager |
+| `_paths.py` | 5 path-resolution helpers — replaces inline logic in `web/runtime_paths.py` |
+
+**Rule:** New platform-specific branching goes in `_windows.py` / `_unix.py`, not inline in app code.
+
+Thin backward-compatible delegation layers exist at `web/platform_adapter.py`,
+`web/runtime_paths.py`, and `web/binary_compatibility.py` — do not add logic there.
+
+## Architecture Boundaries
+
+Import rules enforced by CI (see `docs/technical/adr-0001-architecture-boundaries.md`):
+
+- `newsletter -> web` import is forbidden.
+- `web -> newsletter` import is forbidden; use `newsletter_core.public` instead.
+- `newsletter_core.domain -> newsletter_core.infrastructure` import is forbidden.
+- New modules go under `newsletter_core/`, not `newsletter/`.
+
+## Key Docs
+
+- Architecture: `docs/ARCHITECTURE.md`
+- ADR index: `docs/technical/`
+- Dev guide: `docs/dev/DEVELOPMENT_GUIDE.md`
+- Local setup: `docs/setup/LOCAL_SETUP.md`

--- a/docs/technical/adr-0002-platform-adapter-pattern.md
+++ b/docs/technical/adr-0002-platform-adapter-pattern.md
@@ -1,0 +1,17 @@
+# ADR-0002: Platform Adapter Pattern
+
+## Status
+Accepted
+
+## Context
+Platform-specific branching (Windows UTF-8 setup, freeze detection, signal handling, venv paths) was duplicated inline across `web/` and `newsletter_core/` modules. This made it hard to add new platforms and caused `ctypes.windll` to be imported on non-Windows hosts.
+
+## Decision
+Introduce `newsletter_core/infrastructure/platform/` as the single location for all platform-specific logic. A `PlatformAdapter` Protocol (`_protocol.py`) defines the interface; `_windows.py` and `_unix.py` provide concrete implementations selected at runtime by `_resolver.py` using lazy imports. Supporting modules `_frozen.py`, `_signal.py`, and `_paths.py` consolidate previously duplicated inline helpers. The public API is exposed via `newsletter_core.public.platform`. Existing `web/` shims are retained as thin backward-compatible delegation layers only.
+
+## Consequences
+- Platform branches are isolated to `_windows.py` / `_unix.py`; app code stays platform-agnostic.
+- `ctypes.windll` is never imported on Unix hosts (lazy resolver).
+- Freeze detection and signal setup are deduplicated across the codebase.
+- Backward compatibility is preserved via `web/platform_adapter.py`, `web/runtime_paths.py`, and `web/binary_compatibility.py` delegation layers.
+- New platform-specific behavior must go in `_windows.py` / `_unix.py`, not inline in app code.

--- a/scripts/repo_hygiene_policy.json
+++ b/scripts/repo_hygiene_policy.json
@@ -10,6 +10,7 @@
       ".pre-commit-config.yaml",
       ".secrets.baseline",
       "AGENTS.md",
+      "CLAUDE.md",
       "CHANGELOG.md",
       "CODEOWNERS",
       "Dockerfile",

--- a/tests/unit_tests/newsletter_core/infrastructure/test_paths.py
+++ b/tests/unit_tests/newsletter_core/infrastructure/test_paths.py
@@ -1,0 +1,328 @@
+"""Unit tests for newsletter_core.infrastructure.platform._paths."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from newsletter_core.infrastructure.platform._paths import (
+    resolve_database_path,
+    resolve_env_file_path,
+    resolve_project_root,
+    resolve_static_dir,
+    resolve_template_dir,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_dev_web_dir(tmp_path: Path) -> Path:
+    """Create a minimal web directory layout under *tmp_path* and return the
+    fake ``__file__`` path that callers should pass as *_web_file*."""
+    project_root = tmp_path / "project"
+    web_dir = project_root / "web"
+    (web_dir / "templates").mkdir(parents=True)
+    (web_dir / "static").mkdir(parents=True)
+    return web_dir / "runtime_paths.py"
+
+
+# ---------------------------------------------------------------------------
+# Dev-mode (non-frozen) tests
+# ---------------------------------------------------------------------------
+
+
+class TestPathResolution:
+    def test_resolve_template_dir_dev_mode(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        web_file = _setup_dev_web_dir(tmp_path)
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+        result = resolve_template_dir(str(web_file))
+
+        assert result.endswith("templates")
+
+    def test_resolve_static_dir_dev_mode(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        web_file = _setup_dev_web_dir(tmp_path)
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+        result = resolve_static_dir(str(web_file))
+
+        assert result.endswith("static")
+
+    def test_resolve_database_path_dev_mode(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        web_file = _setup_dev_web_dir(tmp_path)
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+        result = resolve_database_path(str(web_file))
+
+        assert result.endswith("storage.db")
+
+    def test_resolve_env_file_path_dev_mode(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        web_file = _setup_dev_web_dir(tmp_path)
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+        result = resolve_env_file_path(str(web_file))
+
+        assert result.endswith(".env")
+
+    def test_resolve_project_root_dev_mode(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        web_file = _setup_dev_web_dir(tmp_path)
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+        result = resolve_project_root(str(web_file))
+
+        # Should be the parent of the web/ directory
+        assert Path(result).is_dir()
+        assert Path(result) == tmp_path / "project"
+
+    def test_resolve_template_dir_returns_string(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        web_file = _setup_dev_web_dir(tmp_path)
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+        result = resolve_template_dir(str(web_file))
+
+        assert isinstance(result, str)
+
+    def test_resolve_database_path_under_project_root(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        web_file = _setup_dev_web_dir(tmp_path)
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+        project_root = resolve_project_root(str(web_file))
+        db_path = resolve_database_path(str(web_file))
+
+        assert db_path.startswith(project_root)
+
+    def test_resolve_env_file_path_under_project_root(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        web_file = _setup_dev_web_dir(tmp_path)
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+        project_root = resolve_project_root(str(web_file))
+        env_path = resolve_env_file_path(str(web_file))
+
+        assert env_path.startswith(project_root)
+
+    # -----------------------------------------------------------------------
+    # Frozen-mode tests
+    # -----------------------------------------------------------------------
+
+    def test_resolve_template_dir_frozen_mode(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        bundle_dir = tmp_path / "bundle"
+        exe_dir = tmp_path / "exe"
+        (exe_dir / "templates").mkdir(parents=True)
+        (bundle_dir / "templates").mkdir(parents=True)
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", str(bundle_dir), raising=False)
+        monkeypatch.setattr(sys, "executable", str(exe_dir / "app"))
+
+        result = resolve_template_dir()
+
+        # Prefers exe_dir/templates when it exists
+        assert result == str(exe_dir / "templates")
+        assert "templates" in result
+
+    def test_resolve_template_dir_frozen_falls_back_to_bundle(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        bundle_dir = tmp_path / "bundle"
+        exe_dir = tmp_path / "exe"
+        # Only bundle has templates, not exe_dir
+        (bundle_dir / "templates").mkdir(parents=True)
+        exe_dir.mkdir(parents=True)
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", str(bundle_dir), raising=False)
+        monkeypatch.setattr(sys, "executable", str(exe_dir / "app"))
+
+        result = resolve_template_dir()
+
+        assert str(tmp_path) in result
+        assert "templates" in result
+
+    def test_resolve_static_dir_frozen_mode(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        bundle_dir = tmp_path / "bundle"
+        exe_dir = tmp_path / "exe"
+        (exe_dir / "static").mkdir(parents=True)
+        (bundle_dir / "static").mkdir(parents=True)
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", str(bundle_dir), raising=False)
+        monkeypatch.setattr(sys, "executable", str(exe_dir / "app"))
+
+        result = resolve_static_dir()
+
+        assert result == str(exe_dir / "static")
+        assert "static" in result
+
+    def test_resolve_database_path_frozen_mode(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        bundle_dir = tmp_path / "bundle"
+        exe_dir = tmp_path / "exe"
+        exe_dir.mkdir(parents=True)
+        bundle_dir.mkdir(parents=True)
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", str(bundle_dir), raising=False)
+        monkeypatch.setattr(sys, "executable", str(exe_dir / "app"))
+
+        result = resolve_database_path()
+
+        assert result.endswith("storage.db")
+        assert str(exe_dir) in result
+
+    def test_resolve_env_file_path_frozen_mode(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        bundle_dir = tmp_path / "bundle"
+        exe_dir = tmp_path / "exe"
+        exe_dir.mkdir(parents=True)
+        bundle_dir.mkdir(parents=True)
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", str(bundle_dir), raising=False)
+        monkeypatch.setattr(sys, "executable", str(exe_dir / "app"))
+
+        result = resolve_env_file_path()
+
+        assert result.endswith(".env")
+        assert str(exe_dir) in result
+
+    def test_resolve_project_root_frozen_mode(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        bundle_dir = tmp_path / "bundle"
+        bundle_dir.mkdir(parents=True)
+
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", str(bundle_dir), raising=False)
+        monkeypatch.setattr(sys, "executable", str(tmp_path / "exe" / "app"))
+
+        result = resolve_project_root()
+
+        # In frozen mode, project root is bundle_root (i.e. _MEIPASS)
+        assert result == str(bundle_dir)
+
+    # -----------------------------------------------------------------------
+    # No _web_file fallback (package-root based)
+    # -----------------------------------------------------------------------
+
+    def test_resolve_project_root_no_web_file_returns_directory(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+        result = resolve_project_root()
+
+        assert Path(result).is_dir()
+
+    def test_resolve_template_dir_no_web_file_returns_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+        result = resolve_template_dir()
+
+        assert isinstance(result, str)
+        assert "templates" in result
+
+
+# ---------------------------------------------------------------------------
+# Delegation from web/runtime_paths.py
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimePathsDelegation:
+    """Confirm that web.runtime_paths delegates to _paths.py correctly."""
+
+    def test_template_dir_delegation(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from web import runtime_paths
+
+        project_root = tmp_path / "project"
+        web_dir = project_root / "web"
+        (web_dir / "templates").mkdir(parents=True)
+        (web_dir / "static").mkdir(parents=True)
+
+        monkeypatch.setattr(
+            runtime_paths, "__file__", str(web_dir / "runtime_paths.py")
+        )
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+        assert runtime_paths.resolve_template_dir() == str(web_dir / "templates")
+
+    def test_static_dir_delegation(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from web import runtime_paths
+
+        project_root = tmp_path / "project"
+        web_dir = project_root / "web"
+        (web_dir / "templates").mkdir(parents=True)
+        (web_dir / "static").mkdir(parents=True)
+
+        monkeypatch.setattr(
+            runtime_paths, "__file__", str(web_dir / "runtime_paths.py")
+        )
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+        assert runtime_paths.resolve_static_dir() == str(web_dir / "static")
+
+    def test_database_path_delegation(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from web import runtime_paths
+
+        project_root = tmp_path / "project"
+        web_dir = project_root / "web"
+        (web_dir / "templates").mkdir(parents=True)
+        (web_dir / "static").mkdir(parents=True)
+
+        monkeypatch.setattr(
+            runtime_paths, "__file__", str(web_dir / "runtime_paths.py")
+        )
+        monkeypatch.delattr(sys, "frozen", raising=False)
+        monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+        assert runtime_paths.resolve_database_path() == str(
+            project_root / ".local" / "state" / "web" / "storage.db"
+        )


### PR DESCRIPTION
## Summary (what / why)

Follow-up to the Phase 1-5 platform adapter refactoring (PRs #386, #389). Adds test coverage for the new `_paths.py` module, verifies code quality (no issues found), and documents the architecture for future contributors.

## Scope
### In Scope
- **Step 1 (Review)**: Ran full code review of Phase 1-5 changes — circular imports, import boundaries, mypy, flake8, architecture-check. All clean, no fixes needed.
- **Step 2 (Tests)**: 19 new unit tests for `_paths.py` covering dev-mode and frozen (PyInstaller) paths, plus delegation assertions for `web.runtime_paths`.
- **Step 3 (Docs)**: `CLAUDE.md` (developer guidance for AI assistants), `docs/technical/adr-0002-platform-adapter-pattern.md` (architecture decision record).

### Out of Scope
- Functional changes to platform logic
- README changes (README is user-facing, not developer-focused)

## Delivery Unit
RR: #390
Delivery Unit ID: platform-adapter-followup
Merge Boundary: single PR
Rollback Boundary: revert this PR; no schema or data changes

## Test & Evidence
- [x] 349 unit tests pass (19 new, 8 pre-existing failures unchanged)
- [x] `make architecture-check` passes (0 violations, 0 cycles)
- [x] mypy clean on all platform files
- [x] flake8 clean

### Commands and Results
```bash
python -m pytest tests/unit_tests/ -q --ignore=tests/unit_tests/test_compose_contract_lock.py
# 349 passed, 8 failed (pre-existing), 2 skipped
```

## Risk & Rollback
- Risk: None — tests and docs only, no logic changes
- Rollback: revert this PR

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: N/A
- Outbox/send_key 중복 방지 결과: N/A
- import-time side effect 제거 여부: N/A

## Not Run (with reason)
- `make check-full`: real API keys not available in dev environment