### PR TITLE
docs: redefine shim-deprecation-schedule to CHANGELOG versioning

### DIFF
--- a/docs/technical/shim-deprecation-schedule.md
+++ b/docs/technical/shim-deprecation-schedule.md
@@ -5,24 +5,91 @@
 - Primary shim entrypoint: `newsletter/api.py`.
 
 ## Policy
-- Grace window: next 2 official release tags after introduction.
-- Removal point: third official release tag after introduction.
-- Introduction point: `2026-02-22` stack merge (`PR-0` ~ `PR-5`).
 
-## Release-tag timeline
+### Version basis (updated 2026-04-13)
+The removal schedule counts **CHANGELOG versions**, not git tags.
+Git tags were not cut for the early 0.7.x releases, so the schedule is anchored
+to documented CHANGELOG entries instead.
+
+| Label | CHANGELOG version | Date | Status |
+|---|---|---|---|
+| N (introduced) | 0.7.0 | 2026-02-22 | complete |
+| N+1 | 0.8.0 | 2026-02-23 | complete |
+| N+2 | 0.9.0 | TBD | upcoming — shim consumer migration target |
+| N+3 | 1.0.0 | TBD | **shim removal cut** |
+
+### Release-tag timeline (original)
 1. `N` (introduced): warnings enabled, behavior fully backward compatible.
 2. `N+1`: keep shims, block new direct imports of deprecated paths and freeze the `newsletter/` Python surface.
 3. `N+2`: keep shims, migration completion target for remaining consumers.
 4. `N+3`: remove shim modules and deprecated import paths.
 
+## Removal Progress
+
+### Step 1 — Completed (PR #404, commit 91ff2de, 2026-04-13)
+
+**Deleted files (zero live-import, pure shims):**
+- `newsletter/collect.py` — 3-line wildcard re-export to `newsletter_core.application.generation.collect`
+- `newsletter/summarize.py` — 3-line wildcard re-export to `newsletter_core.application.generation.summarize`
+- `newsletter/main.py` — deprecated FastAPI entrypoint (DeprecationWarning at import)
+
+**Associated cleanup:**
+- `scripts/devtools/pyinstaller_hooks/hook-newsletter.py` — removed 3 module strings
+- `web/binary_compatibility.py` — removed `newsletter.collect` module check string
+- `newsletter/cli.py` — migrated `from . import collect` to `newsletter_core.application.generation`; removed unused `from . import summarize`
+- `newsletter/cli_test.py` — migrated `from . import collect` to `newsletter_core.application.generation`
+
+### Step 2 — Target: N+2 (0.9.0)
+
+Files with active consumers that require migration before removal:
+
+| File | Consumer | Replacement path |
+|---|---|---|
+| `newsletter/api.py` | `tests/contract/test_generation_facade.py` (intentional deprecation test) | Delete test with shim |
+| `newsletter/compose.py` | `tests/unit_tests/test_compose_contract_lock.py` (contract lock test) | Delete test with shim |
+| `newsletter/deliver.py` | `tests/api_tests/test_email_integration.py:35` (integration test) | `newsletter_core.application.generation.deliver` |
+
+### Step 3 — Target: N+3 (1.0.0)
+
+Files requiring production-code migration before removal:
+
+| File | Consumer(s) | Migration effort |
+|---|---|---|
+| `web/platform_adapter.py` | `web/app.py:77` + 1 unit test | Low — swap to `newsletter_core.public.platform` |
+| `newsletter/config.py` | `newsletter_core` internal imports in collect/summarize/deliver modules (3 files) | Medium — update newsletter_core internals |
+| `newsletter/compat_env.py` | migration utility; depends on `config.py` being stable | Blocked by config.py migration |
+| `newsletter/settings.py` | `LegacySettings` wrapper; depends on `centralized_settings` | Blocked by config.py migration |
+| `web/runtime_paths.py` | `web/app.py:40`, `web/init_database.py`, `web/schedule_runner.py`, `web/tasks.py`, `web/newsletter_clients.py` (fallback) | High — ops-safety paths; requires separate PR |
+
+### Long-term roadmap (not on N+3 schedule)
+
+These are **maintenance-mode hotspots**, not pure shims. They contain
+original orchestration logic and require a separate migration plan:
+
+| File | Role | Extracted to |
+|---|---|---|
+| `newsletter/llm_factory.py` | Provider/fallback/runtime config shell | `newsletter_core/application/llm_factory*`, `infrastructure/llm_factory_runtime.py` |
+| `newsletter/graph.py` | Legacy LangGraph orchestration shell | `newsletter_core/application/graph_workflow*`, `graph_node_helpers*`, `graph_composition*` |
+| `newsletter/tools.py` | `@tool`-decorated search/delivery helpers | `newsletter_core/application/tools_search_flow*`, `tools_support*`, `infrastructure/tools_search_runtime*` |
+
 ## Enforcement checklist
 - CI boundary check keeps `web -> newsletter` forbidden.
 - CI legacy surface guard keeps new Python modules from landing under `newsletter/`.
 - Deprecated path usage tracked by grep:
-  - `rg "newsletter\\.api|newsletter\\.(collect|summarize|compose|deliver)" -n`
-- Before `N+3` cut:
-  - no runtime consumer depends on shim path
-  - contract/integration tests pass without shim-only imports
+  - `rg "newsletter\.api|newsletter\.(collect|summarize|compose|deliver)" -n`
+  - **Also check relative imports:** `rg "from \. import (collect|summarize|compose|deliver|main)" -n`
+
+## Analysis notes
+
+### Relative import blind spot (discovered 2026-04-13)
+Searching only for absolute import patterns (`from newsletter.X import` / `import newsletter.X`)
+misses relative imports within the same package (`from . import X`).
+Before removing any shim, run **both** searches:
+1. Absolute: `rg "from newsletter\.X import|import newsletter\.X" -n`
+2. Relative: `rg "from \. import X" -n` (within the `newsletter/` package)
+
+This was discovered during Step 1 — `newsletter/cli.py` and `newsletter/cli_test.py`
+used `from . import collect` and `from . import summarize`, which the initial grep missed.
 
 ## Ownership
 - Architecture policy owner: `CODEOWNERS` (`apps/**`, `newsletter_core/**`, `scripts/architecture/**`).


### PR DESCRIPTION
## Summary (what / why)
- git 태그가 없는 현실에 맞게 shim-deprecation-schedule의 버전 기준을 CHANGELOG 버전으로 재정의
- Step 1 완료 내역(PR #404) 및 잔여 제거 대상을 기점별로 문서화
- 상대 import 분석 주의사항(Step 1에서 발견된 blind spot) 추가

## Scope
### In Scope
- `docs/technical/shim-deprecation-schedule.md` 전면 업데이트
  - 버전 기준: git tag → CHANGELOG 버전 (N=0.7.0, N+1=0.8.0, N+2=0.9.0, N+3=1.0.0)
  - Step 1 완료 내역 반영 (7개 파일, PR #404, 커밋 91ff2de)
  - Step 2 대상 (N+2 / 0.9.0): api.py, compose.py, deliver.py
  - Step 3 대상 (N+3 / 1.0.0): platform_adapter.py, config.py 그룹, runtime_paths.py
  - maintenance-mode hotspot 별도 장기 로드맵 섹션 분리

### Out of Scope
- 코드 변경 없음 (문서만)

## Delivery Unit
RR: #405
Delivery Unit ID: DU-20260413-shim-deprecation-schedule-redefine
Merge Boundary: shim-deprecation-schedule.md 업데이트 완료, make check 통과
Rollback Boundary: git revert 1 commit

## Test & Evidence
- [x] `make check`
- [ ] `make check-full`
- [ ] GitHub required checks green before merge
- [ ] Additional tests (if needed):

### Commands and Results
```bash
make check  # ✅ 전체 통과 (docs-quality, markdown link check 포함)
```

## Risk & Rollback
- Risk: Low — 문서 변경만, 코드 영향 없음
- Rollback: `git revert <merge-commit>`

## Ops-Safety Addendum (if touching protected paths)
- 해당 없음 — 문서 변경만

## Not Run (with reason)
- `make check-full`: CI에서 실행 예정. 문서 전용 변경으로 풀 테스트 수행 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)