### PR TITLE
chore(deps): raise langchain-* floors to installed versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,10 @@ dependencies = [
     "redis>=5.0.0",
     "rq>=1.15.0",
     "sentry-sdk[flask]>=1.38.0",
-    "langchain>=0.1.0",
-    "langchain-openai>=0.0.5",
-    "langchain-anthropic>=0.1.0",
-    "langchain-google-genai>=1.0.0",
+    "langchain>=0.3.27",
+    "langchain-openai>=0.3.35",
+    "langchain-anthropic>=0.3.22",
+    "langchain-google-genai>=2.1.4",
     "postmarker>=0.21.3",
 ]
 


### PR DESCRIPTION
## Summary (what / why)
- langchain-* 런타임 의존성의 `pyproject.toml` lower-bound를 `.local/venv` 에 실제 설치된 버전과 일치시킨다.
- 기존 하한(`>=0.1.0` / `>=0.0.5` / `>=0.1.0` / `>=1.0.0`)은 현재 설치본보다 수 minor 이상 뒤처져 있어, 새 환경에서의 `pip install .` 가 legacy pre-0.3 langchain 릴리스로 resolve 되어 import/런타임 회귀를 유발할 수 있다. 본 변경은 metadata 진실성과 resolver 안정성을 회복한다.

## Scope
- 변경 파일: `pyproject.toml` (1 file, 4 lines)
- 변경 내용:
  - `langchain>=0.1.0` → `>=0.3.27`
  - `langchain-openai>=0.0.5` → `>=0.3.35`
  - `langchain-anthropic>=0.1.0` → `>=0.3.22`
  - `langchain-google-genai>=1.0.0` → `>=2.1.4`

## Delivery Unit
RR: #419
Delivery Unit ID: DU-20260414-langchain-floor-bump
Merge Boundary: single squash-merge of this PR; no cross-PR coupling.
Rollback Boundary: revert of the merge commit fully restores prior metadata.

## Test & Evidence
- Floors 값은 `.local/venv/bin/python -m pip freeze` 결과(`requirements-lock.txt`, 로컬 생성물)에서 추출했다.
- metadata-only 변경이라 런타임 코드 경로는 영향받지 않는다 (설치 세트와 동일한 floor → resolver 결과 동일).
- `make check` / `make check-full` 를 CI에서 실행해 ops-safety 및 contract suite 결과를 확인한다.

## Risk & Rollback
- Risk: **Low**. 순수 metadata 변경. 상한(upper bound) 미추가 → 해상도 공간은 축소가 아니라 하한만 상향.
- Rollback: 해당 squash commit 단독 revert.

## Ops-Safety Addendum (if touching protected paths)
- 보호 경로(`web/app.py`, `web/tasks.py`, `web/schedule_runner.py`, `web/routes_generation.py`, `web/routes_send_email.py`, `newsletter/centralized_settings.py`, `newsletter/config_manager.py`) 변경 없음. 해당 없음.

## Not Run (with reason)
- 별도 수동 테스트 없음. 본 PR은 packaging metadata 전용이므로 CI의 정규 게이트로 충분하다.
- Upper bound 추가는 **의도적으로 본 PR 범위 밖** (후속 RR/PR A-2 에서 처리).