### PR TITLE
docs(lessons): add branch-prefix and __init__.py rules

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -52,3 +52,63 @@ PR #434 (docs/readme-operator-positioning)
 파일 일부만 커밋해야 하는 모든 작업에 적용.
 특히 큰 파일(README.md, routes_generation.py 등)의
 부분 수정 시 필수.
+
+## LESSON-002: test/ 브랜치 prefix 는 CI 에서 허용되지 않는다
+
+### 발생 시점
+PR 계획 단계 (2026-04-15, 브랜치 생성 전 prefix 점검 과정에서 식별)
+
+### 무슨 일이 있었나
+- 브랜치명에 test/ prefix 사용 시도
+- CI branch-name policy 가 허용 prefix 를 `feat|fix|chore|docs|refactor|release|codex` 로
+  제한하며, test/ 는 이 목록에 포함되지 않음
+- 결과: CI branch-name gate 실패
+
+### 근본 원인
+- CLAUDE.md Workflow Contract 에 허용 prefix 목록이 명시되어 있으나
+  브랜치 생성 전 확인하지 않음
+- test/ 는 직관적으로 허용될 것처럼 보이나 실제로는 chore/ 로 대체해야 함
+
+### 올바른 지시 패턴
+브랜치 생성 전 항상 허용 prefix 목록 확인:
+
+  # 허용 목록 (CLAUDE.md Workflow Contract)
+  feat | fix | chore | docs | refactor | release | codex
+
+  # 나쁜 예
+  git checkout -b test/my-feature
+
+  # 좋은 예
+  git checkout -b chore/my-feature
+
+### 적용 범위
+모든 브랜치 생성 시 적용. 특히 테스트 관련 작업은 chore/ 사용.
+
+## LESSON-003: 신규 디렉토리 추가 시 __init__.py 를 즉시 추가해야 한다
+
+### 발생 시점
+PR 계획 단계 (2026-04-15, Step 6 pre-write checklist 항목으로 식별)
+
+### 무슨 일이 있었나
+- Python 패키지 디렉토리를 신규 생성했으나 __init__.py 누락
+- 해당 디렉토리가 implicit namespace package 로 처리되어
+  다른 패키지와 namespace 충돌 또는 import 오류 발생
+
+### 근본 원인
+- Python 3 의 implicit namespace package 기능으로 인해
+  __init__.py 없이도 디렉토리가 패키지처럼 동작
+- 그러나 기존 패키지와 동일 namespace 를 공유할 경우 예측 불가한 import 충돌
+
+### 올바른 지시 패턴
+신규 디렉토리 생성 직후 __init__.py 를 함께 추가:
+
+  # 나쁜 예
+  mkdir newsletter_core/new_module/
+  # __init__.py 없이 진행
+
+  # 좋은 예
+  mkdir newsletter_core/new_module/
+  touch newsletter_core/new_module/__init__.py
+
+### 적용 범위
+newsletter_core/, newsletter/, web/ 하위 모든 신규 디렉토리 추가 시 필수.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -9,3 +9,7 @@
     - POST /schedule/<id>/run → 200 (immediate execution)
 - 제약: 신규 파일만, 소스 코드 및 기존 테스트 파일 수정 없음
 - 패턴 참조: tests/contract/test_web_email_routes_contract.py
+
+## Lessons 정비
+- [x] tasks/lessons.md 에 LESSON-002 (test/ prefix 불허) 추가
+- [x] tasks/lessons.md 에 LESSON-003 (__init__.py 필수) 추가


### PR DESCRIPTION
## Summary (what / why)

- `tasks/lessons.md`에 두 가지 미기록 교훈 항목 공식 추가
- LESSON-002: `test/` 브랜치 prefix 는 CI에서 허용되지 않음 (`chore/` 사용)
- LESSON-003: 신규 Python 디렉토리 생성 시 `__init__.py` 즉시 추가 필요
- PRD G5 (docs truthfulness 유지) 목적

## Scope

- `tasks/lessons.md` — LESSON-002, LESSON-003 추가
- `tasks/todo.md` — 해당 작업 완료 항목 추가
- 소스 코드, 설정 파일, 테스트 변경 없음

## Delivery Unit

RR: #443
Delivery Unit ID: DU-20260415-lessons-branch-prefix-init
Merge Boundary: 단일 커밋, docs 전용 변경
Rollback Boundary: `git revert 2a58ecc` 으로 즉시 복원 가능

## Test & Evidence

- `python3 scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json` → warnings=0
- 기존 lessons 형식(발생 시점/무슨 일/근본 원인/올바른 지시 패턴) 준수 확인
- Step 4 체크리스트 5/5 PASS
- Step 5 adversarial review: No issues found

## Risk & Rollback

- Risk: None — docs 전용, 소스/테스트 변경 없음
- Rollback: `git revert 2a58ecc`

## Ops-Safety Addendum (if touching protected paths)

해당 없음 — 보호 경로 미접촉

## Not Run (with reason)

- 전체 test suite 미실행 — docs 전용 변경으로 소스 영향 없음
- CI 자동 게이트에서 확인 예정