### PR TITLE
fix(web): ensure project root in sys.path for newsletter_core import

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -65,9 +65,9 @@ llm_settings:
     # 키워드 생성 (도메인 → 키워드) - 창의성이 중요하므로 Anthropic 사용
     keyword_generation:
       provider: "gemini"
-      model: "gemini-2.5-pro-preview-03-25"
+      model: "gemini-2.5-pro"
       # provider: "anthropic"
-      # model: "claude-3-7-sonnet-latest"
+      # model: "claude-sonnet-4-6"
       temperature: 0.7
       max_retries: 2
       timeout: 60
@@ -75,7 +75,7 @@ llm_settings:
     # 테마 추출 (키워드 → 공통 테마) - 빠른 분석이 중요하므로 Gemini Flash 사용
     theme_extraction:
       provider: "gemini"
-      model: "gemini-2.5-flash-preview-05-20"
+      model: "gemini-2.5-flash"
       temperature: 0.2
       max_retries: 2
       timeout: 60
@@ -83,7 +83,7 @@ llm_settings:
     # 뉴스 요약 (기사 → 요약) - 정확성이 중요하므로 Gemini Pro 사용 (할당량 주의)
     news_summarization:
       provider: "gemini"
-      model: "gemini-2.5-pro-preview-03-25"
+      model: "gemini-2.5-pro"
       temperature: 0.3
       max_retries: 2
       timeout: 120
@@ -91,9 +91,9 @@ llm_settings:
     # 섹션 재생성 (뉴스 링크 → 섹션 요약) - 구조화된 작업이므로 Anthropic 사용
     section_regeneration:
       # provider: "anthropic"
-      # model: "claude-3-7-sonnet-latest"
+      # model: "claude-sonnet-4-6"
       provider: "gemini"
-      model: "gemini-2.5-pro-preview-03-25"
+      model: "gemini-2.5-pro"
       temperature: 0.3
       max_retries: 2
       timeout: 120
@@ -101,9 +101,9 @@ llm_settings:
     # 뉴스레터 소개 생성 - 자연스러운 글쓰기를 위해 Anthropic 사용
     introduction_generation:
       # provider: "anthropic"
-      # model: "claude-3-7-sonnet-latest"
+      # model: "claude-sonnet-4-6"
       provider: "gemini"
-      model: "gemini-2.5-flash-preview-05-20"
+      model: "gemini-2.5-flash"
       temperature: 0.4
       max_retries: 2
       timeout: 60
@@ -111,7 +111,7 @@ llm_settings:
     # HTML 생성 체인 (최종 뉴스레터 생성) - 복잡한 구조화 작업이므로 최신 Gemini 사용
     html_generation:
       provider: "gemini"
-      model: "gemini-2.5-pro-preview-03-25"
+      model: "gemini-2.5-pro"
       temperature: 0.2
       max_retries: 2
       timeout: 180
@@ -119,7 +119,7 @@ llm_settings:
     # 기사 점수 매기기 - 빠른 판단이 중요하므로 Gemini Flash 사용
     article_scoring:
       provider: "gemini"
-      model: "gemini-2.5-flash-preview-05-20"
+      model: "gemini-2.5-flash"
       temperature: 0.1
       max_retries: 2
       timeout: 30
@@ -127,7 +127,7 @@ llm_settings:
     # 번역 작업 - 정확성이 중요하므로 최신 Pro 모델 시도
     translation:
       provider: "gemini"
-      model: "gemini-2.5-pro-preview-03-25"
+      model: "gemini-2.5-pro"
       temperature: 0.1
       max_retries: 2
       timeout: 60
@@ -135,9 +135,9 @@ llm_settings:
   # 제공자별 모델 설정
   provider_models:
     gemini:
-      fast: "gemini-2.5-flash-preview-05-20"
-      standard: "gemini-1.5-pro"
-      advanced: "gemini-2.5-pro-preview-03-25"
+      fast: "gemini-2.5-flash-lite"
+      standard: "gemini-2.5-flash"
+      advanced: "gemini-2.5-pro"
 
     openai:
       fast: "gpt-4o-mini"
@@ -145,9 +145,9 @@ llm_settings:
       advanced: "gpt-4o"
 
     anthropic:
-      fast: "claude-3-5-haiku-latest"
-      standard: "claude-3-7-sonnet-latest"
-      advanced: "claude-sonnet-4-20250514"
+      fast: "claude-haiku-4-5-20251001"
+      standard: "claude-sonnet-4-6"
+      advanced: "claude-opus-4-6"
 
 # Distribution settings for GitHub Actions
 distribution:

--- a/newsletter/chains_llm_utils.py
+++ b/newsletter/chains_llm_utils.py
@@ -122,7 +122,7 @@ def get_llm(
             raise ValueError("GEMINI_API_KEY가 .env 파일에 설정되어 있지 않습니다.")
 
         return ChatGoogleGenerativeAI(
-            model="gemini-1.5-pro",  # 안정적인 모델로 변경
+            model="gemini-2.5-flash",
             google_api_key=config.GEMINI_API_KEY,
             temperature=temperature,
             transport="rest",

--- a/newsletter/config_manager.py
+++ b/newsletter/config_manager.py
@@ -99,42 +99,42 @@ def _build_default_llm_config() -> Dict[str, Any]:
         "models": {
             "keyword_generation": {
                 "provider": "gemini",
-                "model": "gemini-2.5-pro-preview-03-25",
+                "model": "gemini-2.5-pro",
                 "temperature": 0.7,
                 "max_retries": 2,
                 "timeout": 60,
             },
             "theme_extraction": {
                 "provider": "gemini",
-                "model": "gemini-1.5-flash-latest",
+                "model": "gemini-2.5-flash",
                 "temperature": 0.2,
                 "max_retries": 2,
                 "timeout": 60,
             },
             "news_summarization": {
                 "provider": "gemini",
-                "model": "gemini-2.5-pro-preview-03-25",
+                "model": "gemini-2.5-pro",
                 "temperature": 0.3,
                 "max_retries": 3,
                 "timeout": 120,
             },
             "section_regeneration": {
                 "provider": "gemini",
-                "model": "gemini-1.5-pro",
+                "model": "gemini-2.5-flash",
                 "temperature": 0.3,
                 "max_retries": 2,
                 "timeout": 120,
             },
             "introduction_generation": {
                 "provider": "gemini",
-                "model": "gemini-1.5-pro",
+                "model": "gemini-2.5-flash",
                 "temperature": 0.4,
                 "max_retries": 2,
                 "timeout": 60,
             },
             "html_generation": {
                 "provider": "gemini",
-                "model": "gemini-2.5-pro-preview-03-25",
+                "model": "gemini-2.5-pro",
                 "temperature": 0.2,
                 "max_retries": 3,
                 "timeout": 180,
@@ -142,9 +142,9 @@ def _build_default_llm_config() -> Dict[str, Any]:
         },
         "provider_models": {
             "gemini": {
-                "fast": "gemini-1.5-flash-latest",
-                "standard": "gemini-1.5-pro",
-                "advanced": "gemini-2.5-pro-preview-03-25",
+                "fast": "gemini-2.5-flash-lite",
+                "standard": "gemini-2.5-flash",
+                "advanced": "gemini-2.5-pro",
             },
             "openai": {
                 "fast": "gpt-4o-mini",
@@ -152,9 +152,9 @@ def _build_default_llm_config() -> Dict[str, Any]:
                 "advanced": "gpt-4o",
             },
             "anthropic": {
-                "fast": "claude-3-haiku-20240307",
-                "standard": "claude-3-sonnet-20240229",
-                "advanced": "claude-3-5-sonnet-20241022",
+                "fast": "claude-haiku-4-5-20251001",
+                "standard": "claude-sonnet-4-6",
+                "advanced": "claude-opus-4-6",
             },
         },
     }

--- a/newsletter/tools.py
+++ b/newsletter/tools.py
@@ -289,7 +289,7 @@ def generate_keywords_with_gemini(
                 return []
 
             llm = ChatGoogleGenerativeAI(
-                model="gemini-1.5-pro",  # 더 안정적인 모델로 변경
+                model="gemini-2.5-flash",
                 temperature=0.7,
                 google_api_key=config.GEMINI_API_KEY,
                 transport="rest",

--- a/web/runtime_paths.py
+++ b/web/runtime_paths.py
@@ -24,19 +24,19 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from newsletter_core.infrastructure.platform._paths import (
+from newsletter_core.infrastructure.platform._paths import (  # noqa: E402
     resolve_database_path as _resolve_database_path,
 )
-from newsletter_core.infrastructure.platform._paths import (
+from newsletter_core.infrastructure.platform._paths import (  # noqa: E402
     resolve_env_file_path as _resolve_env_file_path,
 )
-from newsletter_core.infrastructure.platform._paths import (
+from newsletter_core.infrastructure.platform._paths import (  # noqa: E402
     resolve_project_root as _resolve_project_root,
 )
-from newsletter_core.infrastructure.platform._paths import (
+from newsletter_core.infrastructure.platform._paths import (  # noqa: E402
     resolve_static_dir as _resolve_static_dir,
 )
-from newsletter_core.infrastructure.platform._paths import (
+from newsletter_core.infrastructure.platform._paths import (  # noqa: E402
     resolve_template_dir as _resolve_template_dir,
 )
 

--- a/web/runtime_paths.py
+++ b/web/runtime_paths.py
@@ -14,6 +14,16 @@ so that existing call-sites continue to work unchanged.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+# Ensure project root is in sys.path so newsletter_core is importable
+# when this module is loaded from the web/ directory directly
+# (e.g. `python web/init_database.py`).
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
 from newsletter_core.infrastructure.platform._paths import (
     resolve_database_path as _resolve_database_path,
 )


### PR DESCRIPTION
## Summary (what / why)
- `web/runtime_paths.py`가 Phase 4 platform 리팩토링 이후 `newsletter_core`를 module-level import
- `python web/init_database.py`처럼 `web/` 직접 실행 시 project root가 `sys.path`에 없어 `ModuleNotFoundError` 발생
- `runtime_paths.py` 상단에 project root `sys.path` 삽입 로직 추가로 해결
- 관련 LLM 모델 ID도 최신 stable 버전으로 일괄 업데이트 (gemini-2.5-pro-preview-03-25 등 404 에러 수정)

## Scope
### In Scope
- `web/runtime_paths.py` — sys.path 보장 + flake8 E402 noqa
- `config/config.yml` — Gemini/Anthropic 모델 ID 업데이트
- `newsletter/config_manager.py` — 코드 기본값 모델 ID 업데이트
- `newsletter/chains_llm_utils.py` — 하드코딩 모델 ID 업데이트
- `newsletter/tools.py` — 하드코딩 모델 ID 업데이트

### Out of Scope
- 기타 로직 변경 없음

## Delivery Unit
RR: #392
Delivery Unit ID: fix/runtime-paths-sys-path
Merge Boundary: main
Rollback Boundary: git revert 가능 (단순 경로/모델 설정 변경)

## Test & Evidence
- [x] `python3 web/init_database.py --verify-only` 정상 실행 확인
- [x] `pytest tests/unit_tests/newsletter_core/infrastructure/` 46개 통과
- [x] `flake8 web/runtime_paths.py` 통과

### Commands and Results
```bash
$ python3 web/init_database.py --verify-only
==================================================
🗄️  Newsletter Generator 데이터베이스 초기화 도구
==================================================
  📊 history 테이블 컬럼: [...]
✅ 데이터베이스 검증 성공

$ pytest tests/unit_tests/newsletter_core/infrastructure/ -q
46 passed in 1.80s
```

## Risk & Rollback
- Risk: 매우 낮음 — sys.path 삽입은 이미 존재하는 경로만 추가, 모델 ID는 설정값만 변경
- Rollback: `git revert HEAD~3` 또는 각 파일 개별 revert

## Ops-Safety Addendum (if touching protected paths)
- Idempotency key 생성/적용 범위: 해당 없음
- Outbox/send_key 중복 방지 결과: 해당 없음
- import-time side effect 제거 여부: sys.path 조작은 once-only guard (`if str(_PROJECT_ROOT) not in sys.path`)로 보호됨

## Not Run (with reason)
- `make check-full`: 통합 테스트는 실제 API key 필요 — CI에서 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)