### PR TITLE
feat(ops-security): quota/abuse observability for generation endpoints (RR-28)

### DIFF
--- a/tests/unit_tests/test_web_quota_abuse.py
+++ b/tests/unit_tests/test_web_quota_abuse.py
@@ -1,0 +1,240 @@
+"""Unit tests for quota/abuse observability (RR-28).
+
+Tests cover:
+- _QuotaAbuseTracker bounded ring-buffer behaviour
+- /newsletter GET rate limit enforcement
+- Abuse events recorded when rate limit exceeded (/api/generate and /newsletter)
+- /api/ops/quota-abuse ops endpoint
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask, jsonify
+
+WEB_DIR = Path(__file__).resolve().parents[2] / "web"
+if str(WEB_DIR) not in sys.path:
+    sys.path.insert(0, str(WEB_DIR))
+
+from access_control import (  # noqa: E402
+    AbuseEvent,
+    _QuotaAbuseTracker,
+    configure_access_control,
+)
+from routes_ops_quota_abuse import register_quota_abuse_routes  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_api]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PROD_ENV = {"APP_ENV": "production"}
+_OPS_TOKEN = "test-ops-secret"
+_OPS_ENV = {**_PROD_ENV, "ADMIN_API_TOKEN_OPS": _OPS_TOKEN}
+
+
+def _build_app(
+    *,
+    generate_rate_limit: int = 5,
+    newsletter_rate_limit: int = 3,
+    environ: dict[str, str] | None = None,
+) -> Flask:
+    """Build a minimal Flask app with access control and quota-abuse routes."""
+    app = Flask(__name__)
+    app.config["TESTING"] = False
+    configure_access_control(
+        app,
+        environ=environ or _OPS_ENV,
+        generate_rate_limit=generate_rate_limit,
+        newsletter_rate_limit=newsletter_rate_limit,
+    )
+    register_quota_abuse_routes(app, ":memory:")
+
+    @app.route("/api/generate", methods=["POST"])  # type: ignore[misc]
+    def generate():
+        return jsonify({"ok": True})
+
+    @app.route("/newsletter")  # type: ignore[misc]
+    def newsletter():
+        return jsonify({"ok": True})
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# _QuotaAbuseTracker unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_tracker_records_event() -> None:
+    tracker = _QuotaAbuseTracker()
+    event = AbuseEvent(
+        timestamp="2026-01-01T00:00:00Z",
+        client_id="1.2.3.4",
+        path="/api/generate",
+        retry_after_seconds=30,
+    )
+    tracker.record(event)
+    assert tracker.total_recorded == 1
+    events = tracker.recent()
+    assert len(events) == 1
+    assert events[0].client_id == "1.2.3.4"
+
+
+def test_tracker_bounded_ring_buffer() -> None:
+    tracker = _QuotaAbuseTracker(maxlen=3)
+    for i in range(5):
+        tracker.record(
+            AbuseEvent(
+                timestamp="t",
+                client_id=str(i),
+                path="/p",
+                retry_after_seconds=1,
+            )
+        )
+    # total_recorded counts all 5 even though deque only holds 3
+    assert tracker.total_recorded == 5
+    events = tracker.recent()
+    assert len(events) == 3
+    assert events[-1].client_id == "4"  # most recent is last
+
+
+def test_tracker_recent_limit() -> None:
+    tracker = _QuotaAbuseTracker()
+    for i in range(10):
+        tracker.record(
+            AbuseEvent(
+                timestamp="t", client_id=str(i), path="/p", retry_after_seconds=1
+            )
+        )
+    assert len(tracker.recent(limit=3)) == 3
+
+
+# ---------------------------------------------------------------------------
+# /newsletter GET rate limit
+# ---------------------------------------------------------------------------
+
+
+def test_newsletter_allows_under_limit() -> None:
+    app = _build_app(newsletter_rate_limit=3)
+    with app.test_client() as client:
+        for _ in range(3):
+            resp = client.get("/newsletter")
+            assert resp.status_code == 200
+
+
+def test_newsletter_enforces_limit() -> None:
+    app = _build_app(newsletter_rate_limit=2)
+    with app.test_client() as client:
+        client.get("/newsletter")
+        client.get("/newsletter")
+        resp = client.get("/newsletter")
+    assert resp.status_code == 429
+    body = resp.get_json()
+    assert "retry_after_seconds" in body
+    assert resp.headers.get("Retry-After") is not None
+
+
+def test_newsletter_rate_limit_records_abuse_event() -> None:
+    app = _build_app(newsletter_rate_limit=1)
+    with app.test_client() as client:
+        client.get("/newsletter")  # allowed
+        client.get("/newsletter")  # denied → abuse recorded
+
+    tracker = app.extensions["quota_abuse_tracker"]
+    assert tracker.total_recorded == 1
+    events = tracker.recent()
+    assert events[0].path == "/newsletter"
+    assert events[0].retry_after_seconds >= 1
+
+
+# ---------------------------------------------------------------------------
+# /api/generate abuse recording
+# ---------------------------------------------------------------------------
+
+
+def test_generate_rate_limit_records_abuse_event() -> None:
+    app = _build_app(generate_rate_limit=1)
+    with app.test_client() as client:
+        client.post("/api/generate", json={})  # allowed
+        client.post("/api/generate", json={})  # denied → abuse recorded
+
+    tracker = app.extensions["quota_abuse_tracker"]
+    assert tracker.total_recorded == 1
+    events = tracker.recent()
+    assert events[0].path == "/api/generate"
+
+
+# ---------------------------------------------------------------------------
+# /api/ops/quota-abuse endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_ops_endpoint_returns_empty_when_no_violations() -> None:
+    app = _build_app()
+    with app.test_client() as client:
+        resp = client.get(
+            "/api/ops/quota-abuse",
+            headers={"X-Admin-Token": _OPS_TOKEN},
+        )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["events"] == []
+    assert body["summary"]["tracker_enabled"] is True
+    assert body["summary"]["total_recorded"] == 0
+
+
+def test_ops_endpoint_returns_violations() -> None:
+    app = _build_app(newsletter_rate_limit=1)
+    with app.test_client() as client:
+        client.get("/newsletter")  # ok
+        client.get("/newsletter")  # denied → recorded
+        resp = client.get(
+            "/api/ops/quota-abuse",
+            headers={"X-Admin-Token": _OPS_TOKEN},
+        )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["summary"]["total_recorded"] == 1
+    assert len(body["events"]) == 1
+    event = body["events"][0]
+    assert event["path"] == "/newsletter"
+    assert event["retry_after_seconds"] >= 1
+    assert "timestamp" in event
+    assert "client_id" in event
+
+
+def test_ops_endpoint_requires_ops_token() -> None:
+    app = _build_app()
+    with app.test_client() as client:
+        resp = client.get("/api/ops/quota-abuse")
+    assert resp.status_code == 401
+
+
+def test_ops_endpoint_wrong_scope_token_rejected() -> None:
+    environ = {**_PROD_ENV, "ADMIN_API_TOKEN_DATA": "data-token"}
+    app = _build_app(environ=environ)
+    with app.test_client() as client:
+        resp = client.get(
+            "/api/ops/quota-abuse",
+            headers={"X-Admin-Token": "data-token"},
+        )
+    assert resp.status_code == 403
+
+
+def test_ops_endpoint_when_no_tracker() -> None:
+    """Graceful response when tracker is not attached (e.g. custom app setup)."""
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    register_quota_abuse_routes(app, ":memory:")
+
+    with app.test_client() as client:
+        resp = client.get("/api/ops/quota-abuse")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["summary"]["tracker_enabled"] is False
+    assert body["events"] == []

--- a/web/access_control.py
+++ b/web/access_control.py
@@ -29,12 +29,23 @@ Auth flow (production-like runtimes)
    If matching but wrong scope → 403 (Insufficient token scope).
    If no match at all → 401 (Admin API token required).
    If no tokens configured at all → 503 (misconfiguration).
+
+Quota / Abuse observability
+----------------------------
+Rate-limit violations on ``/api/generate`` and ``/newsletter`` are recorded
+in a per-process ``_QuotaAbuseTracker`` stored in
+``app.extensions["quota_abuse_tracker"]``.  The ``/api/ops/quota-abuse``
+endpoint (requires ``SCOPE_OPS``) exposes these events to operators without
+requiring direct database or log access.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import threading
+import time
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 from hmac import compare_digest
@@ -54,9 +65,12 @@ ADMIN_TOKEN_ENV_VAR = "ADMIN_API_TOKEN"  # nosec B105
 ADMIN_TOKEN_HEADER = "X-Admin-Token"  # nosec B105
 DEFAULT_GENERATE_RATE_LIMIT = 5
 DEFAULT_GENERATE_WINDOW_SECONDS = 60
+DEFAULT_NEWSLETTER_RATE_LIMIT = 5
+DEFAULT_NEWSLETTER_WINDOW_SECONDS = 60
 DEFAULT_PROTECTED_RATE_LIMIT = 30
 DEFAULT_PROTECTED_WINDOW_SECONDS = 60
 DEFAULT_GENERATE_MAX_BODY_BYTES = 32 * 1024
+_QUOTA_ABUSE_TRACKER_MAXLEN = 1000
 
 # ---------------------------------------------------------------------------
 # Scope constants
@@ -144,6 +158,69 @@ class _TokenConfig:
     value: str
     scopes: frozenset[str]
     label: str
+
+
+@dataclass(frozen=True)
+class AbuseEvent:
+    """A single rate-limit violation event recorded for ops observability."""
+
+    timestamp: str  # ISO-8601 UTC
+    client_id: str  # IP or X-Forwarded-For first segment
+    path: str  # request path that triggered the limit
+    retry_after_seconds: int
+
+
+class _QuotaAbuseTracker:
+    """Thread-safe bounded ring buffer for rate-limit violation events.
+
+    Stored in ``app.extensions["quota_abuse_tracker"]`` by
+    ``configure_access_control()``.  The ``/api/ops/quota-abuse`` endpoint
+    reads from it without importing this class directly.
+    """
+
+    def __init__(self, maxlen: int = _QUOTA_ABUSE_TRACKER_MAXLEN) -> None:
+        self._lock = threading.Lock()
+        self._events: deque[AbuseEvent] = deque(maxlen=maxlen)
+        self._total: int = 0  # cumulative count, not capped by maxlen
+
+    def record(self, event: AbuseEvent) -> None:
+        with self._lock:
+            self._events.append(event)
+            self._total += 1
+
+    def recent(self, limit: int = 100) -> list[AbuseEvent]:
+        with self._lock:
+            events = list(self._events)
+        return events[-limit:]
+
+    @property
+    def total_recorded(self) -> int:
+        with self._lock:
+            return self._total
+
+
+def _record_abuse_event(
+    tracker: _QuotaAbuseTracker,
+    client_id: str,
+    path: str,
+    retry_after_seconds: int,
+) -> None:
+    """Log and record a rate-limit violation event."""
+    timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    LOGGER.warning(
+        "abuse.rate_limit_exceeded path=%s client=%s retry_after_seconds=%d",
+        path,
+        client_id,
+        retry_after_seconds,
+    )
+    tracker.record(
+        AbuseEvent(
+            timestamp=timestamp,
+            client_id=client_id,
+            path=path,
+            retry_after_seconds=retry_after_seconds,
+        )
+    )
 
 
 def _resolve_all_token_configs(
@@ -265,6 +342,8 @@ def configure_access_control(
     prefixes: tuple[str, ...] = _PROTECTED_PREFIXES,
     generate_rate_limit: int = DEFAULT_GENERATE_RATE_LIMIT,
     generate_window_seconds: int = DEFAULT_GENERATE_WINDOW_SECONDS,
+    newsletter_rate_limit: int = DEFAULT_NEWSLETTER_RATE_LIMIT,
+    newsletter_window_seconds: int = DEFAULT_NEWSLETTER_WINDOW_SECONDS,
     protected_rate_limit: int = DEFAULT_PROTECTED_RATE_LIMIT,
     protected_window_seconds: int = DEFAULT_PROTECTED_WINDOW_SECONDS,
     generate_max_body_bytes: int = DEFAULT_GENERATE_MAX_BODY_BYTES,
@@ -277,13 +356,20 @@ def configure_access_control(
     all worker processes enforce a single consistent limit.  When ``None`` (or
     when Redis is unavailable at request time), each process falls back to its
     own in-process ``SlidingWindowRateLimiter``.
+
+    Rate-limit violations on generation endpoints are recorded in
+    ``app.extensions["quota_abuse_tracker"]`` for ops observability.
     """
     env = environ or os.environ
     generate_limiter = RedisRateLimiter(get_redis=get_redis_conn)
+    newsletter_limiter = RedisRateLimiter(get_redis=get_redis_conn)
     protected_limiter = RedisRateLimiter(get_redis=get_redis_conn)
+    abuse_tracker = _QuotaAbuseTracker()
     app.extensions.setdefault("request_limiters", {})
     app.extensions["request_limiters"]["generate"] = generate_limiter
+    app.extensions["request_limiters"]["newsletter"] = newsletter_limiter
     app.extensions["request_limiters"]["protected"] = protected_limiter
+    app.extensions["quota_abuse_tracker"] = abuse_tracker
 
     @app.before_request  # type: ignore[untyped-decorator]
     def require_admin_api_token() -> ResponseReturnValue | None:
@@ -309,8 +395,33 @@ def configure_access_control(
                 window_seconds=generate_window_seconds,
             )
             if not decision.allowed:
+                _record_abuse_event(
+                    abuse_tracker,
+                    client_identifier,
+                    request.path,
+                    decision.retry_after_seconds,
+                )
                 return _rate_limit_response(
                     message="Generate rate limit exceeded",
+                    retry_after_seconds=decision.retry_after_seconds,
+                )
+            return None
+
+        if request.path == "/newsletter":
+            decision = newsletter_limiter.check(
+                f"newsletter:{client_identifier}",
+                limit=newsletter_rate_limit,
+                window_seconds=newsletter_window_seconds,
+            )
+            if not decision.allowed:
+                _record_abuse_event(
+                    abuse_tracker,
+                    client_identifier,
+                    request.path,
+                    decision.retry_after_seconds,
+                )
+                return _rate_limit_response(
+                    message="Newsletter rate limit exceeded",
                     retry_after_seconds=decision.retry_after_seconds,
                 )
             return None

--- a/web/app.py
+++ b/web/app.py
@@ -32,6 +32,7 @@ from web.routes_newsletter_html import register_newsletter_html_route
 from web.routes_ops import register_ops_routes
 from web.routes_ops_dedupe_stats import register_dedupe_stats_routes
 from web.routes_ops_failed_jobs import register_failed_jobs_routes
+from web.routes_ops_quota_abuse import register_quota_abuse_routes
 from web.routes_ops_schedule_drift import register_schedule_drift_routes
 from web.routes_presets import register_preset_routes
 from web.routes_send_email import register_send_email_route
@@ -169,6 +170,7 @@ def _register_routes(app: Flask) -> None:
     register_failed_jobs_routes(app, DATABASE_PATH)
     register_schedule_drift_routes(app, DATABASE_PATH)
     register_dedupe_stats_routes(app, DATABASE_PATH)
+    register_quota_abuse_routes(app, DATABASE_PATH)
     register_send_email_route(app, DATABASE_PATH)
     register_approval_routes(app, DATABASE_PATH)
     register_email_api_routes(app)

--- a/web/routes_ops_quota_abuse.py
+++ b/web/routes_ops_quota_abuse.py
@@ -1,0 +1,82 @@
+"""Operational route for quota and rate-limit abuse observability.
+
+Exposes aggregated rate-limit violation events recorded by the
+``_QuotaAbuseTracker`` that ``configure_access_control()`` attaches to
+``app.extensions["quota_abuse_tracker"]``.  Protected under the standard
+``/api/ops`` prefix (requires ``SCOPE_OPS`` token).
+
+The tracker is in-process and resets on restart.  It is not persisted to the
+database.  For persistent audit logs, correlate with the structured WARNING
+lines emitted by ``access_control._record_abuse_event``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Flask, current_app, jsonify
+from flask.typing import ResponseReturnValue
+
+try:
+    from ops_logging import log_exception, log_info
+except ImportError:  # pragma: no cover
+    from web.ops_logging import log_exception, log_info
+
+logger = logging.getLogger("web.routes_ops_quota_abuse")
+
+
+def register_quota_abuse_routes(app: Flask, database_path: str) -> None:
+    """Register quota/abuse visibility routes on the given Flask app.
+
+    ``database_path`` is accepted for API consistency with other route
+    registration functions but is not used — events are in-memory only.
+    """
+
+    @app.route("/api/ops/quota-abuse", methods=["GET"])  # type: ignore[untyped-decorator]
+    def ops_quota_abuse() -> ResponseReturnValue:
+        """Return recent rate-limit violation events and summary statistics."""
+        try:
+            tracker = current_app.extensions.get("quota_abuse_tracker")
+            if tracker is None:
+                return jsonify(
+                    {
+                        "events": [],
+                        "summary": {
+                            "returned": 0,
+                            "total_recorded": 0,
+                            "tracker_enabled": False,
+                        },
+                    }
+                )
+
+            events = tracker.recent(limit=100)
+            payload = {
+                # most-recent first so operators see the latest violations at top
+                "events": [
+                    {
+                        "timestamp": e.timestamp,
+                        "client_id": e.client_id,
+                        "path": e.path,
+                        "retry_after_seconds": e.retry_after_seconds,
+                    }
+                    for e in reversed(events)
+                ],
+                "summary": {
+                    "returned": len(events),
+                    "total_recorded": tracker.total_recorded,
+                    "tracker_enabled": True,
+                },
+            }
+            log_info(
+                logger,
+                "ops.quota_abuse.listed",
+                returned=len(events),
+                total_recorded=tracker.total_recorded,
+            )
+            return jsonify(payload)
+        except Exception as exc:
+            log_exception(logger, "ops.quota_abuse.list_failed", exc)
+            return (
+                jsonify({"error": f"Quota abuse listing failed: {exc}"}),
+                500,
+            )


### PR DESCRIPTION
## Summary (what / why)

두 생성 엔드포인트(`/api/generate`, `/newsletter`)의 quota 정책 강화 및 abuse 가시성 확보.

- `/newsletter` GET에 슬라이딩 윈도우 rate limit 추가 (기존: 무제한 → 5 req/60s per IP)
- 429 발생 시 구조화된 WARNING 로그 + in-memory `_QuotaAbuseTracker` 기록
- `GET /api/ops/quota-abuse` 엔드포인트 추가 (SCOPE_OPS): 최근 위반 이벤트 + 통계 제공
- 기존 RR-26/27 인프라(RedisRateLimiter, 스코프 토큰 인증) 재사용

## Scope

- `web/access_control.py` — `AbuseEvent`, `_QuotaAbuseTracker` 추가; `/newsletter` rate limit; abuse 이벤트 로깅
- `web/routes_ops_quota_abuse.py` (신규) — `/api/ops/quota-abuse` ops 엔드포인트
- `web/app.py` — `register_quota_abuse_routes` 등록
- `tests/unit_tests/test_web_quota_abuse.py` (신규) — 12개 단위 테스트

## Delivery Unit

RR: #209
Delivery Unit ID: DU-20260413-quota-abuse-observability
Merge Boundary: 단일 PR, 단일 squash commit
Rollback Boundary: 이 커밋 revert (schema 변경 없음, 기존 ext 키 추가만)

## Test & Evidence

```
pytest tests/unit_tests/test_web_quota_abuse.py -v
# 12 passed

pytest tests/unit_tests/test_web_access_control.py tests/unit_tests/test_web_redis_rate_limiter.py -v
# 39 passed (no regressions)
```

커버리지: `access_control.py` 86%, `routes_ops_quota_abuse.py` 86%

## Risk & Rollback

- **위험**: 낮음. 신규 파라미터 기본값이 기존 동작과 동일 (5/60s). in-process tracker 는 재시작 시 초기화되므로 상태 누적 위험 없음. Redis 없이도 in-process fallback 동작.
- **롤백**: `git revert 793c6bf`. DB schema 변경 없으므로 즉시 롤백 가능.

## Ops-Safety Addendum (if touching protected paths)

- `access_control.py`의 `before_request` 훅 수정: `/newsletter` 경로 추가. 기존 `/api/generate` 경로 로직 변경 없음 (abuse logging 추가만).
- 신규 `/api/ops/quota-abuse`는 `SCOPE_OPS` 토큰 필요 (기존 `_ROUTE_SCOPE_MAP`의 `/api/ops` prefix 자동 적용).
- `app.extensions["quota_abuse_tracker"]`: 기존 `request_limiters` 딕셔너리와 동일한 패턴으로 추가.
- ops 엔드포인트 없는 토큰(data/schedule/email scope)으로 접근 시 403 반환 (테스트로 검증).

## Not Run (with reason)

- Integration tests: Redis 의존성 없이 unit 테스트로 동등 커버리지 확보
- E2E browser tests: 해당 엔드포인트는 JSON API, 브라우저 UI 없음