### PR TITLE
docs(readme): align tagline, features, and roadmap with PRD operator-facing positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Deploy Guide (Railway)](https://img.shields.io/badge/deploy-Railway-0B0D0E?logo=railway)](docs/setup/RAILWAY_DEPLOYMENT.md)
 
-Automates turning raw project updates into structured newsletters, reducing maintainer communication overhead.
+Operator-facing workflow system for Korean news curation and newsletter delivery.
 
-Built for open-source maintainers, small teams, and internal technical communication workflows.
+Built for internal operators managing recurring newsletter generation, review, approval, and distribution workflows.
 
-- Turn raw notes into shareable newsletter drafts
-- Reduce time spent on release notes and recurring updates
-- Usable by non-engineers through a web-based workflow
-- Supports cross-platform use and email distribution
+- Collect news by keyword or domain and generate structured HTML newsletters
+- Preview, approve, and send through a web-based operator workflow
+- Schedule recurring runs with retry safety and execution history
+- Distribute via email with deduplication and outbox safety
 
 ## Quick Demo
 Static preview of the default `compact` output shape.
@@ -66,11 +66,11 @@ The production app renders HTML newsletters in `compact`, `detailed`, and `email
 - Communication automation for recurring community digests, stakeholder briefs, and team newsletters
 
 ## Features
-- Automatically summarize raw updates into structured, shareable newsletters
-- Generate clean newsletter drafts that are ready for community or internal distribution
-- Reduce time spent on release notes, status reporting, and recurring update summaries
-- Support email distribution for recurring communication workflows
-- Keep the workflow usable for non-engineers through a web-based, cross-platform experience
+- Collect news from Serper, RSS, and Naver sources by keyword or domain
+- Generate HTML newsletters via AI summarization (LangGraph + multi-LLM pipeline)
+- Preview, approve, and send through a web-based operator workflow
+- Schedule recurring runs with retry safety, deduplication, and execution history
+- Manage presets, source policies, and archive references from the web surface
 
 ## Example Output
 Example of a generated newsletter:
@@ -154,10 +154,12 @@ If the package is installed, the CLI entrypoint is also available as:
 newsletter run --keywords "open source, maintainer tooling"
 ```
 
-## Roadmap
-- GitHub integration for pulling updates directly from repositories
-- Pull request and issue summaries for recurring maintainer digests
-- Release note generation for changelogs and stakeholder updates
+## Current Priorities
+- Maintain stable generate/preview/send/history/schedule flows in the web surface (G1)
+- Keep schedule, approval, preset, and source policy workflows regression-free (G2)
+- Maintain shared core contract across CLI, scheduler, and web via `newsletter_core.public` (G3)
+- Hold legacy runtime surface in maintenance mode — no structural reopening without explicit trigger (G4)
+- Keep operational contracts, support policy, and documentation aligned to the same production reality (G5)
 
 ## Project Docs
 | Purpose | Reference |


### PR DESCRIPTION
## Summary (what / why)

- README tagline, feature bullets, and `## Roadmap` section carried open-source-maintainer / GitHub / release-notes framing that conflicts with the PRD's operator-facing Korean news curation positioning.
- Replaced with language grounded in PRD §1 (product purpose) and G1–G5 (current priorities).
- Renamed `## Roadmap` → `## Current Priorities` to accurately reflect maintenance-mode commitments rather than planned additions.

## Scope

**In scope:** README.md only — lines 11–18 (tagline + top bullets), lines 69–73 (Features body), lines 157–160 (Roadmap section).

**Out of scope (follow-on PR):** L54/L112 example output blocks (GitHub/maintainers framing); `## Use Cases` section (open-source maintainers framing).

## Delivery Unit

RR: #431  
Delivery Unit ID: DU-20260415-readme-operator-positioning  
Merge Boundary: squash-merge to main  
Rollback Boundary: revert commit on main — no runtime impact, docs-only

## Test & Evidence

- `make check` — pre-commit hooks passed at commit time (trim whitespace, EOF, large-files, merge-conflict checks)
- `make check-full` — docs-only change, no Python modules touched; full gate expected to pass
- Conflict mapping table produced in Step 2 (see PR review thread); Step 4/5 self-review gates all PASS

## Risk & Rollback

Risk: none — README.md only, zero runtime impact.  
Rollback: `git revert` the squash commit on main.

## Ops-Safety Addendum (if touching protected paths)

N/A — no protected paths touched.

## Not Run (with reason)

- Ops-safety test suite (`test_web_api.py`, `test_schedule_execution.py`, etc.) — not applicable; no runtime or config files modified.