### PR TITLE
docs(web-api): fix /schedule/<id>/run response code 202 → 200

### DIFF
--- a/docs/reference/web-api.md
+++ b/docs/reference/web-api.md
@@ -80,6 +80,12 @@ source runtime contract와 API 예제의 기준 포트는 `8000`입니다.
 ### `POST /api/schedule/<schedule_id>/run`
 스케줄 즉시 실행.
 
+응답:
+- `200`: `{ "job_id": "...", "status": "queued|completed", "idempotency_key": "..." }`
+- `400`: 스케줄 비활성화 상태
+- `404`: 스케줄 없음
+- `500`: 실행 실패
+
 ### `GET /api/newsletter-html/<job_id>`
 완료된 작업의 HTML 본문 직접 반환 (`text/html`).
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,6 +6,6 @@
     - POST /generate → 202 (first call)
     - POST /generate → 202 + dedup flag (duplicate)
     - POST /generate → 400 (missing required field)
-    - POST /schedule/<id>/run → 202 (immediate execution)
+    - POST /schedule/<id>/run → 200 (immediate execution)
 - 제약: 신규 파일만, 소스 코드 및 기존 테스트 파일 수정 없음
 - 패턴 참조: tests/contract/test_web_email_routes_contract.py


### PR DESCRIPTION
## Summary (what / why)

- `docs/reference/web-api.md`의 `POST /api/schedule/<schedule_id>/run` 엔드포인트에 응답 코드가 미기재되어 있었음
- 실제 핸들러(`web/routes_generation.py` L996)는 Flask 기본 HTTP 200을 반환
- 계약 테스트(`test_generation_routes_contract.py` L156)에서 `assert response.status_code == 200` 검증됨
- docs truthfulness(PRD G5) 유지 목적으로 200/400/404/500 응답 코드 섹션 추가

## Scope

- `docs/reference/web-api.md` — 응답 코드 섹션 추가
- `tasks/todo.md` — 잔존하던 202 오기재 수정
- 소스 코드, 테스트, 설정 파일 변경 없음

## Delivery Unit

RR: #441
Delivery Unit ID: DU-20260415-schedule-run-response-code-doc
Merge Boundary: 단일 커밋, docs 전용 변경
Rollback Boundary: `git revert 3d82cac` 으로 즉시 복원 가능

## Test & Evidence

- `python3 scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json` → warnings=0
- 계약 테스트 기존 통과: `assert response.status_code == 200` (변경 없음)
- 소스 직접 확인: `web/routes_generation.py` L996 `return jsonify(...)` → Flask 기본 200

## Risk & Rollback

- Risk: None — docs 전용, 소스/테스트 변경 없음
- Rollback: `git revert 3d82cac`

## Ops-Safety Addendum (if touching protected paths)

해당 없음 — 보호 경로 미접촉

## Not Run (with reason)

- 전체 test suite 미실행 — docs 전용 변경으로 소스 영향 없음
- CI 자동 게이트에서 확인 예정