### PR TITLE
chore(deps): pin langchain-* packages to next-minor upper bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,10 @@ dependencies = [
     "redis>=5.0.0",
     "rq>=1.15.0",
     "sentry-sdk[flask]>=1.38.0",
-    "langchain>=0.3.27",
-    "langchain-openai>=0.3.35",
-    "langchain-anthropic>=0.3.22",
-    "langchain-google-genai>=2.1.4",
+    "langchain>=0.3.27,<0.4.0",
+    "langchain-openai>=0.3.35,<0.4.0",
+    "langchain-anthropic>=0.3.22,<0.4.0",
+    "langchain-google-genai>=2.1.4,<2.2.0",
     "postmarker>=0.21.3",
 ]
 


### PR DESCRIPTION
## Summary (what / why)
- langchain-* 4개 런타임 의존성에 **next-minor upper bound** 를 추가하여 `>=` 단독 제약의 공급망 회귀 벡터를 차단한다.
- Upper bound 는 각 패키지의 현재 lower-bound minor + 1 로 계산: `<0.4.0` (langchain / -openai / -anthropic), `<2.2.0` (-google-genai).

## Scope
- 변경 파일: `pyproject.toml` (1 file, 4 lines)
- 변경 내용:
  - `langchain>=0.3.27` → `>=0.3.27,<0.4.0`
  - `langchain-openai>=0.3.35` → `>=0.3.35,<0.4.0`
  - `langchain-anthropic>=0.3.22` → `>=0.3.22,<0.4.0`
  - `langchain-google-genai>=2.1.4` → `>=2.1.4,<2.2.0`

## Delivery Unit
RR: #423
Delivery Unit ID: DU-20260414-langchain-upper-bounds
Merge Boundary: single squash-merge of this PR; 독립적으로 revert 가능.
Rollback Boundary: 단일 커밋 revert — 기존 `>=` 플로어 유지.

## Test & Evidence
- Prerequisite: PR A-1 (#420, 0db7e48) 및 lock file PR (#422, ebb50aa) 이미 main 에 merge 완료.
- Conflict check A (lower-bound vs 최신 안정 버전): 모두 통과 — lower bound 가 latest stable 보다 낮음.
- Conflict check B (upper > lower): 모두 통과.
- 현재 `.local/venv/` 설치 세트는 모든 새 constraint 안에 들어감 (0.3.27 / 0.3.35 / 0.3.22 / 2.1.4 < 각 상한). resolver 결과 불변.
- CI 의 `make check` / `make check-full` 정규 게이트로 검증.

## Risk & Rollback
- Risk: **Low**. 순수 metadata 변경. 현재 설치 세트는 모두 새 상한 아래 — 기존 동작 유지. 아직 릴리스되지 않은 future-minor(>=0.4 / >=2.2) 로의 자동 resolver 상승 경로만 차단.
- Rollback: 단일 squash commit revert.

## Ops-Safety Addendum (if touching protected paths)
- 보호 경로 변경 없음. 해당 없음.

## Not Run (with reason)
- 본 PR 은 packaging metadata 전용이므로 별도 수동 테스트 없음. CI 정규 게이트로 충분.
- Follow-up (이 PR 범위 밖): dependabot weekly config for langchain-* packages.