### PR TITLE
docs: fix remaining operator-positioning expressions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Updates that reduce repetitive maintainer coordination work.
 - **Idempotency key:** A stable request identifier used to prevent duplicate jobs or duplicate email sends.
 
 ## 💡 Things to Watch
-> If GitHub issue and pull request summaries are added next, maintainers can publish weekly updates with much less manual editing.
+> Operators managing recurring digests can reduce review time by refining keyword sets and source policies as coverage patterns stabilize.
 ```
 
 ## Overview
@@ -60,7 +60,7 @@ Maintainers and teams spend significant time summarizing updates and rewriting i
 The production app renders HTML newsletters in `compact`, `detailed`, and `email_compatible` styles. This README keeps a static English preview of the default `compact` structure so first-time visitors can understand the real layout quickly; the shipped production templates in this repository are currently Korean-oriented. This repository also keeps the operational guidance that matters for real use: support policy, environment-variable contracts, local setup, deployment references, and verification gates.
 
 ## Use Cases
-- Open-source maintainers sending weekly or monthly project updates to contributors and users
+- Operators managing recurring keyword-based newsletter generation, review, and distribution
 - Small teams sharing cross-functional progress without asking engineers to hand-write summaries
 - Internal teams sharing domain-specific technical updates across product, platform, and operations groups
 - Communication automation for recurring community digests, stakeholder briefs, and team newsletters
@@ -109,7 +109,7 @@ Improvements that make updates easier to consume across community and internal a
 - **Docs gate:** An automated check that verifies documentation links, required references, and policy consistency.
 
 ## 💡 Things to Watch
-> If GitHub issue and pull request summaries are added next, maintainers can publish weekly updates with much less manual editing.
+> Operators managing recurring digests can reduce review time by refining keyword sets and source policies as coverage patterns stabilize.
 
 _Generated as an English compact preview of the production newsletter template._
 ```


### PR DESCRIPTION
## Summary (what / why)

- Follow-on to #432. Three lines retained GitHub/PR-summaries/maintainers language after the main operator-positioning pass.
- L54 (Quick Demo Things to Watch) and L112 (Example Output Things to Watch) both contained "GitHub issue and pull request summaries" and "maintainers" — replaced with operator-facing language referencing keyword sets, source policies, and recurring digests.
- L63 (Use Cases) contained "Open-source maintainers sending weekly or monthly project updates" — replaced with "Operators managing recurring keyword-based newsletter generation, review, and distribution."

## Scope

**In scope:** README.md only — L54, L112 (Things to Watch blockquotes), L63 (Use Cases bullet).

**Out of scope:** L42/L88 (newsletter body text inside example code blocks), L118 (Why This Matters), CLI keyword examples — not positioning claims, left for a separate pass if needed.

## Delivery Unit

RR: #433  
Delivery Unit ID: DU-20260415-readme-followup-expressions  
Merge Boundary: squash-merge to main  
Rollback Boundary: revert commit on main — no runtime impact, docs-only

## Test & Evidence

- `make check` passed: Black, isort, Flake8, import boundary, link integrity, style, newsletter-smoke, web-source-smoke, schedule tests all pass
- pre-commit hooks passed at commit time
- Grep confirms zero remaining instances of "GitHub issue and pull request summaries" or "open-source maintainers" / "Open-source maintainers" in README

## Risk & Rollback

Risk: none — README.md only, no runtime impact.  
Rollback: `git revert` the squash commit on main.

## Ops-Safety Addendum (if touching protected paths)

N/A — no protected paths touched.

## Not Run (with reason)

- Ops-safety test suite — not applicable; no runtime or config files modified.