### PR TITLE
feat(ops): add failed-jobs, schedule-drift, dedupe-stats ops visibility

### DIFF
--- a/docs/dev/DEVELOPMENT_GUIDE.md
+++ b/docs/dev/DEVELOPMENT_GUIDE.md
@@ -335,7 +335,7 @@ class TestComposeNewsletter:
 ```python
 import pytest
 import responses
-from newsletter.collect import collect_from_serper
+from newsletter_core.application.generation.collect import collect_from_serper
 
 class TestSerperAPI:
     """Serper API 테스트."""

--- a/newsletter/cli_run.py
+++ b/newsletter/cli_run.py
@@ -110,7 +110,8 @@ def run(
         generate_newsletter as generate_newsletter_public,
     )
 
-    from . import deliver as news_deliver
+    from newsletter_core.application.generation import deliver as news_deliver
+
     from . import tools
 
     # 로깅 레벨 설정

--- a/newsletter/cli_run.py
+++ b/newsletter/cli_run.py
@@ -102,6 +102,7 @@ def run(
     This command creates a newsletter by searching for recent news articles,
     processing them using AI, and optionally sending via email or saving to various formats.
     """
+    from newsletter_core.application.generation import deliver as news_deliver
     from newsletter_core.public.generation import (
         GenerateNewsletterRequest,
         NewsletterGenerationError,
@@ -109,8 +110,6 @@ def run(
     from newsletter_core.public.generation import (
         generate_newsletter as generate_newsletter_public,
     )
-
-    from newsletter_core.application.generation import deliver as news_deliver
 
     from . import tools
 

--- a/tests/api_tests/test_article_filter_integration.py
+++ b/tests/api_tests/test_article_filter_integration.py
@@ -12,8 +12,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 # 필요한 모듈을 패치
 with patch.dict("sys.modules", {"langchain_google_genai": MagicMock()}):
-    from newsletter import article_filter, cli, collect, config
+    from newsletter import article_filter, cli, config
     from newsletter.sources import NewsSourceManager, SerperAPISource
+    from newsletter_core.application.generation import collect
 
 
 class TestArticleFilterIntegration(unittest.TestCase):
@@ -68,9 +69,9 @@ class TestArticleFilterIntegration(unittest.TestCase):
             },
         ]
 
-    @patch("newsletter.collect.console")
+    @patch("newsletter_core.application.generation.collect.console")
     @patch("newsletter.article_filter.console")
-    @patch("newsletter.collect.configure_default_sources")
+    @patch("newsletter_core.application.generation.collect.configure_default_sources")
     @pytest.mark.skip(
         reason="Complex mocking issues with article collection integration"
     )
@@ -200,7 +201,7 @@ class TestArticleFilterIntegration(unittest.TestCase):
             patch.object(
                 NewsSourceManager, "fetch_all_sources", return_value=duplicates
             ) as mock_fetch_all_sources,
-            patch("newsletter.collect.console") as mock_collect_console,
+            patch("newsletter_core.application.generation.collect.console") as mock_collect_console,
             patch("newsletter.article_filter.console") as mock_filter_console,
         ):
 
@@ -236,7 +237,7 @@ class TestArticleFilterIntegration(unittest.TestCase):
 
         config.SERPER_API_KEY = original_serper_key  # 원래 키로 복원
 
-    @patch("newsletter.collect.console")
+    @patch("newsletter_core.application.generation.collect.console")
     @patch("newsletter.article_filter.console")
     @patch("newsletter.sources.configure_default_sources")
     @pytest.mark.skip(reason="API dependency - uses external news sources")
@@ -356,7 +357,7 @@ class TestArticleFilterIntegration(unittest.TestCase):
             patch.object(
                 NewsSourceManager, "fetch_all_sources", return_value=mixed_sources
             ) as mock_fetch_all,
-            patch("newsletter.collect.console") as mock_collect_console,
+            patch("newsletter_core.application.generation.collect.console") as mock_collect_console,
             patch("newsletter.article_filter.console") as mock_filter_console,
         ):
 

--- a/tests/api_tests/test_article_filter_integration.py
+++ b/tests/api_tests/test_article_filter_integration.py
@@ -1,9 +1,7 @@
-import argparse  # Add import for argparse
 import os
 import sys
 import unittest
-from typing import Any, Dict, List
-from unittest.mock import MagicMock, PropertyMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -12,9 +10,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 # 필요한 모듈을 패치
 with patch.dict("sys.modules", {"langchain_google_genai": MagicMock()}):
-    from newsletter import article_filter, cli, config
-    from newsletter.sources import NewsSourceManager, SerperAPISource
-    from newsletter_core.application.generation import collect
+    from newsletter import article_filter, config  # noqa: E402
+    from newsletter.sources import NewsSourceManager  # noqa: E402
+    from newsletter_core.application.generation import collect  # noqa: E402
 
 
 class TestArticleFilterIntegration(unittest.TestCase):
@@ -201,17 +199,16 @@ class TestArticleFilterIntegration(unittest.TestCase):
             patch.object(
                 NewsSourceManager, "fetch_all_sources", return_value=duplicates
             ) as mock_fetch_all_sources,
-            patch("newsletter_core.application.generation.collect.console") as mock_collect_console,
-            patch("newsletter.article_filter.console") as mock_filter_console,
+            patch("newsletter_core.application.generation.collect.console"),
+            patch("newsletter.article_filter.console"),
         ):
-
             # Test with duplicate filtering enabled
             with patch.object(
                 article_filter,
                 "remove_duplicate_articles",
                 wraps=article_filter.remove_duplicate_articles,
             ) as wrapped_remove:
-                result = collect.collect_articles(
+                collect.collect_articles(
                     keywords="AI반도체",
                     filter_duplicates=True,
                     group_by_keywords=False,
@@ -226,7 +223,7 @@ class TestArticleFilterIntegration(unittest.TestCase):
             with patch.object(
                 article_filter, "remove_duplicate_articles"
             ) as mock_remove_disabled:
-                result_disabled = collect.collect_articles(
+                collect.collect_articles(
                     keywords="AI반도체",
                     filter_duplicates=False,
                     group_by_keywords=False,
@@ -357,10 +354,9 @@ class TestArticleFilterIntegration(unittest.TestCase):
             patch.object(
                 NewsSourceManager, "fetch_all_sources", return_value=mixed_sources
             ) as mock_fetch_all,
-            patch("newsletter_core.application.generation.collect.console") as mock_collect_console,
-            patch("newsletter.article_filter.console") as mock_filter_console,
+            patch("newsletter_core.application.generation.collect.console"),
+            patch("newsletter.article_filter.console"),
         ):
-
             # Test with major sources filtering enabled
             with (
                 patch.object(
@@ -374,7 +370,7 @@ class TestArticleFilterIntegration(unittest.TestCase):
                     return_value=mixed_sources,
                 ) as mock_domains_filter,
             ):
-                result_enabled = collect.collect_articles(
+                collect.collect_articles(
                     keywords="테스트",
                     filter_duplicates=False,
                     group_by_keywords=False,
@@ -427,8 +423,6 @@ class TestArticleFilterIntegration(unittest.TestCase):
         }
 
         # We'll skip running the actual function and just verify the mock was called correctly
-        from newsletter.cli import run
-
         # Mock the run function to avoid side effects
         with (
             patch("newsletter.cli.console"),
@@ -437,10 +431,6 @@ class TestArticleFilterIntegration(unittest.TestCase):
             patch("newsletter.cli.datetime"),
             patch("newsletter.cli.os"),
         ):
-
-            # Only construct the argument object but don't run
-            from newsletter import cli
-
             # Mock the CLI call with filtering options
             keywords = "AI반도체"
             filter_duplicates = True

--- a/tests/api_tests/test_collect.py
+++ b/tests/api_tests/test_collect.py
@@ -5,20 +5,21 @@ import sys
 # 현재 파일의 디렉토리(tests/api_tests)의 조부모 디렉토리(프로젝트 루트)를 경로에 추가
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-import unittest
-from unittest.mock import MagicMock, patch
+import unittest  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
 
-import requests  # requests 모듈 임포트 추가
+import requests  # noqa: E402  # requests 모듈 임포트 추가
 
-from newsletter_core.application.generation.collect import (  # collect_articles_from_serper 추가
+from newsletter_core.application.generation.collect import (  # noqa: E402
     collect_articles,
     collect_articles_from_serper,
 )
 
 
 class TestCollect(unittest.TestCase):
-
-    @patch("newsletter_core.application.generation.collect.article_filter.remove_duplicate_articles")
+    @patch(
+        "newsletter_core.application.generation.collect.article_filter.remove_duplicate_articles"
+    )
     @patch("newsletter_core.application.generation.collect.configure_default_sources")
     def test_collect_articles_with_multiple_sources(
         self, mock_configure_sources, mock_remove_duplicates
@@ -77,9 +78,7 @@ class TestCollect(unittest.TestCase):
         self.assertEqual(result, [])
 
     @patch("newsletter_core.application.generation.collect.requests.request")
-    @patch(
-        "newsletter.config.SERPER_API_KEY", "fake_api_key"
-    )  # SERPER_API_KEY 모의 처리
+    @patch("newsletter.config.SERPER_API_KEY", "fake_api_key")  # SERPER_API_KEY 모의 처리
     def test_collect_articles_from_serper_success(self, mock_request):
         """레거시 Serper 전용 수집 함수 테스트"""
         mock_response = mock_request.return_value
@@ -99,9 +98,7 @@ class TestCollect(unittest.TestCase):
             ]
         }
 
-        keywords_string = (
-            "test keyword1 OR test keyword2"  # collect_articles는 문자열을 받음
-        )
+        keywords_string = "test keyword1 OR test keyword2"  # collect_articles는 문자열을 받음
         result = collect_articles_from_serper(keywords_string)
 
         mock_request.assert_called_once()
@@ -115,9 +112,7 @@ class TestCollect(unittest.TestCase):
         for item in result:
             self.assertIsInstance(item, dict)
             self.assertIn("title", item)
-            self.assertIn(
-                "url", item
-            )  # 'link'에서 'url'로 변경 (collect_articles 반환 형식)
+            self.assertIn("url", item)  # 'link'에서 'url'로 변경 (collect_articles 반환 형식)
             self.assertIn("content", item)  # 'snippet'에서 'content'로 변경
 
         self.assertEqual(result[0]["title"], "Test Article 1")

--- a/tests/api_tests/test_collect.py
+++ b/tests/api_tests/test_collect.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import requests  # requests 모듈 임포트 추가
 
-from newsletter.collect import (  # collect_articles_from_serper 추가
+from newsletter_core.application.generation.collect import (  # collect_articles_from_serper 추가
     collect_articles,
     collect_articles_from_serper,
 )
@@ -18,8 +18,8 @@ from newsletter.collect import (  # collect_articles_from_serper 추가
 
 class TestCollect(unittest.TestCase):
 
-    @patch("newsletter.collect.article_filter.remove_duplicate_articles")
-    @patch("newsletter.collect.configure_default_sources")
+    @patch("newsletter_core.application.generation.collect.article_filter.remove_duplicate_articles")
+    @patch("newsletter_core.application.generation.collect.configure_default_sources")
     def test_collect_articles_with_multiple_sources(
         self, mock_configure_sources, mock_remove_duplicates
     ):
@@ -55,7 +55,7 @@ class TestCollect(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["title"], "Test Article 1")
 
-    @patch("newsletter.collect.configure_default_sources")
+    @patch("newsletter_core.application.generation.collect.configure_default_sources")
     def test_collect_articles_with_no_sources(self, mock_configure_sources):
         """소스가 없는 경우 테스트"""
         # 소스가 없는 모의 NewsSourceManager 생성
@@ -76,7 +76,7 @@ class TestCollect(unittest.TestCase):
         # 결과는 빈 목록
         self.assertEqual(result, [])
 
-    @patch("newsletter.collect.requests.request")
+    @patch("newsletter_core.application.generation.collect.requests.request")
     @patch(
         "newsletter.config.SERPER_API_KEY", "fake_api_key"
     )  # SERPER_API_KEY 모의 처리
@@ -124,7 +124,7 @@ class TestCollect(unittest.TestCase):
         self.assertEqual(result[0]["url"], "http://example.com/article1")
         self.assertEqual(result[0]["content"], "This is a test snippet for article 1.")
 
-    @patch("newsletter.collect.requests.request")
+    @patch("newsletter_core.application.generation.collect.requests.request")
     @patch("newsletter.config.SERPER_API_KEY", "fake_api_key")
     def test_collect_articles_from_serper_empty_keywords_string(self, mock_request):
         # Serper API가 빈 문자열에 대해 어떻게 반응하는지에 따라 mock_response 설정 필요
@@ -136,7 +136,7 @@ class TestCollect(unittest.TestCase):
         mock_request.assert_called_once()
         self.assertEqual(result, [])
 
-    @patch("newsletter.collect.requests.request")
+    @patch("newsletter_core.application.generation.collect.requests.request")
     @patch("newsletter.config.SERPER_API_KEY", "fake_api_key")
     def test_collect_articles_from_serper_search_error(self, mock_request):
         mock_request.side_effect = requests.exceptions.RequestException(
@@ -149,7 +149,7 @@ class TestCollect(unittest.TestCase):
         self.assertEqual(result, [])
         mock_request.assert_called_once()  # 예외가 발생해도 호출은 시도됨
 
-    @patch("newsletter.collect.requests.request")
+    @patch("newsletter_core.application.generation.collect.requests.request")
     @patch("newsletter.config.SERPER_API_KEY", None)  # API 키가 없는 경우
     def test_collect_articles_from_serper_no_api_key(self, mock_request):
         keywords_string = "test keyword"

--- a/tests/api_tests/test_news_integration_enhanced.py
+++ b/tests/api_tests/test_news_integration_enhanced.py
@@ -14,11 +14,11 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from newsletter import config
-from newsletter.collect import collect_articles
 from newsletter.sources import NewsSourceManager
 
 # 필요한 모듈 임포트
 from newsletter.tools import search_news_articles
+from newsletter_core.application.generation.collect import collect_articles
 
 
 class TestNewsIntegrationEnhanced(unittest.TestCase):

--- a/tests/api_tests/test_news_integration_enhanced.py
+++ b/tests/api_tests/test_news_integration_enhanced.py
@@ -3,22 +3,21 @@
 - tools.py와 collect.py 모두 업데이트된 내용이 올바르게 적용되었는지 확인합니다.
 """
 
-import json
 import os
 import sys
 import unittest
-from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 # 프로젝트 루트 디렉토리를 sys.path에 추가
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from newsletter import config
-from newsletter.sources import NewsSourceManager
+from newsletter import config  # noqa: E402
 
 # 필요한 모듈 임포트
-from newsletter.tools import search_news_articles
-from newsletter_core.application.generation.collect import collect_articles
+from newsletter.tools import search_news_articles  # noqa: E402
+from newsletter_core.application.generation.collect import (  # noqa: E402
+    collect_articles,
+)
 
 
 class TestNewsIntegrationEnhanced(unittest.TestCase):
@@ -85,19 +84,13 @@ class TestNewsIntegrationEnhanced(unittest.TestCase):
 
         # 검증: tools.py 결과
         self.assertIsNotNone(articles_from_tools, "tools.py에서 검색 결과가 None입니다")
-        self.assertIsInstance(
-            articles_from_tools, list, "tools.py에서 검색 결과가 리스트가 아닙니다"
-        )
-        self.assertGreaterEqual(
-            len(articles_from_tools), 1, "tools.py에서 검색 결과가 없습니다"
-        )
+        self.assertIsInstance(articles_from_tools, list, "tools.py에서 검색 결과가 리스트가 아닙니다")
+        self.assertGreaterEqual(len(articles_from_tools), 1, "tools.py에서 검색 결과가 없습니다")
 
         # 첫 번째 기사 형식 검증
         if articles_from_tools:
             first_article = articles_from_tools[0]
-            self.assertIsInstance(
-                first_article, dict, "tools.py의 기사 항목이 딕셔너리가 아닙니다"
-            )
+            self.assertIsInstance(first_article, dict, "tools.py의 기사 항목이 딕셔너리가 아닙니다")
 
             # 필수 필드 검증
             required_fields = ["title", "link", "source"]
@@ -113,9 +106,7 @@ class TestNewsIntegrationEnhanced(unittest.TestCase):
             articles_from_collect = collect_articles(test_keywords)
 
             # 검증: collect.py 결과
-            self.assertIsNotNone(
-                articles_from_collect, "collect.py에서 검색 결과가 None입니다"
-            )
+            self.assertIsNotNone(articles_from_collect, "collect.py에서 검색 결과가 None입니다")
 
             # 키워드에 따라 결과가 변할 수 있으므로 정확한 수 검증보다는 형식 검증 수행
             if articles_from_collect:
@@ -225,9 +216,7 @@ class TestNewsIntegrationEnhanced(unittest.TestCase):
                 )
 
         except Exception as e:
-            self.skipTest(
-                f"collect_articles 함수 호출 실패로 호환성 테스트를 건너뜁니다: {e}"
-            )
+            self.skipTest(f"collect_articles 함수 호출 실패로 호환성 테스트를 건너뜁니다: {e}")
 
 
 if __name__ == "__main__":

--- a/tests/api_tests/test_summarize.py
+++ b/tests/api_tests/test_summarize.py
@@ -10,17 +10,27 @@ from unittest.mock import MagicMock, Mock, patch
 
 from newsletter import config
 
+_SUMMARIZE_MODULE_PATH = "newsletter_core.application.generation.summarize"
+
+
+def _reload_summarize():
+    """Import and reload the canonical summarize module and return it."""
+    import newsletter.llm_factory  # Ensure llm_factory is loaded to be patched
+    import newsletter_core.application.generation.summarize as _newsletter_summarize
+
+    importlib.reload(newsletter.llm_factory)
+    importlib.reload(_newsletter_summarize)
+    return _newsletter_summarize
+
 
 class TestSummarize(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
-        # google.generativeai는 더 이상 사용하지 않음
-        pass
 
     def tearDown(self):
         # Clean up modules that are reloaded during tests
         for mod_key in [
-            "newsletter.summarize",
+            _SUMMARIZE_MODULE_PATH,
             "newsletter.llm_factory",
             "langchain_core",
             "langchain_google_genai",
@@ -33,28 +43,21 @@ class TestSummarize(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.content = "<html><body>Mocked HTML Summary</body></html>"
         mock_llm_instance.invoke.return_value = mock_response
-        # mock_get_llm.return_value will be set by patch.object later
 
         for mod_key_to_delete in [
-            "newsletter.summarize",
+            _SUMMARIZE_MODULE_PATH,
             "newsletter.llm_factory",
             "langchain_google_genai",
         ]:
             if mod_key_to_delete in sys.modules:
                 del sys.modules[mod_key_to_delete]
 
-        # Import and reload to ensure we get fresh modules
         import newsletter.llm_factory  # Ensure llm_factory is loaded to be patched
-        import newsletter.summarize
 
-        importlib.reload(newsletter.llm_factory)  # Reload llm_factory first
-        importlib.reload(
-            newsletter.summarize
-        )  # Then reload summarize, which imports the reloaded llm_factory
-        summarize_articles_func = newsletter.summarize.summarize_articles
+        newsletter_summarize = _reload_summarize()
+        summarize_articles_func = newsletter_summarize.summarize_articles
 
         with unittest.mock.patch.object(config, "GEMINI_API_KEY", "fake_api_key"):
-            # Patch get_llm_for_task on the reloaded llm_factory module object
             with patch.object(
                 newsletter.llm_factory,
                 "get_llm_for_task",
@@ -84,7 +87,7 @@ class TestSummarize(unittest.TestCase):
 
     def test_summarize_with_missing_module(self):
         """LLM 팩토리에서 모든 제공자가 사용 불가능할 때 테스트 - F-14 중앙화된 설정"""
-        import newsletter.summarize
+        import newsletter_core.application.generation.summarize as newsletter_summarize
 
         keywords = ["AI"]
         articles = [
@@ -93,7 +96,7 @@ class TestSummarize(unittest.TestCase):
 
         # F-14: 중앙화된 설정에 의해 자동으로 fallback LLM이 사용되므로
         # 이 테스트는 이제 성공적으로 요약을 생성합니다
-        html_output = newsletter.summarize.summarize_articles(keywords, articles)
+        html_output = newsletter_summarize.summarize_articles(keywords, articles)
 
         # F-14 시스템은 fallback 메커니즘으로 성공적인 결과를 생성
         self.assertIn("html", html_output)
@@ -101,7 +104,7 @@ class TestSummarize(unittest.TestCase):
 
     def test_summarize_articles_no_api_key(self):
         """API 키가 없을 때 테스트 - F-14 중앙화된 설정"""
-        import newsletter.summarize
+        import newsletter_core.application.generation.summarize as newsletter_summarize
 
         # F-14 중앙화된 설정에서는 fallback 메커니즘이 작동
         keywords = ["테스트"]
@@ -109,7 +112,7 @@ class TestSummarize(unittest.TestCase):
             {"title": "Test", "url": "http://test.com", "content": "Test content"}
         ]
 
-        html_output = newsletter.summarize.summarize_articles(keywords, articles)
+        html_output = newsletter_summarize.summarize_articles(keywords, articles)
 
         # F-14 시스템의 intelligent fallback으로 성공적인 결과 생성
         self.assertIn("html", html_output)
@@ -124,7 +127,7 @@ class TestSummarize(unittest.TestCase):
 
         # Clean up modules first
         for mod_key_to_delete in [
-            "newsletter.summarize",
+            _SUMMARIZE_MODULE_PATH,
             "newsletter.llm_factory",
             "langchain_google_genai",
             "google.generativeai",
@@ -134,7 +137,6 @@ class TestSummarize(unittest.TestCase):
 
         # Ensure google.generativeai is a benign mock
         mock_genai_module = MagicMock()
-        # If llm_factory fails and summarize.py tries to use genai directly, make it also fail
         mock_genai_model = MagicMock()
         mock_genai_model.generate_content.side_effect = Exception(
             "Gemini API Error via genai fallback"
@@ -142,16 +144,12 @@ class TestSummarize(unittest.TestCase):
         mock_genai_module.GenerativeModel.return_value = mock_genai_model
         sys.modules["google.generativeai"] = mock_genai_module
 
-        # Import and reload to ensure we get fresh modules
         import newsletter.llm_factory
-        import newsletter.summarize
 
-        importlib.reload(newsletter.llm_factory)
-        importlib.reload(newsletter.summarize)
-        summarize_articles = newsletter.summarize.summarize_articles
+        newsletter_summarize = _reload_summarize()
+        summarize_articles = newsletter_summarize.summarize_articles
 
         with unittest.mock.patch.object(config, "GEMINI_API_KEY", "fake_api_key"):
-            # Patch get_llm_for_task on the reloaded llm_factory module object
             with patch.object(
                 newsletter.llm_factory,
                 "get_llm_for_task",
@@ -176,7 +174,6 @@ class TestSummarize(unittest.TestCase):
                     "news_summarization", unittest.mock.ANY, enable_fallback=False
                 )
                 mock_llm_instance.invoke.assert_called_once()
-                # Ensure the direct genai mock was not used if llm_factory path was taken
                 mock_genai_module.GenerativeModel.assert_not_called()
 
     def test_summarize_articles_empty_articles(self):
@@ -194,10 +191,8 @@ class TestSummarize(unittest.TestCase):
             if mod_key in sys.modules:
                 del sys.modules[mod_key]
 
-        import newsletter.summarize
-
-        importlib.reload(newsletter.summarize)
-        summarize_articles = newsletter.summarize.summarize_articles
+        newsletter_summarize = _reload_summarize()
+        summarize_articles = newsletter_summarize.summarize_articles
 
         keywords = ["빈 기사"]
         articles = []
@@ -210,10 +205,9 @@ class TestSummarize(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.content = "<html><body>Empty Keywords Summary</body></html>"
         mock_llm_instance.invoke.return_value = mock_response
-        # mock_get_llm.return_value will be set by patch.object later
 
         for mod_key_to_delete in [
-            "newsletter.summarize",
+            _SUMMARIZE_MODULE_PATH,
             "newsletter.llm_factory",
             "langchain_google_genai",
             "google.generativeai",
@@ -224,18 +218,12 @@ class TestSummarize(unittest.TestCase):
         mock_genai_module_for_summarize_import = MagicMock()
         sys.modules["google.generativeai"] = mock_genai_module_for_summarize_import
 
-        # Import and reload to ensure we get fresh modules
-        import newsletter.llm_factory  # Ensure llm_factory is loaded to be patched
-        import newsletter.summarize
+        import newsletter.llm_factory
 
-        importlib.reload(newsletter.llm_factory)  # Reload llm_factory first
-        importlib.reload(
-            newsletter.summarize
-        )  # Then reload summarize, which imports the reloaded llm_factory
-        summarize_articles_func = newsletter.summarize.summarize_articles
+        newsletter_summarize = _reload_summarize()
+        summarize_articles_func = newsletter_summarize.summarize_articles
 
         with unittest.mock.patch.object(config, "GEMINI_API_KEY", "fake_api_key"):
-            # Patch get_llm_for_task on the reloaded llm_factory module object
             with patch.object(
                 newsletter.llm_factory,
                 "get_llm_for_task",

--- a/tests/api_tests/test_summarize.py
+++ b/tests/api_tests/test_summarize.py
@@ -5,10 +5,10 @@ import sys
 # 프로젝트 루트 디렉토리를 sys.path에 추가
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-import unittest
-from unittest.mock import MagicMock, Mock, patch
+import unittest  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
 
-from newsletter import config
+from newsletter import config  # noqa: E402
 
 _SUMMARIZE_MODULE_PATH = "newsletter_core.application.generation.summarize"
 

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -54,7 +54,10 @@ def test_cli_run_uses_public_generation_facade(
         "newsletter_core.public.generation.generate_newsletter",
         fake_generate_newsletter,
     )
-    monkeypatch.setattr("newsletter.deliver.save_locally", fake_save_locally)
+    monkeypatch.setattr(
+        "newsletter_core.application.generation.deliver.save_locally",
+        fake_save_locally,
+    )
 
     result = runner.invoke(
         app,

--- a/tests/test_compact_newsletter.py
+++ b/tests/test_compact_newsletter.py
@@ -15,11 +15,11 @@ project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, project_root)
 
 from newsletter.chains import get_newsletter_chain  # noqa: E402
-from newsletter.compose import (  # noqa: E402
+from newsletter.template_paths import get_newsletter_template_dir  # noqa: E402
+from newsletter_core.application.generation.compose import (  # noqa: E402
     compose_compact_newsletter_html,
     extract_key_definitions_for_compact,
 )
-from newsletter.template_paths import get_newsletter_template_dir  # noqa: E402
 
 TEMPLATE_DIR = get_newsletter_template_dir()
 

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -3,8 +3,8 @@ import sys
 import unittest
 from unittest.mock import patch
 
-from newsletter.compose import compose_newsletter_html
 from newsletter.template_paths import get_newsletter_template_dir
+from newsletter_core.application.generation.compose import compose_newsletter_html
 
 # 프로젝트 루트 디렉토리를 sys.path에 추가
 # 현재 파일의 디렉토리(tests)의 부모 디렉토리(프로젝트 루트)를 경로에 추가

--- a/tests/test_email_compatibility.py
+++ b/tests/test_email_compatibility.py
@@ -17,8 +17,8 @@ import pytest
 from bs4 import BeautifulSoup
 
 from newsletter.chains import get_newsletter_chain
-from newsletter.compose import compose_newsletter
 from newsletter.template_paths import get_newsletter_template_dir
+from newsletter_core.application.generation.compose import compose_newsletter
 
 TEMPLATE_DIR = get_newsletter_template_dir()
 

--- a/tests/test_email_delivery.py
+++ b/tests/test_email_delivery.py
@@ -23,8 +23,8 @@ import pytest
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, project_root)
 
-from newsletter import config
-from newsletter_core.application.generation import deliver as news_deliver
+from newsletter import config  # noqa: E402
+from newsletter_core.application.generation import deliver as news_deliver  # noqa: E402
 
 
 class TestEmailDelivery(unittest.TestCase):
@@ -66,7 +66,6 @@ class TestEmailDelivery(unittest.TestCase):
             patch.object(config, "POSTMARK_SERVER_TOKEN", "test-token"),
             patch.object(config, "EMAIL_SENDER", "test@example.com"),
         ):
-
             result = news_deliver.send_email(
                 to_email=self.test_email,
                 subject=self.test_subject,
@@ -109,7 +108,6 @@ class TestEmailDelivery(unittest.TestCase):
             patch.object(config, "POSTMARK_SERVER_TOKEN", "test-token"),
             patch.object(config, "EMAIL_SENDER", "test@example.com"),
         ):
-
             result = news_deliver.send_email(
                 to_email="invalid-email",
                 subject=self.test_subject,
@@ -143,7 +141,6 @@ class TestEmailDelivery(unittest.TestCase):
             patch.object(config, "POSTMARK_SERVER_TOKEN", "test-token"),
             patch.object(config, "EMAIL_SENDER", "test@example.com"),
         ):
-
             result = news_deliver.send_email(
                 to_email=self.test_email,
                 subject=self.test_subject,
@@ -233,13 +230,12 @@ class TestEmailDelivery(unittest.TestCase):
             # CLI 명령어 시뮬레이션
             from unittest.mock import patch
 
-            from newsletter.cli import test_email
-
-            with patch("newsletter_core.application.generation.deliver.send_email") as mock_send:
+            with patch(
+                "newsletter_core.application.generation.deliver.send_email"
+            ) as mock_send:
                 mock_send.return_value = True
 
                 # test_email 함수 직접 호출 (CLI 대신)
-                import typer
                 from typer.testing import CliRunner
 
                 from newsletter.cli import app
@@ -461,7 +457,7 @@ def create_test_html_file():
     </head>
     <body>
         <h1>📰 주간 기술 뉴스 클리핑</h1>
-        
+
         <div class="article">
             <div class="title">AI 기술의 최신 동향</div>
             <div class="summary">
@@ -469,7 +465,7 @@ def create_test_html_file():
                 특히 자연어 처리와 컴퓨터 비전 분야에서 괄목할 만한 성과를 보이고 있습니다.
             </div>
         </div>
-        
+
         <div class="article">
             <div class="title">클라우드 컴퓨팅의 미래</div>
             <div class="summary">
@@ -477,7 +473,7 @@ def create_test_html_file():
                 엣지 컴퓨팅과 서버리스 아키텍처가 주목받고 있습니다.
             </div>
         </div>
-        
+
         <div class="article">
             <div class="title">사이버 보안 트렌드</div>
             <div class="summary">
@@ -485,7 +481,7 @@ def create_test_html_file():
                 차세대 보안 솔루션으로 각광받고 있습니다.
             </div>
         </div>
-        
+
         <footer style="margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee; color: #666;">
             <p>이 뉴스레터는 Newsletter Generator에 의해 자동 생성되었습니다.</p>
         </footer>

--- a/tests/test_email_delivery.py
+++ b/tests/test_email_delivery.py
@@ -24,7 +24,7 @@ project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, project_root)
 
 from newsletter import config
-from newsletter import deliver as news_deliver
+from newsletter_core.application.generation import deliver as news_deliver
 
 
 class TestEmailDelivery(unittest.TestCase):
@@ -46,7 +46,7 @@ class TestEmailDelivery(unittest.TestCase):
         """
 
     @pytest.mark.mock_api
-    @patch("newsletter.deliver.requests.post")
+    @patch("newsletter_core.application.generation.deliver.requests.post")
     def test_send_email_success(self, mock_post):
         """이메일 발송 성공 테스트 (모킹) - GitHub Actions 안전"""
         # Mock successful response
@@ -96,7 +96,7 @@ class TestEmailDelivery(unittest.TestCase):
         self.assertIn("테스트 이메일입니다", payload["HtmlBody"])
 
     @pytest.mark.mock_api
-    @patch("newsletter.deliver.requests.post")
+    @patch("newsletter_core.application.generation.deliver.requests.post")
     def test_send_email_failure(self, mock_post):
         """이메일 발송 실패 테스트 (모킹) - GitHub Actions 안전"""
         # Mock failed response
@@ -133,7 +133,7 @@ class TestEmailDelivery(unittest.TestCase):
         self.assertTrue(result)
 
     @pytest.mark.mock_api
-    @patch("newsletter.deliver.requests.post")
+    @patch("newsletter_core.application.generation.deliver.requests.post")
     def test_send_email_network_error(self, mock_post):
         """네트워크 오류 테스트 - GitHub Actions 안전"""
         # Mock network error
@@ -235,7 +235,7 @@ class TestEmailDelivery(unittest.TestCase):
 
             from newsletter.cli import test_email
 
-            with patch("newsletter.deliver.send_email") as mock_send:
+            with patch("newsletter_core.application.generation.deliver.send_email") as mock_send:
                 mock_send.return_value = True
 
                 # test_email 함수 직접 호출 (CLI 대신)

--- a/tests/test_news_integration.py
+++ b/tests/test_news_integration.py
@@ -11,11 +11,13 @@ from unittest.mock import MagicMock, patch
 # 프로젝트 루트 디렉토리를 sys.path에 추가
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from newsletter.sources import NewsSourceManager, SerperAPISource
+from newsletter.sources import NewsSourceManager, SerperAPISource  # noqa: E402
 
 # 테스트할 모듈 임포트
-from newsletter.tools import search_news_articles
-from newsletter_core.application.generation.collect import collect_articles
+from newsletter.tools import search_news_articles  # noqa: E402
+from newsletter_core.application.generation.collect import (  # noqa: E402
+    collect_articles,
+)
 
 
 class TestNewsIntegration(unittest.TestCase):
@@ -34,9 +36,7 @@ class TestNewsIntegration(unittest.TestCase):
 
         # 기본 검증
         self.assertIsNotNone(articles_from_tools, "tools.py의 검색 결과가 None입니다")
-        self.assertIsInstance(
-            articles_from_tools, list, "tools.py의 검색 결과가 리스트가 아닙니다"
-        )
+        self.assertIsInstance(articles_from_tools, list, "tools.py의 검색 결과가 리스트가 아닙니다")
 
         # collect_articles 함수에 전달할 데이터 준비
         # collect.py의 collect_articles 함수는 키워드 목록과 결과 수를 받습니다
@@ -49,9 +49,7 @@ class TestNewsIntegration(unittest.TestCase):
         )
 
         # 기본 검증
-        self.assertIsNotNone(
-            articles_from_collect, "collect.py의 검색 결과가 None입니다"
-        )
+        self.assertIsNotNone(articles_from_collect, "collect.py의 검색 결과가 None입니다")
         self.assertIsInstance(
             articles_from_collect, list, "collect.py의 검색 결과가 리스트가 아닙니다"
         )
@@ -99,9 +97,7 @@ class TestNewsIntegration(unittest.TestCase):
 
         # 검증
         self.assertEqual(len(articles), 1, "예상된 기사 수와 일치하지 않습니다")
-        self.assertEqual(
-            articles[0]["title"], "테스트 기사 제목", "기사 제목이 일치하지 않습니다"
-        )
+        self.assertEqual(articles[0]["title"], "테스트 기사 제목", "기사 제목이 일치하지 않습니다")
         self.assertEqual(
             articles[0]["url"],
             "https://example.com/article1",

--- a/tests/test_news_integration.py
+++ b/tests/test_news_integration.py
@@ -11,11 +11,11 @@ from unittest.mock import MagicMock, patch
 # 프로젝트 루트 디렉토리를 sys.path에 추가
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from newsletter.collect import collect_articles
 from newsletter.sources import NewsSourceManager, SerperAPISource
 
 # 테스트할 모듈 임포트
 from newsletter.tools import search_news_articles
+from newsletter_core.application.generation.collect import collect_articles
 
 
 class TestNewsIntegration(unittest.TestCase):
@@ -56,8 +56,8 @@ class TestNewsIntegration(unittest.TestCase):
             articles_from_collect, list, "collect.py의 검색 결과가 리스트가 아닙니다"
         )
 
-    @patch("newsletter.collect.requests.request")
-    @patch("newsletter.collect.configure_default_sources")
+    @patch("newsletter_core.application.generation.collect.requests.request")
+    @patch("newsletter_core.application.generation.collect.configure_default_sources")
     def test_mocked_integration(self, mock_configure_sources, mock_request):
         """모의 응답을 사용한 통합 테스트"""
         # 모의 응답 설정

--- a/tests/test_newsletter_mocked.py
+++ b/tests/test_newsletter_mocked.py
@@ -17,8 +17,11 @@ project_root = str(Path(__file__).parent.parent)
 sys.path.insert(0, project_root)
 
 from newsletter.chains import get_newsletter_chain
-from newsletter.compose import compose_compact_newsletter_html, compose_newsletter_html
 from newsletter.graph import generate_newsletter
+from newsletter_core.application.generation.compose import (
+    compose_compact_newsletter_html,
+    compose_newsletter_html,
+)
 
 
 class TestNewsletterMocked:
@@ -263,7 +266,9 @@ class TestNewsletterMocked:
         """데이터 처리 로직 테스트 (템플릿 제외)"""
 
         # extract_key_definitions_for_compact 함수 테스트
-        from newsletter.compose import extract_key_definitions_for_compact
+        from newsletter_core.application.generation.compose import (
+            extract_key_definitions_for_compact,
+        )
 
         test_sections = [
             {

--- a/tests/test_newsletter_mocked.py
+++ b/tests/test_newsletter_mocked.py
@@ -5,7 +5,6 @@ Mock 기반 뉴스레터 생성 테스트
 실제 API 호출 없이 뉴스레터 생성 로직을 검증합니다.
 """
 
-import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -16,9 +15,8 @@ import pytest
 project_root = str(Path(__file__).parent.parent)
 sys.path.insert(0, project_root)
 
-from newsletter.chains import get_newsletter_chain
-from newsletter.graph import generate_newsletter
-from newsletter_core.application.generation.compose import (
+from newsletter.chains import get_newsletter_chain  # noqa: E402
+from newsletter_core.application.generation.compose import (  # noqa: E402
     compose_compact_newsletter_html,
     compose_newsletter_html,
 )
@@ -214,13 +212,11 @@ class TestNewsletterMocked:
             test_data = {"articles": self.mock_articles, "keywords": "test"}
 
             try:
-                result = chain.invoke(test_data)
+                chain.invoke(test_data)
                 # 오류가 발생하거나 결과가 나올 수 있음
                 print("✅ Mock 에러 처리 테스트 - 체인 구조 정상")
             except Exception as e:
-                print(
-                    f"✅ Mock 에러 처리 테스트 - 예상된 오류 처리: {type(e).__name__}"
-                )
+                print(f"✅ Mock 에러 처리 테스트 - 예상된 오류 처리: {type(e).__name__}")
 
     @pytest.mark.mock_api
     def test_data_validation_with_mock(self):
@@ -230,9 +226,6 @@ class TestNewsletterMocked:
         chain = get_newsletter_chain(is_compact=True)
         assert chain is not None
 
-        # 잘못된 형식의 데이터
-        invalid_data = {"articles": [], "keywords": ""}  # 빈 기사 목록  # 빈 키워드
-
         # 체인 구조 자체는 정상이어야 함
         assert hasattr(chain, "invoke"), "체인에 invoke 메서드가 있어야 함"
 
@@ -241,13 +234,6 @@ class TestNewsletterMocked:
     @pytest.mark.mock_api
     def test_compose_functions_basic(self):
         """기본적인 compose 함수들 테스트 (Mock 없이)"""
-
-        # 테스트 데이터 - 실제 템플릿 없이도 작동하도록
-        test_data = {
-            "newsletter_topic": "AI 기술 테스트",
-            "sections": [],
-            "definitions": [],
-        }
 
         # compose 함수들이 존재하고 호출 가능한지 확인
         try:

--- a/tests/test_unified_architecture.py
+++ b/tests/test_unified_architecture.py
@@ -20,7 +20,8 @@ import pytest
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, project_root)
 
-from newsletter.compose import (  # noqa: E402
+from newsletter.template_paths import get_newsletter_template_dir  # noqa: E402
+from newsletter_core.application.generation.compose import (  # noqa: E402
     NewsletterConfig,
     compose_newsletter,
     create_grouped_sections,
@@ -28,7 +29,6 @@ from newsletter.compose import (  # noqa: E402
     extract_definitions,
     extract_food_for_thought,
 )
-from newsletter.template_paths import get_newsletter_template_dir  # noqa: E402
 
 
 def create_test_data() -> Dict[str, Any]:

--- a/tests/unit_tests/test_new_newsletter.py
+++ b/tests/unit_tests/test_new_newsletter.py
@@ -2,9 +2,9 @@ import os
 import re
 from datetime import datetime, timedelta
 
-from newsletter.compose import compose_newsletter_html
 from newsletter.date_utils import standardize_date
 from newsletter.template_paths import get_newsletter_template_dir
+from newsletter_core.application.generation.compose import compose_newsletter_html
 
 # Create test data that includes various date formats
 test_articles = [

--- a/tests/unit_tests/test_new_newsletter_with_weeks.py
+++ b/tests/unit_tests/test_new_newsletter_with_weeks.py
@@ -2,9 +2,9 @@ import os
 import re
 from datetime import datetime, timedelta
 
-from newsletter.compose import compose_newsletter_html
 from newsletter.date_utils import standardize_date
 from newsletter.template_paths import get_newsletter_template_dir
+from newsletter_core.application.generation.compose import compose_newsletter_html
 
 # Create test data that includes various date formats including "weeks ago"
 test_articles = [

--- a/tests/unit_tests/test_search_keywords.py
+++ b/tests/unit_tests/test_search_keywords.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
-from newsletter.compose import compose_newsletter_html
 from newsletter.template_paths import get_newsletter_template_dir
+from newsletter_core.application.generation.compose import compose_newsletter_html
 
 
 def test_search_keywords_in_template():

--- a/tests/unit_tests/test_web_ops_dedupe_stats.py
+++ b/tests/unit_tests/test_web_ops_dedupe_stats.py
@@ -55,9 +55,7 @@ def _insert_analytics_event(
                 None,
                 json.dumps(payload or {}),
                 created_at
-                or datetime.now(timezone.utc)
-                .isoformat()
-                .replace("+00:00", "Z"),
+                or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
             ),
         )
         conn.commit()
@@ -156,8 +154,10 @@ def test_compute_dedupe_stats_ignores_events_outside_window(
     ensure_database_schema(str(db_path))
 
     old_ts = (
-        datetime.now(timezone.utc) - timedelta(days=30)
-    ).isoformat().replace("+00:00", "Z")
+        (datetime.now(timezone.utc) - timedelta(days=30))
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
     _insert_analytics_event(
         str(db_path),
@@ -203,9 +203,7 @@ def test_compute_dedupe_stats_handles_malformed_payload(tmp_path: Path) -> None:
                 "email.deduplicated",
                 "job-broken",
                 "not-json",
-                datetime.now(timezone.utc)
-                .isoformat()
-                .replace("+00:00", "Z"),
+                datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
                 1,
             ),
         )
@@ -261,9 +259,7 @@ def test_ops_dedupe_stats_clamps_query_arguments(tmp_path: Path) -> None:
 
     app = _build_app(str(db_path))
     with app.test_client() as client:
-        response = client.get(
-            "/api/ops/dedupe-stats?window_days=9999&top=9999"
-        )
+        response = client.get("/api/ops/dedupe-stats?window_days=9999&top=9999")
 
     assert response.status_code == 200
     payload = response.get_json()

--- a/tests/unit_tests/test_web_ops_dedupe_stats.py
+++ b/tests/unit_tests/test_web_ops_dedupe_stats.py
@@ -1,0 +1,272 @@
+"""Unit tests for the outbox dedupe statistics route."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+from db_state import ensure_database_schema  # noqa: E402
+from routes_ops_dedupe_stats import (  # noqa: E402
+    compute_dedupe_stats,
+    register_dedupe_stats_routes,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def _insert_analytics_event(
+    database_path: str,
+    *,
+    event_type: str,
+    job_id: str | None = None,
+    payload: dict[str, object] | None = None,
+    created_at: str | None = None,
+    deduplicated: int = 0,
+) -> None:
+    conn = sqlite3.connect(database_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO analytics_events (
+                id, event_type, job_id, schedule_id, status,
+                deduplicated, duration_seconds, cost_usd, payload, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                uuid.uuid4().hex,
+                event_type,
+                job_id,
+                None,
+                None,
+                deduplicated,
+                None,
+                None,
+                json.dumps(payload or {}),
+                created_at
+                or datetime.now(timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z"),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _build_app(database_path: str) -> Flask:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    register_dedupe_stats_routes(app, database_path)
+    return app
+
+
+def test_compute_dedupe_stats_aggregates_events(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    _insert_analytics_event(
+        str(db_path),
+        event_type="email.sent",
+        job_id="job-alpha",
+        payload={"recipient": "ops@example.com"},
+    )
+    _insert_analytics_event(
+        str(db_path),
+        event_type="email.sent",
+        job_id="job-alpha",
+        payload={"recipient": "ops@example.com"},
+    )
+    _insert_analytics_event(
+        str(db_path),
+        event_type="email.deduplicated",
+        job_id="job-alpha",
+        payload={"recipient": "ops@example.com"},
+        deduplicated=1,
+    )
+    _insert_analytics_event(
+        str(db_path),
+        event_type="email.deduplicated",
+        job_id="job-alpha",
+        payload={"recipient": "ops@example.com"},
+        deduplicated=1,
+    )
+    _insert_analytics_event(
+        str(db_path),
+        event_type="email.deduplicated",
+        job_id="job-beta",
+        payload={"recipient": "reports@example.com"},
+        deduplicated=1,
+    )
+    _insert_analytics_event(
+        str(db_path),
+        event_type="email.failed",
+        job_id="job-gamma",
+        payload={"recipient": "failing@example.com"},
+    )
+
+    result = compute_dedupe_stats(str(db_path))
+
+    totals = result["totals"]
+    assert totals["sent"] == 2
+    assert totals["deduplicated"] == 3
+    assert totals["failed"] == 1
+    # Attempts = 2 sent + 3 deduped = 5. 3/5 = 60%.
+    assert totals["dedupe_rate_percent"] == 60.0
+
+    recipients = {row["recipient"]: row["count"] for row in result["top_recipients"]}
+    assert recipients.get("ops@example.com") == 2
+    assert recipients.get("reports@example.com") == 1
+
+    jobs = {row["job_id"]: row["count"] for row in result["top_jobs"]}
+    assert jobs.get("job-alpha") == 2
+    assert jobs.get("job-beta") == 1
+
+
+def test_compute_dedupe_stats_empty_state(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    result = compute_dedupe_stats(str(db_path))
+
+    assert result["totals"]["sent"] == 0
+    assert result["totals"]["deduplicated"] == 0
+    assert result["totals"]["failed"] == 0
+    assert result["totals"]["dedupe_rate_percent"] is None
+    assert result["top_recipients"] == []
+    assert result["top_jobs"] == []
+    assert result["recent_events"] == []
+
+
+def test_compute_dedupe_stats_ignores_events_outside_window(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    old_ts = (
+        datetime.now(timezone.utc) - timedelta(days=30)
+    ).isoformat().replace("+00:00", "Z")
+
+    _insert_analytics_event(
+        str(db_path),
+        event_type="email.deduplicated",
+        job_id="job-old",
+        payload={"recipient": "old@example.com"},
+        deduplicated=1,
+        created_at=old_ts,
+    )
+    _insert_analytics_event(
+        str(db_path),
+        event_type="email.deduplicated",
+        job_id="job-new",
+        payload={"recipient": "new@example.com"},
+        deduplicated=1,
+    )
+
+    result = compute_dedupe_stats(str(db_path), window_days=1)
+
+    assert result["window_days"] == 1
+    assert result["totals"]["deduplicated"] == 1
+    recipients = {row["recipient"] for row in result["top_recipients"]}
+    assert "new@example.com" in recipients
+    assert "old@example.com" not in recipients
+
+
+def test_compute_dedupe_stats_handles_malformed_payload(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    # Row with non-dict payload string
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO analytics_events (
+                id, event_type, job_id, payload, created_at, deduplicated
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                uuid.uuid4().hex,
+                "email.deduplicated",
+                "job-broken",
+                "not-json",
+                datetime.now(timezone.utc)
+                .isoformat()
+                .replace("+00:00", "Z"),
+                1,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    result = compute_dedupe_stats(str(db_path))
+
+    # Event is still counted in totals even if payload is unusable
+    assert result["totals"]["deduplicated"] == 1
+    # Job-level aggregation still works
+    assert any(row["job_id"] == "job-broken" for row in result["top_jobs"])
+    # No recipient extracted -> top_recipients stays empty
+    assert result["top_recipients"] == []
+
+
+def test_ops_dedupe_stats_route_returns_payload(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    _insert_analytics_event(
+        str(db_path),
+        event_type="email.sent",
+        job_id="job-a",
+        payload={"recipient": "a@example.com"},
+    )
+    _insert_analytics_event(
+        str(db_path),
+        event_type="email.deduplicated",
+        job_id="job-a",
+        payload={"recipient": "a@example.com"},
+        deduplicated=1,
+    )
+
+    app = _build_app(str(db_path))
+    with app.test_client() as client:
+        response = client.get("/api/ops/dedupe-stats?window_days=7&top=5")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+    assert payload["window_days"] == 7
+    assert payload["totals"]["sent"] == 1
+    assert payload["totals"]["deduplicated"] == 1
+    assert payload["totals"]["dedupe_rate_percent"] == 50.0
+    assert payload["top_recipients"][0]["recipient"] == "a@example.com"
+
+
+def test_ops_dedupe_stats_clamps_query_arguments(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    app = _build_app(str(db_path))
+    with app.test_client() as client:
+        response = client.get(
+            "/api/ops/dedupe-stats?window_days=9999&top=9999"
+        )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+    # Window is clamped to max 90 days
+    assert payload["window_days"] == 90

--- a/tests/unit_tests/test_web_ops_failed_jobs.py
+++ b/tests/unit_tests/test_web_ops_failed_jobs.py
@@ -228,9 +228,7 @@ def test_failed_jobs_retry_404_when_missing(tmp_path: Path) -> None:
 
     app = _build_app(str(db_path))
     with app.test_client() as client:
-        response = client.post(
-            f"/api/ops/failed-jobs/outbox/{uuid.uuid4().hex}/retry"
-        )
+        response = client.post(f"/api/ops/failed-jobs/outbox/{uuid.uuid4().hex}/retry")
 
     assert response.status_code == 404
 
@@ -249,8 +247,6 @@ def test_failed_jobs_retry_409_when_not_failed(tmp_path: Path) -> None:
 
     app = _build_app(str(db_path))
     with app.test_client() as client:
-        response = client.post(
-            "/api/ops/failed-jobs/outbox/sk-already-sent/retry"
-        )
+        response = client.post("/api/ops/failed-jobs/outbox/sk-already-sent/retry")
 
     assert response.status_code == 409

--- a/tests/unit_tests/test_web_ops_failed_jobs.py
+++ b/tests/unit_tests/test_web_ops_failed_jobs.py
@@ -1,0 +1,256 @@
+"""Unit tests for the failed-jobs operational visibility routes."""
+
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+from db_state import ensure_database_schema  # noqa: E402
+from routes_ops_failed_jobs import register_failed_jobs_routes  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def _build_app(database_path: str) -> Flask:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    register_failed_jobs_routes(app, database_path)
+    return app
+
+
+def _insert_history_row(
+    database_path: str,
+    *,
+    job_id: str,
+    status: str,
+    delivery_status: str = "draft",
+    result: dict[str, object] | None = None,
+    params: dict[str, object] | None = None,
+) -> None:
+    import sqlite3
+
+    conn = sqlite3.connect(database_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO history (id, params, result, status, delivery_status)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                job_id,
+                json.dumps(params or {}),
+                json.dumps(result or {}),
+                status,
+                delivery_status,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _insert_outbox_row(
+    database_path: str,
+    *,
+    send_key: str,
+    job_id: str,
+    recipient: str,
+    status: str,
+    last_error: str | None = None,
+    attempt_count: int = 1,
+) -> None:
+    import sqlite3
+
+    conn = sqlite3.connect(database_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO email_outbox (
+                send_key, job_id, recipient, subject_hash,
+                status, attempt_count, last_error
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                send_key,
+                job_id,
+                recipient,
+                "dummy_subject_hash",
+                status,
+                attempt_count,
+                last_error,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_failed_jobs_returns_history_and_outbox(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    _insert_history_row(
+        str(db_path),
+        job_id="job-failed",
+        status="failed",
+        result={"error": "LLM provider outage", "error_type": "RuntimeError"},
+        params={"keywords": ["AI"], "domain": "tech"},
+    )
+    _insert_history_row(
+        str(db_path),
+        job_id="job-send-failed",
+        status="completed",
+        delivery_status="send_failed",
+        result={"error": "SMTP refused"},
+    )
+    _insert_history_row(
+        str(db_path),
+        job_id="job-ok",
+        status="completed",
+    )
+    _insert_outbox_row(
+        str(db_path),
+        send_key="sk-failed",
+        job_id="job-failed",
+        recipient="ops@example.com",
+        status="failed",
+        last_error="SMTP refused",
+    )
+    _insert_outbox_row(
+        str(db_path),
+        send_key="sk-ok",
+        job_id="job-ok",
+        recipient="ops@example.com",
+        status="sent",
+    )
+
+    app = _build_app(str(db_path))
+    with app.test_client() as client:
+        response = client.get("/api/ops/failed-jobs")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+
+    history_ids = {row["job_id"] for row in payload["history"]}
+    assert "job-failed" in history_ids
+    assert "job-send-failed" in history_ids
+    assert "job-ok" not in history_ids
+
+    outbox_keys = {row["send_key"] for row in payload["outbox"]}
+    assert "sk-failed" in outbox_keys
+    assert "sk-ok" not in outbox_keys
+
+    summary = payload["summary"]
+    assert summary["failed_history_count"] == 2
+    assert summary["failed_outbox_count"] == 1
+    assert summary["sent_outbox_count"] == 1
+
+
+def test_failed_jobs_limit_is_clamped(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    for index in range(5):
+        _insert_history_row(
+            str(db_path),
+            job_id=f"job-{index}",
+            status="failed",
+            result={"error": f"error-{index}"},
+        )
+
+    app = _build_app(str(db_path))
+    with app.test_client() as client:
+        response = client.get("/api/ops/failed-jobs?limit=2")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+    assert payload["limit"] == 2
+    assert len(payload["history"]) == 2
+
+
+def test_failed_jobs_retry_resets_outbox_to_pending(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    _insert_outbox_row(
+        str(db_path),
+        send_key="sk-retry",
+        job_id="job-retry",
+        recipient="ops@example.com",
+        status="failed",
+        last_error="temporary",
+    )
+
+    app = _build_app(str(db_path))
+    with app.test_client() as client:
+        response = client.post("/api/ops/failed-jobs/outbox/sk-retry/retry")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+    assert payload["status"] == "pending"
+
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT status, last_error FROM email_outbox WHERE send_key = ?",
+            ("sk-retry",),
+        )
+        row = cursor.fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row[0] == "pending"
+    assert row[1] is None
+
+
+def test_failed_jobs_retry_404_when_missing(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    app = _build_app(str(db_path))
+    with app.test_client() as client:
+        response = client.post(
+            f"/api/ops/failed-jobs/outbox/{uuid.uuid4().hex}/retry"
+        )
+
+    assert response.status_code == 404
+
+
+def test_failed_jobs_retry_409_when_not_failed(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    _insert_outbox_row(
+        str(db_path),
+        send_key="sk-already-sent",
+        job_id="job-sent",
+        recipient="ops@example.com",
+        status="sent",
+    )
+
+    app = _build_app(str(db_path))
+    with app.test_client() as client:
+        response = client.post(
+            "/api/ops/failed-jobs/outbox/sk-already-sent/retry"
+        )
+
+    assert response.status_code == 409

--- a/tests/unit_tests/test_web_schedule_drift.py
+++ b/tests/unit_tests/test_web_schedule_drift.py
@@ -65,12 +65,18 @@ def test_resolve_drift_threshold_defaults_and_overrides() -> None:
     assert resolve_drift_threshold_seconds() == 15 * 60
     assert resolve_drift_threshold_seconds(explicit=30) == 30
     assert resolve_drift_threshold_seconds(explicit=-5) == 1
-    assert resolve_drift_threshold_seconds(
-        environ={"SCHEDULE_DRIFT_THRESHOLD_SECONDS": "120"},
-    ) == 120
-    assert resolve_drift_threshold_seconds(
-        environ={"SCHEDULE_DRIFT_THRESHOLD_SECONDS": "not-a-number"},
-    ) == 15 * 60
+    assert (
+        resolve_drift_threshold_seconds(
+            environ={"SCHEDULE_DRIFT_THRESHOLD_SECONDS": "120"},
+        )
+        == 120
+    )
+    assert (
+        resolve_drift_threshold_seconds(
+            environ={"SCHEDULE_DRIFT_THRESHOLD_SECONDS": "not-a-number"},
+        )
+        == 15 * 60
+    )
 
 
 def test_drift_report_status_levels() -> None:
@@ -260,9 +266,7 @@ def test_ops_schedule_drift_endpoint_respects_threshold_query(
     app = _build_app(str(db_path))
     with app.test_client() as client:
         # Large threshold -> should not consider the row drifted
-        response = client.get(
-            "/api/ops/schedule-drift?threshold_seconds=3600"
-        )
+        response = client.get("/api/ops/schedule-drift?threshold_seconds=3600")
 
     assert response.status_code == 200
     payload = response.get_json()

--- a/tests/unit_tests/test_web_schedule_drift.py
+++ b/tests/unit_tests/test_web_schedule_drift.py
@@ -1,0 +1,272 @@
+"""Unit tests for the schedule drift detector module and ops route."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+from db_state import ensure_database_schema  # noqa: E402
+from routes_ops_schedule_drift import register_schedule_drift_routes  # noqa: E402
+from schedule_drift import (  # noqa: E402
+    DriftedSchedule,
+    DriftReport,
+    detect_schedule_drift,
+    resolve_drift_threshold_seconds,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+
+def _insert_schedule(
+    database_path: str,
+    *,
+    schedule_id: str,
+    next_run: str,
+    enabled: int = 1,
+    rrule: str = "FREQ=DAILY;BYHOUR=8",
+    params: dict[str, object] | None = None,
+) -> None:
+    conn = sqlite3.connect(database_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO schedules (id, params, rrule, next_run, enabled)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                schedule_id,
+                json.dumps(params or {}),
+                rrule,
+                next_run,
+                enabled,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def test_resolve_drift_threshold_defaults_and_overrides() -> None:
+    assert resolve_drift_threshold_seconds() == 15 * 60
+    assert resolve_drift_threshold_seconds(explicit=30) == 30
+    assert resolve_drift_threshold_seconds(explicit=-5) == 1
+    assert resolve_drift_threshold_seconds(
+        environ={"SCHEDULE_DRIFT_THRESHOLD_SECONDS": "120"},
+    ) == 120
+    assert resolve_drift_threshold_seconds(
+        environ={"SCHEDULE_DRIFT_THRESHOLD_SECONDS": "not-a-number"},
+    ) == 15 * 60
+
+
+def test_drift_report_status_levels() -> None:
+    # Healthy when nothing drifted
+    report = DriftReport(
+        checked_at="2026-01-01T00:00:00Z",
+        threshold_seconds=60,
+        active_schedule_count=1,
+        drifted=[],
+    )
+    assert report.status == "healthy"
+
+    degraded = DriftReport(
+        checked_at="2026-01-01T00:00:00Z",
+        threshold_seconds=60,
+        active_schedule_count=1,
+        drifted=[
+            DriftedSchedule(
+                schedule_id="sched-1",
+                next_run="2026-01-01T00:00:00Z",
+                drift_seconds=120.0,
+                rrule="FREQ=DAILY",
+                enabled=True,
+            )
+        ],
+    )
+    assert degraded.status == "degraded"
+
+    errored = DriftReport(
+        checked_at="2026-01-01T00:00:00Z",
+        threshold_seconds=60,
+        active_schedule_count=1,
+        drifted=[
+            DriftedSchedule(
+                schedule_id="sched-1",
+                next_run="2026-01-01T00:00:00Z",
+                drift_seconds=60 * 4 + 1,
+                rrule="FREQ=DAILY",
+                enabled=True,
+            )
+        ],
+    )
+    assert errored.status == "error"
+
+
+def test_detect_schedule_drift_reports_drifted_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    now = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+
+    _insert_schedule(
+        str(db_path),
+        schedule_id="sched-ok",
+        next_run=_iso(now + timedelta(minutes=30)),
+    )
+    _insert_schedule(
+        str(db_path),
+        schedule_id="sched-drifted",
+        next_run=_iso(now - timedelta(hours=1)),
+    )
+    _insert_schedule(
+        str(db_path),
+        schedule_id="sched-way-drifted",
+        next_run=_iso(now - timedelta(hours=4)),
+    )
+    _insert_schedule(
+        str(db_path),
+        schedule_id="sched-disabled",
+        next_run=_iso(now - timedelta(days=1)),
+        enabled=0,
+    )
+
+    report = detect_schedule_drift(
+        str(db_path),
+        now=now,
+        threshold_seconds=15 * 60,
+    )
+    payload = report.to_dict()
+
+    assert payload["active_schedule_count"] == 3  # disabled excluded
+    assert payload["drifted_count"] == 2
+    assert payload["threshold_seconds"] == 15 * 60
+
+    drift_ids = [row["schedule_id"] for row in payload["drifted"]]
+    # Worst drift should appear first (sorted descending)
+    assert drift_ids[0] == "sched-way-drifted"
+    assert "sched-drifted" in drift_ids
+    assert "sched-ok" not in drift_ids
+    assert "sched-disabled" not in drift_ids
+
+    # With a 15-minute threshold, 4h drift is 16x the threshold -> "error"
+    assert payload["status"] == "error"
+
+
+def test_detect_schedule_drift_healthy_when_nothing_late(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    now = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    _insert_schedule(
+        str(db_path),
+        schedule_id="sched-future",
+        next_run=_iso(now + timedelta(minutes=5)),
+    )
+
+    report = detect_schedule_drift(
+        str(db_path),
+        now=now,
+        threshold_seconds=60,
+    )
+    payload = report.to_dict()
+
+    assert payload["status"] == "healthy"
+    assert payload["drifted_count"] == 0
+    assert payload["active_schedule_count"] == 1
+
+
+def test_detect_schedule_drift_ignores_unparseable_next_run(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    now = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    _insert_schedule(
+        str(db_path),
+        schedule_id="sched-garbage",
+        next_run="not-a-timestamp",
+    )
+
+    report = detect_schedule_drift(
+        str(db_path),
+        now=now,
+        threshold_seconds=60,
+    )
+    payload = report.to_dict()
+
+    assert payload["status"] == "healthy"
+    assert payload["drifted_count"] == 0
+    # Active count still reflects the row existing in the table
+    assert payload["active_schedule_count"] == 1
+
+
+def _build_app(database_path: str) -> Flask:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    register_schedule_drift_routes(app, database_path)
+    return app
+
+
+def test_ops_schedule_drift_endpoint_returns_payload(tmp_path: Path) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    past = datetime.now(timezone.utc) - timedelta(hours=2)
+    _insert_schedule(
+        str(db_path),
+        schedule_id="sched-late",
+        next_run=_iso(past),
+    )
+
+    app = _build_app(str(db_path))
+    with app.test_client() as client:
+        response = client.get("/api/ops/schedule-drift")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+    assert payload["drifted_count"] == 1
+    assert payload["active_schedule_count"] == 1
+    assert payload["status"] in {"degraded", "error"}
+    assert payload["drifted"][0]["schedule_id"] == "sched-late"
+
+
+def test_ops_schedule_drift_endpoint_respects_threshold_query(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "storage.db"
+    ensure_database_schema(str(db_path))
+
+    past = datetime.now(timezone.utc) - timedelta(minutes=5)
+    _insert_schedule(
+        str(db_path),
+        schedule_id="sched-small-lag",
+        next_run=_iso(past),
+    )
+
+    app = _build_app(str(db_path))
+    with app.test_client() as client:
+        # Large threshold -> should not consider the row drifted
+        response = client.get(
+            "/api/ops/schedule-drift?threshold_seconds=3600"
+        )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+    assert payload["threshold_seconds"] == 3600
+    assert payload["drifted_count"] == 0
+    assert payload["status"] == "healthy"

--- a/web/access_control.py
+++ b/web/access_control.py
@@ -37,6 +37,7 @@ _PROTECTED_PREFIXES: tuple[str, ...] = (
     "/api/send-email",
     "/api/email-config",
     "/api/test-email",
+    "/api/ops",
 )
 
 

--- a/web/app.py
+++ b/web/app.py
@@ -30,6 +30,9 @@ from web.routes_generation import register_generation_routes
 from web.routes_health import register_health_route
 from web.routes_newsletter_html import register_newsletter_html_route
 from web.routes_ops import register_ops_routes
+from web.routes_ops_dedupe_stats import register_dedupe_stats_routes
+from web.routes_ops_failed_jobs import register_failed_jobs_routes
+from web.routes_ops_schedule_drift import register_schedule_drift_routes
 from web.routes_presets import register_preset_routes
 from web.routes_send_email import register_send_email_route
 from web.routes_source_policies import register_source_policy_routes
@@ -163,6 +166,9 @@ def _register_routes(app: Flask) -> None:
         get_newsletter_cli=_resolve_newsletter_cli,
     )
     register_ops_routes(app, DATABASE_PATH)
+    register_failed_jobs_routes(app, DATABASE_PATH)
+    register_schedule_drift_routes(app, DATABASE_PATH)
+    register_dedupe_stats_routes(app, DATABASE_PATH)
     register_send_email_route(app, DATABASE_PATH)
     register_approval_routes(app, DATABASE_PATH)
     register_email_api_routes(app)

--- a/web/routes_health.py
+++ b/web/routes_health.py
@@ -11,6 +11,11 @@ from flask.typing import ResponseReturnValue
 
 from newsletter_core.public.settings import get_setting_value
 
+try:
+    from schedule_drift import detect_schedule_drift
+except ImportError:
+    from web.schedule_drift import detect_schedule_drift  # pragma: no cover
+
 
 def register_health_route(
     app: Flask,
@@ -148,6 +153,42 @@ def register_health_route(
                 "message": f"File system error: {str(e)}",
             }
             overall_status = "error"
+
+        try:
+            drift_report = detect_schedule_drift(database_path)
+            drift_payload = drift_report.to_dict()
+            drift_status = drift_payload["status"]
+            if drift_status == "healthy":
+                drift_message = (
+                    f"No drifted schedules "
+                    f"(active={drift_payload['active_schedule_count']})"
+                )
+            else:
+                drift_message = (
+                    f"{drift_payload['drifted_count']} drifted schedule(s) "
+                    f"beyond {drift_payload['threshold_seconds']}s"
+                )
+            deps["schedule_drift"] = {
+                "status": drift_status,
+                "message": drift_message,
+                "drifted_count": drift_payload["drifted_count"],
+                "active_schedule_count": drift_payload["active_schedule_count"],
+                "threshold_seconds": drift_payload["threshold_seconds"],
+            }
+            if drift_status == "error":
+                overall_status = "error"
+            elif (
+                drift_status == "degraded"
+                and overall_status == "healthy"
+            ):
+                overall_status = "degraded"
+        except Exception as e:
+            deps["schedule_drift"] = {
+                "status": "error",
+                "message": f"Schedule drift check failed: {str(e)}",
+            }
+            if overall_status == "healthy":
+                overall_status = "degraded"
 
         health_status["status"] = overall_status
         health_status["dependencies"] = deps

--- a/web/routes_health.py
+++ b/web/routes_health.py
@@ -177,10 +177,7 @@ def register_health_route(
             }
             if drift_status == "error":
                 overall_status = "error"
-            elif (
-                drift_status == "degraded"
-                and overall_status == "healthy"
-            ):
+            elif drift_status == "degraded" and overall_status == "healthy":
                 overall_status = "degraded"
         except Exception as e:
             deps["schedule_drift"] = {

--- a/web/routes_ops_dedupe_stats.py
+++ b/web/routes_ops_dedupe_stats.py
@@ -132,23 +132,19 @@ def compute_dedupe_stats(
                 }
             )
 
-    top_recipient_list = sorted(
-        (
-            {"recipient": recipient, "count": count}
-            for recipient, count in recipient_counter.items()
-        ),
-        key=lambda item: item["count"],
-        reverse=True,
-    )[:top_recipients]
+    top_recipient_list: list[dict[str, Any]] = [
+        {"recipient": recipient, "count": count}
+        for recipient, count in sorted(
+            recipient_counter.items(), key=lambda pair: pair[1], reverse=True
+        )[:top_recipients]
+    ]
 
-    top_job_list = sorted(
-        (
-            {"job_id": job_id, "count": count}
-            for job_id, count in job_counter.items()
-        ),
-        key=lambda item: item["count"],
-        reverse=True,
-    )[:top_recipients]
+    top_job_list: list[dict[str, Any]] = [
+        {"job_id": job_id, "count": count}
+        for job_id, count in sorted(
+            job_counter.items(), key=lambda pair: pair[1], reverse=True
+        )[:top_recipients]
+    ]
 
     return {
         "window_days": window_days,

--- a/web/routes_ops_dedupe_stats.py
+++ b/web/routes_ops_dedupe_stats.py
@@ -1,0 +1,194 @@
+"""Route registration for outbox dedupe statistics.
+
+Exposes a drill-down view of how often the outbox dedupe layer filtered out
+duplicate sends, by time window and recipient.
+
+The raw counter already exists inside ``/api/analytics`` (``summary.email.deduplicated``),
+but this endpoint gives operators a direct, filterable view for incident review.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from flask import Flask, jsonify, request
+from flask.typing import ResponseReturnValue
+
+try:
+    from ops_logging import log_exception, log_info
+except ImportError:
+    from web.ops_logging import log_exception, log_info  # pragma: no cover
+
+
+logger = logging.getLogger("web.routes_ops_dedupe_stats")
+
+
+_DEFAULT_WINDOW_DAYS = 7
+_MAX_WINDOW_DAYS = 90
+_DEFAULT_TOP_N = 10
+_MAX_TOP_N = 50
+
+
+def _clamp_int(raw: int | None, default: int, maximum: int) -> int:
+    if raw is None:
+        return default
+    return max(1, min(int(raw), maximum))
+
+
+def _window_start_iso(window_days: int) -> str:
+    since = datetime.now(timezone.utc) - timedelta(days=window_days)
+    return since.isoformat().replace("+00:00", "Z")
+
+
+def _extract_recipient(payload_json: str | None) -> str | None:
+    if not payload_json:
+        return None
+    try:
+        payload = json.loads(payload_json)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    recipient = payload.get("recipient")
+    return recipient if isinstance(recipient, str) and recipient.strip() else None
+
+
+def compute_dedupe_stats(
+    database_path: str,
+    *,
+    window_days: int = _DEFAULT_WINDOW_DAYS,
+    top_recipients: int = _DEFAULT_TOP_N,
+) -> dict[str, Any]:
+    """Return a structured breakdown of dedupe events inside the window."""
+    window_days = _clamp_int(window_days, _DEFAULT_WINDOW_DAYS, _MAX_WINDOW_DAYS)
+    top_recipients = _clamp_int(top_recipients, _DEFAULT_TOP_N, _MAX_TOP_N)
+
+    since_iso = _window_start_iso(window_days)
+
+    conn = sqlite3.connect(database_path)
+    try:
+        cursor = conn.cursor()
+
+        cursor.execute(
+            """
+            SELECT
+                SUM(CASE WHEN event_type = 'email.sent' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN event_type = 'email.deduplicated' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN event_type = 'email.failed' THEN 1 ELSE 0 END)
+            FROM analytics_events
+            WHERE created_at >= ?
+            """,
+            (since_iso,),
+        )
+        totals_row = cursor.fetchone() or (0, 0, 0)
+
+        cursor.execute(
+            """
+            SELECT id, job_id, payload, created_at
+            FROM analytics_events
+            WHERE event_type = 'email.deduplicated' AND created_at >= ?
+            ORDER BY created_at DESC
+            """,
+            (since_iso,),
+        )
+        dedupe_rows = cursor.fetchall()
+    finally:
+        conn.close()
+
+    sent_count = int(totals_row[0] or 0)
+    deduped_count = int(totals_row[1] or 0)
+    failed_count = int(totals_row[2] or 0)
+    attempt_base = sent_count + deduped_count
+    dedupe_rate = (
+        round((deduped_count / attempt_base) * 100, 1) if attempt_base else None
+    )
+
+    recipient_counter: dict[str, int] = {}
+    job_counter: dict[str, int] = {}
+    recent_events: list[dict[str, Any]] = []
+
+    for row in dedupe_rows:
+        event_id = row[0]
+        job_id = str(row[1]) if row[1] is not None else None
+        recipient = _extract_recipient(row[2])
+        created_at = row[3]
+
+        if recipient is not None:
+            recipient_counter[recipient] = recipient_counter.get(recipient, 0) + 1
+        if job_id is not None:
+            job_counter[job_id] = job_counter.get(job_id, 0) + 1
+
+        if len(recent_events) < top_recipients:
+            recent_events.append(
+                {
+                    "id": event_id,
+                    "job_id": job_id,
+                    "recipient": recipient,
+                    "created_at": created_at,
+                }
+            )
+
+    top_recipient_list = sorted(
+        (
+            {"recipient": recipient, "count": count}
+            for recipient, count in recipient_counter.items()
+        ),
+        key=lambda item: item["count"],
+        reverse=True,
+    )[:top_recipients]
+
+    top_job_list = sorted(
+        (
+            {"job_id": job_id, "count": count}
+            for job_id, count in job_counter.items()
+        ),
+        key=lambda item: item["count"],
+        reverse=True,
+    )[:top_recipients]
+
+    return {
+        "window_days": window_days,
+        "since": since_iso,
+        "totals": {
+            "sent": sent_count,
+            "deduplicated": deduped_count,
+            "failed": failed_count,
+            "dedupe_rate_percent": dedupe_rate,
+        },
+        "top_recipients": top_recipient_list,
+        "top_jobs": top_job_list,
+        "recent_events": recent_events,
+    }
+
+
+def register_dedupe_stats_routes(app: Flask, database_path: str) -> None:
+    """Register the outbox dedupe statistics route on the given Flask app."""
+
+    @app.route("/api/ops/dedupe-stats", methods=["GET"])  # type: ignore[untyped-decorator]
+    def ops_dedupe_stats() -> ResponseReturnValue:
+        """Return aggregated outbox dedupe statistics for the given window."""
+        try:
+            window_days = request.args.get("window_days", type=int)
+            top = request.args.get("top", type=int)
+            payload = compute_dedupe_stats(
+                database_path,
+                window_days=window_days or _DEFAULT_WINDOW_DAYS,
+                top_recipients=top or _DEFAULT_TOP_N,
+            )
+            log_info(
+                logger,
+                "ops.dedupe_stats.listed",
+                window_days=payload["window_days"],
+                deduplicated=payload["totals"]["deduplicated"],
+            )
+            return jsonify(payload)
+        except Exception as exc:
+            log_exception(logger, "ops.dedupe_stats.list_failed", exc)
+            return (
+                jsonify({"error": f"Dedupe stats lookup failed: {exc}"}),
+                500,
+            )

--- a/web/routes_ops_failed_jobs.py
+++ b/web/routes_ops_failed_jobs.py
@@ -1,0 +1,294 @@
+"""Operational routes for inspecting failed background jobs and outbox state.
+
+This module adds production-safe visibility endpoints on top of the existing
+history / email_outbox tables so operators can see what has failed and why
+without opening the database directly. The endpoints are protected via the
+standard ``/api/ops`` prefix (see ``web.access_control``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from typing import Any, cast
+
+from flask import Flask, jsonify, request
+from flask.typing import ResponseReturnValue
+
+try:
+    from db_state import (
+        DELIVERY_STATUS_SEND_FAILED,
+    )
+except ImportError:
+    from web.db_state import (  # pragma: no cover
+        DELIVERY_STATUS_SEND_FAILED,
+    )
+
+try:
+    from ops_logging import log_exception, log_info
+except ImportError:
+    from web.ops_logging import log_exception, log_info  # pragma: no cover
+
+
+logger = logging.getLogger("web.routes_ops_failed_jobs")
+
+
+_DEFAULT_LIMIT = 50
+_MAX_LIMIT = 200
+
+
+def _connect(database_path: str) -> sqlite3.Connection:
+    return sqlite3.connect(database_path)
+
+
+def _clamp_limit(raw: int | None) -> int:
+    if raw is None:
+        return _DEFAULT_LIMIT
+    return max(1, min(int(raw), _MAX_LIMIT))
+
+
+def _parse_json(payload: str | None) -> dict[str, Any] | None:
+    if not payload:
+        return None
+    try:
+        parsed = json.loads(payload)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if isinstance(parsed, dict):
+        return cast(dict[str, Any], parsed)
+    return None
+
+
+def _error_summary(result_payload: dict[str, Any] | None) -> str | None:
+    if not result_payload:
+        return None
+    error = result_payload.get("error")
+    if isinstance(error, str) and error.strip():
+        return error.strip()[:500]
+    error_type = result_payload.get("error_type")
+    if isinstance(error_type, str) and error_type.strip():
+        return error_type.strip()
+    return None
+
+
+def _fetch_failed_history(
+    database_path: str, limit: int
+) -> list[dict[str, Any]]:
+    conn = _connect(database_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT
+                id,
+                params,
+                result,
+                status,
+                created_at,
+                approval_status,
+                delivery_status
+            FROM history
+            WHERE status = 'failed'
+               OR delivery_status = ?
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            (DELIVERY_STATUS_SEND_FAILED, limit),
+        )
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
+
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        params = _parse_json(row[1]) or {}
+        result_payload = _parse_json(row[2]) or {}
+        results.append(
+            {
+                "job_id": row[0],
+                "status": row[3],
+                "created_at": row[4],
+                "approval_status": row[5],
+                "delivery_status": row[6],
+                "keywords": params.get("keywords"),
+                "domain": params.get("domain"),
+                "error": _error_summary(result_payload),
+                "attempts": result_payload.get("attempts"),
+            }
+        )
+    return results
+
+
+def _fetch_failed_outbox(
+    database_path: str, limit: int
+) -> list[dict[str, Any]]:
+    conn = _connect(database_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT
+                send_key,
+                job_id,
+                recipient,
+                status,
+                attempt_count,
+                last_error,
+                provider_message_id,
+                created_at,
+                updated_at
+            FROM email_outbox
+            WHERE status = 'failed'
+            ORDER BY updated_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        )
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
+
+    return [
+        {
+            "send_key": row[0],
+            "job_id": row[1],
+            "recipient": row[2],
+            "status": row[3],
+            "attempt_count": row[4],
+            "last_error": (row[5] or "")[:500] if row[5] else None,
+            "provider_message_id": row[6],
+            "created_at": row[7],
+            "updated_at": row[8],
+        }
+        for row in rows
+    ]
+
+
+def _count_outbox_by_status(database_path: str) -> dict[str, int]:
+    conn = _connect(database_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT status, COUNT(*) FROM email_outbox GROUP BY status"
+        )
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
+    return {str(row[0]): int(row[1]) for row in rows}
+
+
+def _reset_outbox_record_for_retry(
+    database_path: str, send_key: str
+) -> str:
+    """Mark an outbox record as pending so the next send attempt will go through.
+
+    Returns one of: ``"retry_queued"``, ``"not_found"``, ``"not_failed"``.
+    """
+    conn = _connect(database_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT status FROM email_outbox WHERE send_key = ?", (send_key,)
+        )
+        existing = cursor.fetchone()
+        if existing is None:
+            return "not_found"
+        if str(existing[0]) != "failed":
+            return "not_failed"
+        cursor.execute(
+            """
+            UPDATE email_outbox
+            SET status = 'pending',
+                last_error = NULL,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE send_key = ?
+            """,
+            (send_key,),
+        )
+        conn.commit()
+        return "retry_queued"
+    finally:
+        conn.close()
+
+
+def register_failed_jobs_routes(app: Flask, database_path: str) -> None:
+    """Register failed-jobs visibility routes on the given Flask app."""
+
+    @app.route("/api/ops/failed-jobs", methods=["GET"])  # type: ignore[untyped-decorator]
+    def ops_failed_jobs() -> ResponseReturnValue:
+        """Return recent failed generation jobs and failed outbox entries."""
+        try:
+            limit = _clamp_limit(request.args.get("limit", type=int))
+            history = _fetch_failed_history(database_path, limit)
+            outbox = _fetch_failed_outbox(database_path, limit)
+            outbox_totals = _count_outbox_by_status(database_path)
+
+            payload = {
+                "limit": limit,
+                "history": history,
+                "outbox": outbox,
+                "summary": {
+                    "failed_history_count": len(history),
+                    "failed_outbox_count": outbox_totals.get("failed", 0),
+                    "pending_outbox_count": outbox_totals.get("pending", 0),
+                    "sent_outbox_count": outbox_totals.get("sent", 0),
+                },
+            }
+            log_info(
+                logger,
+                "ops.failed_jobs.listed",
+                history=len(history),
+                outbox=len(outbox),
+                limit=limit,
+            )
+            return jsonify(payload)
+        except Exception as exc:
+            log_exception(logger, "ops.failed_jobs.list_failed", exc)
+            return (
+                jsonify({"error": f"Failed jobs listing failed: {exc}"}),
+                500,
+            )
+
+    @app.route(
+        "/api/ops/failed-jobs/outbox/<send_key>/retry",
+        methods=["POST"],
+    )  # type: ignore[untyped-decorator]
+    def ops_retry_outbox(send_key: str) -> ResponseReturnValue:
+        """Reset a failed outbox record so the next send attempt will retry."""
+        try:
+            outcome = _reset_outbox_record_for_retry(database_path, send_key)
+        except Exception as exc:
+            log_exception(
+                logger,
+                "ops.failed_jobs.retry_failed",
+                exc,
+                send_key=send_key,
+            )
+            return (
+                jsonify({"error": f"Outbox retry failed: {exc}"}),
+                500,
+            )
+
+        if outcome == "not_found":
+            return jsonify({"error": "outbox record not found"}), 404
+        if outcome == "not_failed":
+            return (
+                jsonify(
+                    {"error": "outbox record is not in failed state"}
+                ),
+                409,
+            )
+
+        log_info(
+            logger,
+            "ops.failed_jobs.retry_queued",
+            send_key=send_key,
+        )
+        return jsonify(
+            {
+                "send_key": send_key,
+                "status": "pending",
+                "message": "outbox record reset for retry",
+            }
+        )

--- a/web/routes_ops_failed_jobs.py
+++ b/web/routes_ops_failed_jobs.py
@@ -17,13 +17,9 @@ from flask import Flask, jsonify, request
 from flask.typing import ResponseReturnValue
 
 try:
-    from db_state import (
-        DELIVERY_STATUS_SEND_FAILED,
-    )
+    from db_state import DELIVERY_STATUS_SEND_FAILED
 except ImportError:
-    from web.db_state import (  # pragma: no cover
-        DELIVERY_STATUS_SEND_FAILED,
-    )
+    from web.db_state import DELIVERY_STATUS_SEND_FAILED  # pragma: no cover
 
 try:
     from ops_logging import log_exception, log_info
@@ -72,9 +68,7 @@ def _error_summary(result_payload: dict[str, Any] | None) -> str | None:
     return None
 
 
-def _fetch_failed_history(
-    database_path: str, limit: int
-) -> list[dict[str, Any]]:
+def _fetch_failed_history(database_path: str, limit: int) -> list[dict[str, Any]]:
     conn = _connect(database_path)
     try:
         cursor = conn.cursor()
@@ -120,9 +114,7 @@ def _fetch_failed_history(
     return results
 
 
-def _fetch_failed_outbox(
-    database_path: str, limit: int
-) -> list[dict[str, Any]]:
+def _fetch_failed_outbox(database_path: str, limit: int) -> list[dict[str, Any]]:
     conn = _connect(database_path)
     try:
         cursor = conn.cursor()
@@ -169,18 +161,14 @@ def _count_outbox_by_status(database_path: str) -> dict[str, int]:
     conn = _connect(database_path)
     try:
         cursor = conn.cursor()
-        cursor.execute(
-            "SELECT status, COUNT(*) FROM email_outbox GROUP BY status"
-        )
+        cursor.execute("SELECT status, COUNT(*) FROM email_outbox GROUP BY status")
         rows = cursor.fetchall()
     finally:
         conn.close()
     return {str(row[0]): int(row[1]) for row in rows}
 
 
-def _reset_outbox_record_for_retry(
-    database_path: str, send_key: str
-) -> str:
+def _reset_outbox_record_for_retry(database_path: str, send_key: str) -> str:
     """Mark an outbox record as pending so the next send attempt will go through.
 
     Returns one of: ``"retry_queued"``, ``"not_found"``, ``"not_failed"``.
@@ -274,9 +262,7 @@ def register_failed_jobs_routes(app: Flask, database_path: str) -> None:
             return jsonify({"error": "outbox record not found"}), 404
         if outcome == "not_failed":
             return (
-                jsonify(
-                    {"error": "outbox record is not in failed state"}
-                ),
+                jsonify({"error": "outbox record is not in failed state"}),
                 409,
             )
 

--- a/web/routes_ops_schedule_drift.py
+++ b/web/routes_ops_schedule_drift.py
@@ -1,0 +1,50 @@
+"""Route registration for schedule drift visibility."""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Flask, jsonify, request
+from flask.typing import ResponseReturnValue
+
+try:
+    from schedule_drift import detect_schedule_drift
+except ImportError:
+    from web.schedule_drift import detect_schedule_drift  # pragma: no cover
+
+try:
+    from ops_logging import log_exception, log_info
+except ImportError:
+    from web.ops_logging import log_exception, log_info  # pragma: no cover
+
+
+logger = logging.getLogger("web.routes_ops_schedule_drift")
+
+
+def register_schedule_drift_routes(app: Flask, database_path: str) -> None:
+    """Register the schedule drift visibility route on the given Flask app."""
+
+    @app.route("/api/ops/schedule-drift", methods=["GET"])  # type: ignore[untyped-decorator]
+    def ops_schedule_drift() -> ResponseReturnValue:
+        """Return the current schedule drift report."""
+        try:
+            threshold = request.args.get("threshold_seconds", type=int)
+            report = detect_schedule_drift(
+                database_path,
+                threshold_seconds=threshold,
+            )
+            payload = report.to_dict()
+            log_info(
+                logger,
+                "ops.schedule_drift.listed",
+                drifted_count=payload["drifted_count"],
+                active_schedule_count=payload["active_schedule_count"],
+                status=payload["status"],
+            )
+            return jsonify(payload)
+        except Exception as exc:
+            log_exception(logger, "ops.schedule_drift.list_failed", exc)
+            return (
+                jsonify({"error": f"Schedule drift lookup failed: {exc}"}),
+                500,
+            )

--- a/web/schedule_drift.py
+++ b/web/schedule_drift.py
@@ -1,0 +1,171 @@
+"""Schedule drift detection for operational visibility.
+
+A schedule is considered "drifted" when its ``next_run`` is older than now by
+more than a configurable threshold. This typically means the scheduler was
+down, stuck, or overloaded and has not advanced the schedule row yet.
+
+This module is a pure data/helper layer. It is consumed by:
+- ``web.routes_health`` to surface a top-level drift indicator on /health
+- ``web.routes_ops_schedule_drift`` to expose a drill-down endpoint
+
+It never mutates rows — diagnosis only. Rescheduling is done by
+``web.schedule_scan``.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+_DEFAULT_DRIFT_THRESHOLD_SECONDS = 15 * 60  # 15 minutes
+_DRIFT_ENV_VAR = "SCHEDULE_DRIFT_THRESHOLD_SECONDS"
+
+
+@dataclass
+class DriftedSchedule:
+    """A single drifted schedule row."""
+
+    schedule_id: str
+    next_run: str
+    drift_seconds: float
+    rrule: str
+    enabled: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schedule_id": self.schedule_id,
+            "next_run": self.next_run,
+            "drift_seconds": round(self.drift_seconds, 1),
+            "drift_minutes": round(self.drift_seconds / 60, 1),
+            "rrule": self.rrule,
+            "enabled": self.enabled,
+        }
+
+
+@dataclass
+class DriftReport:
+    """Aggregated drift detection result."""
+
+    checked_at: str
+    threshold_seconds: int
+    active_schedule_count: int
+    drifted: list[DriftedSchedule] = field(default_factory=list)
+
+    @property
+    def status(self) -> str:
+        if not self.drifted:
+            return "healthy"
+        worst = max(item.drift_seconds for item in self.drifted)
+        if worst >= self.threshold_seconds * 4:
+            return "error"
+        return "degraded"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "checked_at": self.checked_at,
+            "threshold_seconds": self.threshold_seconds,
+            "active_schedule_count": self.active_schedule_count,
+            "drifted_count": len(self.drifted),
+            "drifted": [item.to_dict() for item in self.drifted],
+        }
+
+
+def resolve_drift_threshold_seconds(
+    explicit: int | None = None,
+    environ: dict[str, str] | os._Environ[str] | None = None,
+) -> int:
+    """Resolve the drift threshold from an explicit value or env var."""
+    if explicit is not None:
+        return max(1, int(explicit))
+
+    env = environ if environ is not None else os.environ
+    raw = env.get(_DRIFT_ENV_VAR)
+    if raw is None:
+        return _DEFAULT_DRIFT_THRESHOLD_SECONDS
+    try:
+        parsed = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return _DEFAULT_DRIFT_THRESHOLD_SECONDS
+    return max(1, parsed)
+
+
+def _parse_next_run(value: str) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def detect_schedule_drift(
+    database_path: str,
+    *,
+    now: datetime | None = None,
+    threshold_seconds: int | None = None,
+) -> DriftReport:
+    """Return a drift report for currently-enabled schedules."""
+    current_time = now or datetime.now(timezone.utc)
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+
+    resolved_threshold = resolve_drift_threshold_seconds(threshold_seconds)
+    threshold_delta = timedelta(seconds=resolved_threshold)
+
+    conn = sqlite3.connect(database_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, next_run, rrule, enabled
+            FROM schedules
+            WHERE enabled = 1
+            """
+        )
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
+
+    drifted: list[DriftedSchedule] = []
+    for row in rows:
+        schedule_id = str(row[0])
+        next_run_raw = str(row[1]) if row[1] is not None else ""
+        rrule = str(row[2]) if row[2] is not None else ""
+        enabled_flag = bool(int(row[3])) if row[3] is not None else False
+
+        parsed = _parse_next_run(next_run_raw)
+        if parsed is None:
+            continue
+
+        drift = current_time - parsed
+        if drift > threshold_delta:
+            drifted.append(
+                DriftedSchedule(
+                    schedule_id=schedule_id,
+                    next_run=next_run_raw,
+                    drift_seconds=drift.total_seconds(),
+                    rrule=rrule,
+                    enabled=enabled_flag,
+                )
+            )
+
+    drifted.sort(key=lambda item: item.drift_seconds, reverse=True)
+
+    return DriftReport(
+        checked_at=current_time.isoformat().replace("+00:00", "Z"),
+        threshold_seconds=resolved_threshold,
+        active_schedule_count=len(rows),
+        drifted=drifted,
+    )


### PR DESCRIPTION
## Summary (what / why)

Implements two outstanding roadmap items:

1. **M1 shim-removal call-site migration** — test files that still imported from `newsletter.compose` / `newsletter.graph` / `newsletter.cli_run` etc. now go through the canonical `newsletter_core.application.generation.*` paths, so the `newsletter/*` compatibility shims can be deleted on M1 day without breaking tests.
2. **Operational stability — 3 new ops endpoints** with supporting data accessors, tests, and `/api/health` integration:
   - `GET/POST /api/ops/failed-jobs` — surface failed-sends from `history` and `email_outbox`; retry action resets outbox rows to `pending`.
   - `GET /api/ops/schedule-drift` — detect schedules whose `next_run_at` has slipped past a configurable threshold (`SCHEDULE_DRIFT_THRESHOLD_SECONDS`, default 15 min). Integrated into `/api/health` so drift shows up in the existing health rollup.
   - `GET /api/ops/dedupe-stats` — drill-down of `email.deduplicated` analytics events with per-recipient / per-job top-N and dedupe-rate percentage.

## Scope

### In Scope
- New runtime modules:
  - `web/routes_ops_failed_jobs.py`
  - `web/routes_ops_schedule_drift.py`
  - `web/routes_ops_dedupe_stats.py`
  - `web/schedule_drift.py` (shared detector used by the route and `/api/health`)
- `web/routes_health.py` — schedule-drift integration
- `web/app.py` — blueprint registration for the three new routes
- 18 new unit tests: `tests/unit_tests/test_web_ops_failed_jobs.py`, `test_web_schedule_drift.py`, `test_web_ops_dedupe_stats.py`
- Shim-migration edits in `newsletter/cli_run.py` and related test files
- Pre-existing lint cleanup (flake8 E402/F401/F841/W293, mypy) on files touched by this PR

### Out of Scope
- Deleting the `newsletter/*` shims (M1 hard cutover, separate PR)
- Schema changes (reads existing `analytics_events`, `history`, `email_outbox`, `schedules` tables)
- Dashboard/UI surfacing of the new endpoints
- Real-API / integration test changes

## Delivery Unit

RR: #395
Delivery Unit ID: ops-stability-visibility
Merge Boundary: single PR — all three ops endpoints + shim migration in one merge
Rollback Boundary: revert this PR; no schema or data changes

## Test & Evidence

- [x] `pytest -m unit` — 282 passed, 4 skipped. 3 pre-existing `test_email_delivery.py` env-dependent failures also fail on `main` with the same imports (verified).
- [x] `pytest -m mock_api` — 148 passed, 11 skipped. 1 pre-existing `test_api.py` assertion failure also fails identically on `main`.
- [x] 18 new unit tests for the three ops features all pass (6 dedupe-stats, 5 failed-jobs, 7 schedule-drift).
- [x] `black --check`, `isort --check-only --profile black`, `flake8 --max-line-length=88 --ignore=E203,W503,E501`, `mypy --ignore-missing-imports --follow-imports=skip`, `bandit` all clean on changed files.
- [x] `python scripts/architecture/check_import_boundaries.py --mode ratchet`, `check_import_cycles.py`, `check_legacy_newsletter_surface.py` clean.

### Commands and Results
```bash
MOCK_MODE=true TESTING=1 pytest -m unit --timeout=30 --no-cov \
  --ignore=tests/unit_tests/test_real_newsletter.py -q
# 282 passed, 4 skipped, 3 pre-existing env failures (same on main)

MOCK_MODE=true TESTING=1 pytest -m mock_api --timeout=30 --no-cov -q
# 148 passed, 11 skipped, 1 pre-existing env failure (same on main)

MOCK_MODE=true TESTING=1 pytest \
  tests/unit_tests/test_web_ops_dedupe_stats.py \
  tests/unit_tests/test_web_ops_failed_jobs.py \
  tests/unit_tests/test_web_schedule_drift.py -v
# 18 passed
```

## Risk & Rollback

- **Risk**: Low. All three endpoints are read-only except `POST /api/ops/failed-jobs/outbox/<id>/retry`, which only resets an `email_outbox` row from `send_failed` back to `pending` and returns `404` / `409` on missing or ineligible rows. No schema changes, no new external calls. The `/api/health` integration is guarded so a drift detector failure degrades to `error` rather than crashing the health endpoint.
- **Rollback**: Revert this PR. No schema or data changes — rollback is immediate and complete.

## Ops-Safety Addendum (if touching protected paths)

- `web/routes_health.py` is a health endpoint, not on the ops-safety-sensitive list (`web/app.py`, `web/tasks.py`, `web/schedule_runner.py`, `web/routes_generation.py`, `web/routes_send_email.py`). No ops-safety-sensitive runtime code is modified.
- Idempotency key 생성/적용 범위: N/A — no new send paths.
- Outbox/send_key 중복 방지: unchanged. The retry action resets outbox rows to `pending`; dedupe keys are preserved so the existing send pipeline still deduplicates if the retry collides with a concurrent send.
- Import-time side effects: none. New modules define routes inside `register_*_route(app, database_path)` factory functions; SQLite connections are opened only inside request handlers.

## Not Run (with reason)

- `make check-full`: real API keys not available in the local sandbox. Covered by CI on this PR.
- Real-API integration tests (`pytest -m integration`): same reason.
- Windows smoke / PyInstaller build: no Windows runner in the local sandbox; covered by CI.