### PR TITLE
chore(ci): add dependabot weekly config for langchain-* packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # Weekly update PRs for langchain-family runtime dependencies.
+  # Upper bounds (<0.4.0 / <2.2.0) were added in PR #424 to block
+  # resolver-driven regressions; dependabot opens PRs to widen the
+  # allowed range on new minor releases so maintainers can review
+  # the jump rather than silently inherit it.
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Seoul
+    labels:
+      - dependencies
+      - langchain
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+    open-pull-requests-limit: 4
+    allow:
+      - dependency-name: langchain
+      - dependency-name: langchain-openai
+      - dependency-name: langchain-anthropic
+      - dependency-name: langchain-google-genai


### PR DESCRIPTION
## Summary (what / why)
- PR #424 에서 추가한 langchain-* upper bound(`<0.4.0` / `<2.2.0`)는 자동 resolver 회귀를 차단하는 장점이 있으나, 향후 minor 릴리스가 나오면 `pip install .` 이 그 버전을 선택하지 못해 silently stale 해진다.
- 본 PR 은 `.github/dependabot.yml` 을 추가해 dependabot 이 주 1회(Monday 09:00 Asia/Seoul) langchain-* 4개 패키지에 대해서만 PR 을 생성하도록 설정한다 — future minor 가 나오면 검토 가능한 PR 형태로 노출된다.

## Scope
- 신규 파일 1개: `.github/dependabot.yml` (26 lines)
- pip ecosystem, weekly
- `allow` 필드로 scope 를 `langchain`, `langchain-openai`, `langchain-anthropic`, `langchain-google-genai` 로만 제한
- 그 외 파일 변경 없음

## Delivery Unit
RR: #425
Delivery Unit ID: DU-20260414-dependabot-langchain
Merge Boundary: single squash-merge of this PR; 독립적으로 revert 가능.
Rollback Boundary: 단일 커밋 revert — dependabot scheduling 중단.

## Test & Evidence
- YAML 문법 검증: pre-commit `check yaml` 통과 (commit hook).
- 런타임 영향 없음 (CI/bot 구성 전용).
- dependabot 의 실제 PR 생성은 GitHub 측 스케줄러가 처리 (merge 후 첫 월요일 09:00 Asia/Seoul 기준).

## Risk & Rollback
- Risk: **None (runtime)**. 순수 메타/봇 구성.
- Rollback: 단일 squash commit revert.

## Ops-Safety Addendum (if touching protected paths)
- 보호 경로 변경 없음. 해당 없음.

## Not Run (with reason)
- dependabot 작동 자체는 GitHub 서비스 측에서 merge 후 비동기로 시작되므로 PR 범위 내에서는 검증 불가. 첫 주간 PR 생성 여부로 post-merge 확인.