### PR TITLE
feat(ops-security): RR-26 scoped multi-token auth for protected routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,14 @@ LOG_FORMAT=standard
 
 # Web / Ops
 SECRET_KEY=change-this-in-production
+# Root token — grants all scopes (data, schedule, email, ops). Fully backward-compatible.
 ADMIN_API_TOKEN=replace-me-with-an-ops-token
+# Scoped tokens — each grants access only to the named scope.
+# Prefer scoped tokens in production to limit blast radius if a token leaks.
+# ADMIN_API_TOKEN_DATA=replace-me-with-a-data-token
+# ADMIN_API_TOKEN_SCHEDULE=replace-me-with-a-schedule-token
+# ADMIN_API_TOKEN_EMAIL=replace-me-with-an-email-token
+# ADMIN_API_TOKEN_OPS=replace-me-with-an-ops-token
 ALLOWED_ORIGINS=http://localhost:3000,https://yourdomain.com
 
 # API Keys (Required for functionality)

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -26,7 +26,11 @@
 | `LOG_LEVEL` | 선택 | runtime/application log level |
 | `LOG_FORMAT` | 선택 | logging format (`standard`/`json`) |
 | `SECRET_KEY` | 프로덕션 권장(웹) | Flask 시크릿 키 |
-| `ADMIN_API_TOKEN` | 민감 운영 API 보호 시 필수 | `/api/history`, `/api/schedule*`, `/api/send-email`, `/api/email-config`, `/api/test-email` 보호 토큰 |
+| `ADMIN_API_TOKEN` | 민감 운영 API 보호 시 필수 | 모든 스코프(data·schedule·email·ops)를 허용하는 root 토큰. 기존 단일 토큰 방식과 완전히 하위호환. |
+| `ADMIN_API_TOKEN_DATA` | 선택 | `data` 스코프 전용 토큰 — `/api/history`, `/api/analytics`, `/api/archive`, `/api/presets`, `/api/approvals`, `/api/source-policies` |
+| `ADMIN_API_TOKEN_SCHEDULE` | 선택 | `schedule` 스코프 전용 토큰 — `/api/schedule*`, `/api/schedules*` |
+| `ADMIN_API_TOKEN_EMAIL` | 선택 | `email` 스코프 전용 토큰 — `/api/send-email`, `/api/email-config`, `/api/test-email` |
+| `ADMIN_API_TOKEN_OPS` | 선택 | `ops` 스코프 전용 토큰 — `/api/ops/*` |
 | `ALLOWED_ORIGINS` | 선택 | canonical Flask runtime CORS allow-list |
 
 ### Search / LLM / Delivery
@@ -128,12 +132,19 @@ DEBUG_COST_TRACKING=false
 POSTMARK_SERVER_TOKEN=ps_xxx
 EMAIL_SENDER=newsletter@example.com
 
-# 웹/운영
+# 웹/운영 — root token (기존 방식, 모든 스코프 허용)
 APP_ENV=production
 SECRET_KEY=replace-me-in-production
 ADMIN_API_TOKEN=replace-me-with-an-ops-token
 ALLOWED_ORIGINS=https://app.example.com
 REDIS_URL=redis://localhost:6379/0
+
+# 웹/운영 — 스코프별 분리 방식 (더 강한 보안)
+# 각 시스템/서비스에 필요한 최소 스코프만 발급
+# ADMIN_API_TOKEN_SCHEDULE=scheduler-service-token
+# ADMIN_API_TOKEN_EMAIL=mailer-service-token
+# ADMIN_API_TOKEN_DATA=analytics-service-token
+# ADMIN_API_TOKEN_OPS=ops-monitoring-token
 
 # 선택적 compatibility alias
 # FLASK_ENV=production

--- a/tests/unit_tests/test_web_access_control.py
+++ b/tests/unit_tests/test_web_access_control.py
@@ -10,7 +10,19 @@ WEB_DIR = Path(__file__).resolve().parents[2] / "web"
 if str(WEB_DIR) not in sys.path:
     sys.path.insert(0, str(WEB_DIR))
 
-from access_control import configure_access_control, is_protected_route  # noqa: E402
+from access_control import (  # noqa: E402
+    ALL_SCOPES,
+    SCOPE_DATA,
+    SCOPE_EMAIL,
+    SCOPE_OPS,
+    SCOPE_SCHEDULE,
+    _check_token_auth,
+    _resolve_all_token_configs,
+    _scope_for_path,
+    _TokenConfig,
+    configure_access_control,
+    is_protected_route,
+)
 
 pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
 
@@ -202,3 +214,297 @@ def test_protected_routes_are_rate_limited_even_with_valid_token(
     assert third.status_code == 429
     assert third.get_json()["error"] == "Protected route rate limit exceeded"
     assert int(third.headers["Retry-After"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Scope constant and helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_all_scopes_contains_every_defined_scope() -> None:
+    assert SCOPE_DATA in ALL_SCOPES
+    assert SCOPE_SCHEDULE in ALL_SCOPES
+    assert SCOPE_EMAIL in ALL_SCOPES
+    assert SCOPE_OPS in ALL_SCOPES
+
+
+def test_scope_for_path_maps_known_prefixes() -> None:
+    assert _scope_for_path("/api/history") == SCOPE_DATA
+    assert _scope_for_path("/api/history/123") == SCOPE_DATA
+    assert _scope_for_path("/api/analytics") == SCOPE_DATA
+    assert _scope_for_path("/api/presets") == SCOPE_DATA
+    assert _scope_for_path("/api/approvals") == SCOPE_DATA
+    assert _scope_for_path("/api/source-policies") == SCOPE_DATA
+    assert _scope_for_path("/api/archive") == SCOPE_DATA
+    assert _scope_for_path("/api/schedule") == SCOPE_SCHEDULE
+    assert _scope_for_path("/api/schedules") == SCOPE_SCHEDULE
+    assert _scope_for_path("/api/schedules/abc/run") == SCOPE_SCHEDULE
+    assert _scope_for_path("/api/send-email") == SCOPE_EMAIL
+    assert _scope_for_path("/api/email-config") == SCOPE_EMAIL
+    assert _scope_for_path("/api/test-email") == SCOPE_EMAIL
+    assert _scope_for_path("/api/ops") == SCOPE_OPS
+    assert _scope_for_path("/api/ops/failed-jobs") == SCOPE_OPS
+
+
+def test_scope_for_path_returns_none_for_public_routes() -> None:
+    assert _scope_for_path("/health") is None
+    assert _scope_for_path("/api/generate") is None
+    assert _scope_for_path("/") is None
+
+
+def test_resolve_all_token_configs_root_token_has_all_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ADMIN_API_TOKEN", "root-secret")
+    monkeypatch.delenv("ADMIN_API_TOKEN_DATA", raising=False)
+    monkeypatch.delenv("ADMIN_API_TOKEN_SCHEDULE", raising=False)
+    monkeypatch.delenv("ADMIN_API_TOKEN_EMAIL", raising=False)
+    monkeypatch.delenv("ADMIN_API_TOKEN_OPS", raising=False)
+
+    configs = _resolve_all_token_configs()
+
+    assert len(configs) == 1
+    assert configs[0].label == "root"
+    assert configs[0].scopes == ALL_SCOPES
+
+
+def test_resolve_all_token_configs_scoped_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ADMIN_API_TOKEN", raising=False)
+    monkeypatch.setenv("ADMIN_API_TOKEN_SCHEDULE", "sched-secret")
+    monkeypatch.delenv("ADMIN_API_TOKEN_DATA", raising=False)
+    monkeypatch.delenv("ADMIN_API_TOKEN_EMAIL", raising=False)
+    monkeypatch.delenv("ADMIN_API_TOKEN_OPS", raising=False)
+
+    configs = _resolve_all_token_configs()
+
+    assert len(configs) == 1
+    assert configs[0].label == "ADMIN_API_TOKEN_SCHEDULE"
+    assert configs[0].scopes == frozenset({SCOPE_SCHEDULE})
+
+
+def test_resolve_all_token_configs_empty_when_none_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ADMIN_API_TOKEN", raising=False)
+    monkeypatch.delenv("ADMIN_API_TOKEN_DATA", raising=False)
+    monkeypatch.delenv("ADMIN_API_TOKEN_SCHEDULE", raising=False)
+    monkeypatch.delenv("ADMIN_API_TOKEN_EMAIL", raising=False)
+    monkeypatch.delenv("ADMIN_API_TOKEN_OPS", raising=False)
+
+    assert _resolve_all_token_configs() == []
+
+
+def test_check_token_auth_root_token_grants_any_scope() -> None:
+    configs = [_TokenConfig(value="root-tok", scopes=ALL_SCOPES, label="root")]
+    authorized, label = _check_token_auth("root-tok", SCOPE_SCHEDULE, configs)
+    assert authorized is True
+    assert label == "root"
+
+
+def test_check_token_auth_scoped_token_allows_matching_scope() -> None:
+    configs = [
+        _TokenConfig(
+            value="sched-tok",
+            scopes=frozenset({SCOPE_SCHEDULE}),
+            label="ADMIN_API_TOKEN_SCHEDULE",
+        )
+    ]
+    authorized, label = _check_token_auth("sched-tok", SCOPE_SCHEDULE, configs)
+    assert authorized is True
+
+
+def test_check_token_auth_scoped_token_denies_wrong_scope() -> None:
+    configs = [
+        _TokenConfig(
+            value="sched-tok",
+            scopes=frozenset({SCOPE_SCHEDULE}),
+            label="ADMIN_API_TOKEN_SCHEDULE",
+        )
+    ]
+    # Schedule token should NOT access data routes.
+    authorized, label = _check_token_auth("sched-tok", SCOPE_DATA, configs)
+    assert authorized is False
+    assert label == "ADMIN_API_TOKEN_SCHEDULE"  # token was recognised
+
+
+def test_check_token_auth_unknown_token_returns_no_label() -> None:
+    configs = [_TokenConfig(value="real-tok", scopes=ALL_SCOPES, label="root")]
+    authorized, label = _check_token_auth("bogus-tok", SCOPE_OPS, configs)
+    assert authorized is False
+    assert label is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: scoped tokens via configure_access_control
+# ---------------------------------------------------------------------------
+
+
+def _build_app_scoped(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    root_token: str | None = None,
+    schedule_token: str | None = None,
+    email_token: str | None = None,
+    data_token: str | None = None,
+    ops_token: str | None = None,
+) -> Flask:
+    monkeypatch.setenv("APP_ENV", "production")
+    for env_var, value in [
+        ("ADMIN_API_TOKEN", root_token),
+        ("ADMIN_API_TOKEN_SCHEDULE", schedule_token),
+        ("ADMIN_API_TOKEN_EMAIL", email_token),
+        ("ADMIN_API_TOKEN_DATA", data_token),
+        ("ADMIN_API_TOKEN_OPS", ops_token),
+    ]:
+        if value is not None:
+            monkeypatch.setenv(env_var, value)
+        else:
+            monkeypatch.delenv(env_var, raising=False)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = False
+    configure_access_control(app)
+
+    @app.route("/api/schedules")
+    def schedules():  # type: ignore[return]
+        return jsonify({"ok": True})
+
+    @app.route("/api/history")
+    def history():  # type: ignore[return]
+        return jsonify({"ok": True})
+
+    @app.route("/api/ops/failed-jobs")
+    def failed_jobs():  # type: ignore[return]
+        return jsonify({"ok": True})
+
+    @app.route("/api/send-email", methods=["POST"])
+    def send_email():  # type: ignore[return]
+        return jsonify({"ok": True})
+
+    return app
+
+
+def test_scoped_schedule_token_allows_schedule_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_app_scoped(monkeypatch=monkeypatch, schedule_token="sched-secret")
+
+    with app.test_client() as client:
+        response = client.get(
+            "/api/schedules", headers={"X-Admin-Token": "sched-secret"}
+        )
+
+    assert response.status_code == 200
+
+
+def test_scoped_schedule_token_denies_data_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_app_scoped(monkeypatch=monkeypatch, schedule_token="sched-secret")
+
+    with app.test_client() as client:
+        response = client.get("/api/history", headers={"X-Admin-Token": "sched-secret"})
+
+    assert response.status_code == 403
+    body = response.get_json()
+    assert body["error"] == "Insufficient token scope"
+    assert body["required_scope"] == SCOPE_DATA
+
+
+def test_scoped_ops_token_denies_schedule_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_app_scoped(monkeypatch=monkeypatch, ops_token="ops-secret")
+
+    with app.test_client() as client:
+        response = client.get("/api/schedules", headers={"X-Admin-Token": "ops-secret"})
+
+    assert response.status_code == 403
+    body = response.get_json()
+    assert body["error"] == "Insufficient token scope"
+    assert body["required_scope"] == SCOPE_SCHEDULE
+
+
+def test_root_token_grants_all_scopes_across_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_app_scoped(monkeypatch=monkeypatch, root_token="root-secret")
+
+    with app.test_client() as client:
+        r1 = client.get("/api/schedules", headers={"X-Admin-Token": "root-secret"})
+        r2 = client.get("/api/history", headers={"X-Admin-Token": "root-secret"})
+        r3 = client.get(
+            "/api/ops/failed-jobs", headers={"X-Admin-Token": "root-secret"}
+        )
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r3.status_code == 200
+
+
+def test_multiple_scoped_tokens_each_allow_only_their_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_app_scoped(
+        monkeypatch=monkeypatch,
+        schedule_token="sched-secret",
+        data_token="data-secret",
+    )
+
+    with app.test_client() as client:
+        sched_ok = client.get(
+            "/api/schedules", headers={"X-Admin-Token": "sched-secret"}
+        )
+        sched_denied = client.get(
+            "/api/history", headers={"X-Admin-Token": "sched-secret"}
+        )
+        data_ok = client.get("/api/history", headers={"X-Admin-Token": "data-secret"})
+        data_denied = client.get(
+            "/api/schedules", headers={"X-Admin-Token": "data-secret"}
+        )
+
+    assert sched_ok.status_code == 200
+    assert sched_denied.status_code == 403
+    assert data_ok.status_code == 200
+    assert data_denied.status_code == 403
+
+
+def test_bearer_header_accepted_for_scoped_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_app_scoped(monkeypatch=monkeypatch, email_token="email-secret")
+
+    with app.test_client() as client:
+        response = client.post(
+            "/api/send-email",
+            headers={"Authorization": "Bearer email-secret"},
+        )
+
+    assert response.status_code == 200
+
+
+def test_wrong_token_returns_401_not_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_app_scoped(monkeypatch=monkeypatch, schedule_token="sched-secret")
+
+    with app.test_client() as client:
+        response = client.get(
+            "/api/schedules", headers={"X-Admin-Token": "completely-wrong"}
+        )
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Admin API token required"}
+
+
+def test_503_when_no_tokens_configured_at_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_app_scoped(monkeypatch=monkeypatch)  # all tokens None
+
+    with app.test_client() as client:
+        response = client.get("/api/schedules")
+
+    assert response.status_code == 503

--- a/web/access_control.py
+++ b/web/access_control.py
@@ -1,9 +1,41 @@
-"""Minimal access control for sensitive Flask operational routes."""
+"""Minimal access control for sensitive Flask operational routes.
+
+Token model
+-----------
+``ADMIN_API_TOKEN`` (root/bootstrap token) — grants all scopes.  Used as the
+single shared credential in existing deployments and remains fully
+backward-compatible.
+
+Scoped tokens — each grants access only to the named scope:
+
+  * ``ADMIN_API_TOKEN_DATA``     — read/write history, analytics, archive,
+                                    presets, approvals, source-policies
+  * ``ADMIN_API_TOKEN_SCHEDULE`` — schedule management endpoints
+  * ``ADMIN_API_TOKEN_EMAIL``    — email send/config/test endpoints
+  * ``ADMIN_API_TOKEN_OPS``      — ops diagnostics endpoints
+
+Using scoped tokens reduces the blast radius of a leak: an email-service token
+cannot access schedule management, and vice versa.  Different deployments or
+automation systems should each receive the smallest token that satisfies their
+needs.
+
+Auth flow (production-like runtimes)
+-------------------------------------
+1. Rate-limit check (shared sliding-window limiter).
+2. Find all configured tokens from environment.
+3. Determine the required scope for the requested path.
+4. Walk token list, compare with ``hmac.compare_digest`` (constant-time).
+5. If a matching token is found and it holds the required scope → 200.
+   If matching but wrong scope → 403 (Insufficient token scope).
+   If no match at all → 401 (Admin API token required).
+   If no tokens configured at all → 503 (misconfiguration).
+"""
 
 from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 from hmac import compare_digest
 from typing import Mapping
 
@@ -25,20 +57,45 @@ DEFAULT_PROTECTED_RATE_LIMIT = 30
 DEFAULT_PROTECTED_WINDOW_SECONDS = 60
 DEFAULT_GENERATE_MAX_BODY_BYTES = 32 * 1024
 
-_PROTECTED_PREFIXES: tuple[str, ...] = (
-    "/api/history",
-    "/api/analytics",
-    "/api/presets",
-    "/api/approvals",
-    "/api/source-policies",
-    "/api/archive",
-    "/api/schedule",
-    "/api/schedules",
-    "/api/send-email",
-    "/api/email-config",
-    "/api/test-email",
-    "/api/ops",
+# ---------------------------------------------------------------------------
+# Scope constants
+# ---------------------------------------------------------------------------
+
+SCOPE_DATA = "data"
+SCOPE_SCHEDULE = "schedule"
+SCOPE_EMAIL = "email"
+SCOPE_OPS = "ops"
+
+ALL_SCOPES: frozenset[str] = frozenset(
+    {SCOPE_DATA, SCOPE_SCHEDULE, SCOPE_EMAIL, SCOPE_OPS}
 )
+
+# Map each protected route prefix to its required scope.
+_ROUTE_SCOPE_MAP: dict[str, str] = {
+    "/api/history": SCOPE_DATA,
+    "/api/analytics": SCOPE_DATA,
+    "/api/presets": SCOPE_DATA,
+    "/api/approvals": SCOPE_DATA,
+    "/api/source-policies": SCOPE_DATA,
+    "/api/archive": SCOPE_DATA,
+    "/api/schedule": SCOPE_SCHEDULE,
+    "/api/schedules": SCOPE_SCHEDULE,
+    "/api/send-email": SCOPE_EMAIL,
+    "/api/email-config": SCOPE_EMAIL,
+    "/api/test-email": SCOPE_EMAIL,
+    "/api/ops": SCOPE_OPS,
+}
+
+# Scoped token env-var names (one per scope).
+_SCOPED_TOKEN_ENV_VARS: dict[str, str] = {  # nosec B105
+    SCOPE_DATA: "ADMIN_API_TOKEN_DATA",
+    SCOPE_SCHEDULE: "ADMIN_API_TOKEN_SCHEDULE",
+    SCOPE_EMAIL: "ADMIN_API_TOKEN_EMAIL",
+    SCOPE_OPS: "ADMIN_API_TOKEN_OPS",
+}
+
+# Derived from _ROUTE_SCOPE_MAP so the two stay in sync automatically.
+_PROTECTED_PREFIXES: tuple[str, ...] = tuple(_ROUTE_SCOPE_MAP.keys())
 
 
 def _is_dev_like(app: Flask, environ: Mapping[str, str] | None = None) -> bool:
@@ -77,6 +134,83 @@ def is_protected_route(
 ) -> bool:
     """Return whether the request path should require the admin API token."""
     return any(path == prefix or path.startswith(f"{prefix}/") for prefix in prefixes)
+
+
+@dataclass(frozen=True)
+class _TokenConfig:
+    """A configured token with its granted scopes and a human-readable label."""
+
+    value: str
+    scopes: frozenset[str]
+    label: str
+
+
+def _resolve_all_token_configs(
+    environ: Mapping[str, str] | None = None,
+) -> list[_TokenConfig]:
+    """Return every token configured in the environment.
+
+    The root ``ADMIN_API_TOKEN`` is granted ``ALL_SCOPES``.  Each scoped token
+    (``ADMIN_API_TOKEN_<SCOPE>``) is granted only the corresponding scope.
+    """
+    env = environ or os.environ
+    configs: list[_TokenConfig] = []
+
+    root_token = env.get(ADMIN_TOKEN_ENV_VAR, "").strip()
+    if root_token:
+        configs.append(_TokenConfig(value=root_token, scopes=ALL_SCOPES, label="root"))
+
+    for scope, env_var in _SCOPED_TOKEN_ENV_VARS.items():
+        scoped_token = env.get(env_var, "").strip()
+        if scoped_token:
+            configs.append(
+                _TokenConfig(
+                    value=scoped_token,
+                    scopes=frozenset({scope}),
+                    label=env_var,
+                )
+            )
+
+    return configs
+
+
+def _scope_for_path(path: str) -> str | None:
+    """Return the scope required for *path*, or ``None`` if no mapping exists."""
+    for prefix, scope in _ROUTE_SCOPE_MAP.items():
+        if path == prefix or path.startswith(f"{prefix}/"):
+            return scope
+    return None
+
+
+def _check_token_auth(
+    provided: str,
+    required_scope: str,
+    configs: list[_TokenConfig],
+) -> tuple[bool, str | None]:
+    """Constant-time multi-token check.
+
+    Scans every config to avoid short-circuit timing leaks.
+
+    Returns:
+        (authorized, label): ``(True, label)`` if a token matched and holds the
+        required scope; ``(False, label)`` if a token matched but lacks scope;
+        ``(False, None)`` if no token matched.
+    """
+    matched_label: str | None = None
+    scope_granted: bool = False
+
+    for config in configs:
+        if compare_digest(provided, config.value):
+            matched_label = config.label
+            if required_scope in config.scopes:
+                scope_granted = True
+
+    return (scope_granted and matched_label is not None), matched_label
+
+
+# ---------------------------------------------------------------------------
+# Legacy single-token helpers — kept for internal backward compat only.
+# ---------------------------------------------------------------------------
 
 
 def _resolve_expected_admin_token(
@@ -186,8 +320,8 @@ def configure_access_control(
                 retry_after_seconds=decision.retry_after_seconds,
             )
 
-        expected_token = _resolve_expected_admin_token(env)
-        if not expected_token:
+        configs = _resolve_all_token_configs(env)
+        if not configs:
             LOGGER.error(
                 "Protected web routes are enabled without %s configured.",
                 ADMIN_TOKEN_ENV_VAR,
@@ -200,7 +334,46 @@ def configure_access_control(
             )
 
         provided_token = _resolve_provided_admin_token()
-        if not provided_token or not compare_digest(provided_token, expected_token):
+        if not provided_token:
             return jsonify({"error": "Admin API token required"}), 401
 
-        return None
+        required_scope = _scope_for_path(request.path)
+        if required_scope is None:
+            # Protected prefix with no scope mapping — fail closed.
+            LOGGER.warning(
+                "Protected route %s has no scope mapping; denying access.",
+                request.path,
+            )
+            return jsonify({"error": "Admin API token required"}), 401
+
+        authorized, token_label = _check_token_auth(
+            provided_token, required_scope, configs
+        )
+        if authorized:
+            LOGGER.debug(
+                "Request authorized: path=%s scope=%s token=%s",
+                request.path,
+                required_scope,
+                token_label,
+            )
+            return None
+
+        if token_label is not None:
+            # Token was recognised but lacks the required scope.
+            LOGGER.warning(
+                "Token %s lacks scope '%s' required for path %s",
+                token_label,
+                required_scope,
+                request.path,
+            )
+            return (
+                jsonify(
+                    {
+                        "error": "Insufficient token scope",
+                        "required_scope": required_scope,
+                    }
+                ),
+                403,
+            )
+
+        return jsonify({"error": "Admin API token required"}), 401


### PR DESCRIPTION
## Summary (what / why)

- 단일 공유 `ADMIN_API_TOKEN` 방식을 **스코프 분리 다중 토큰 모델**로 교체
- 토큰 유출 시 피해 범위를 해당 스코프로만 제한 (최소 권한 원칙)
- 요청별 토큰 레이블 로깅으로 행위자 귀속 가능

## Scope

### In Scope
- `web/access_control.py`: 4개 스코프(data·schedule·email·ops) 상수, 경로→스코프 맵, `_TokenConfig` dataclass, `_check_token_auth()` 상수시간 다중 토큰 비교, 스코프 불일치 403 응답
- `tests/unit_tests/test_web_access_control.py`: 스코프 단위 테스트 18개 추가 (총 28개)
- `docs/reference/environment-variables.md`: 스코프 토큰 4종 문서화
- `.env.example`: 스코프 토큰 예시 주석 추가

### Out of Scope
- Redis 기반 중앙화 rate limiting (RR-27)
- 생성 quota / abuse policy (RR-28)
- DB 기반 API 키 레지스트리 (동적 발급/폐기)

## Delivery Unit

RR: #209 (RR-26)
Delivery Unit ID: RR-26
Merge Boundary: `ops-security/rr-26-scoped-token-auth` → `main`
Rollback Boundary: `git revert 217b417` 단일 커밋 롤백 가능

## Test & Evidence

- [x] `make check`
- [ ] `make check-full`
- [ ] GitHub required checks green before merge
- [ ] Additional tests: `pytest tests/unit_tests/test_web_access_control.py` — 28 passed

### Commands and Results

```bash
# 테스트
.local/venv/bin/python -m pytest tests/unit_tests/test_web_access_control.py -v
# → 28 passed in 2.22s

.local/venv/bin/python -m pytest tests/test_web_api.py -v
# → 21 passed, 1 skipped in 2.52s

make check
# → ✅ Black, isort, Flake8, Import 경계, Import 사이클, Legacy surface, Pre-commit — 전체 PASS
```

## Risk & Rollback

- Risk: 신규 403 응답(스코프 불일치)은 기존 클라이언트가 처리하지 않을 수 있음 — 단, 스코프 토큰을 설정하지 않으면 기존 동작과 동일
- Rollback: 스코프 토큰 환경변수(`ADMIN_API_TOKEN_*`) 미설정 시 root 토큰 단독 동작으로 자동 복귀. 코드 롤백 필요 시 `git revert 217b417`

## Ops-Safety Addendum

- Idempotency key: 해당 없음 (인증 레이어만 변경, 생성/발송 경로 미변경)
- Outbox/send_key: 해당 없음
- import-time side effect: 신규 도입 없음 (`dataclass`, `frozenset` 사용, 모두 순수 정적 정의)

## Not Run (with reason)

- `make check-full`: 로컬 환경 API key 미설정으로 LLM 연동 테스트 skip 예상 — CI에서 확인