### PR TITLE
docs(env): add block sections and Required/Optional labels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,73 +3,72 @@
 # Canonical Flask/CLI runtime sample. Experimental FastAPI settings live in
 # apps/experimental/.env.example.
 
-# Application Environment (canonical)
-APP_ENV=development
+# ── APP ENVIRONMENT ──
+APP_ENV=development  # Optional: canonical env flag (development / testing / production)
 
-# Optional compatibility aliases for legacy fallback paths
-# FLASK_ENV=development
-# ENVIRONMENT=development
-# DEBUG=true
+# Compatibility aliases — use APP_ENV instead; keep in sync when set
+# FLASK_ENV=development    # Optional (compat): legacy web entrypoint toggle
+# ENVIRONMENT=development  # Optional (compat): legacy logging/security fallback
+# DEBUG=true               # Optional: dev-only debug flag
 
-# Server Configuration
-HOST=0.0.0.0
-PORT=8000
-LOG_LEVEL=INFO
-LOG_FORMAT=standard
+# ── SERVER ──
+HOST=0.0.0.0        # Optional: web bind host
+PORT=8000           # Optional: web port (Windows EXE compatibility default: 5000)
+LOG_LEVEL=INFO      # Optional: runtime log level
+LOG_FORMAT=standard # Optional: log format (standard / json)
 
-# Web / Ops
-SECRET_KEY=change-this-in-production
+# ── WEB / OPS ──
+SECRET_KEY=change-this-in-production  # Required in production: Flask session signing key
 # Root token — grants all scopes (data, schedule, email, ops). Fully backward-compatible.
-ADMIN_API_TOKEN=replace-me-with-an-ops-token
+ADMIN_API_TOKEN=replace-me-with-an-ops-token  # Required: protects all API scopes
 # Scoped tokens — each grants access only to the named scope.
 # Prefer scoped tokens in production to limit blast radius if a token leaks.
-# ADMIN_API_TOKEN_DATA=replace-me-with-a-data-token
-# ADMIN_API_TOKEN_SCHEDULE=replace-me-with-a-schedule-token
-# ADMIN_API_TOKEN_EMAIL=replace-me-with-an-email-token
-# ADMIN_API_TOKEN_OPS=replace-me-with-an-ops-token
-ALLOWED_ORIGINS=http://localhost:3000,https://yourdomain.com
+# ADMIN_API_TOKEN_DATA=replace-me-with-a-data-token         # Optional: data scope only
+# ADMIN_API_TOKEN_SCHEDULE=replace-me-with-a-schedule-token # Optional: schedule scope only
+# ADMIN_API_TOKEN_EMAIL=replace-me-with-an-email-token      # Optional: email scope only
+# ADMIN_API_TOKEN_OPS=replace-me-with-an-ops-token          # Optional: ops scope only
+ALLOWED_ORIGINS=http://localhost:3000,https://yourdomain.com  # Optional: CORS allow-list
 
-# API Keys (Required for functionality)
-SERPER_API_KEY=your-serper-api-key
-OPENAI_API_KEY=your-openai-api-key
-ANTHROPIC_API_KEY=your-anthropic-api-key
-GEMINI_API_KEY=your-gemini-api-key
+# ── SEARCH & LLM ──
+# At least one LLM key is required for generation
+SERPER_API_KEY=your-serper-api-key        # Optional (Required for Serper-based news search)
+OPENAI_API_KEY=your-openai-api-key        # Required (≥1 of: OPENAI / ANTHROPIC / GEMINI)
+ANTHROPIC_API_KEY=your-anthropic-api-key  # Required (≥1 of: OPENAI / ANTHROPIC / GEMINI)
+GEMINI_API_KEY=your-gemini-api-key        # Required (≥1 of: OPENAI / ANTHROPIC / GEMINI)
 
-# Email Configuration
-POSTMARK_SERVER_TOKEN=your-postmark-server-token
-EMAIL_SENDER=noreply@yourdomain.com
+# ── EMAIL / DELIVERY ──
+POSTMARK_SERVER_TOKEN=your-postmark-server-token  # Required for email sending
+EMAIL_SENDER=noreply@yourdomain.com               # Required for email sending
 
-# Google Integration (Optional)
-GOOGLE_APPLICATION_CREDENTIALS=path/to/google-credentials.json
-GOOGLE_CLIENT_ID=your-google-client-id
-GOOGLE_CLIENT_SECRET=your-google-client-secret
+# ── GOOGLE INTEGRATION ──
+GOOGLE_APPLICATION_CREDENTIALS=path/to/google-credentials.json  # Optional: Google Drive
+GOOGLE_CLIENT_ID=your-google-client-id      # Optional: Google OAuth
+GOOGLE_CLIENT_SECRET=your-google-client-secret  # Optional: Google OAuth
 
-# Naver API (Optional)
-NAVER_CLIENT_ID=your-naver-client-id
-NAVER_CLIENT_SECRET=your-naver-client-secret
+# ── NAVER API ──
+NAVER_CLIENT_ID=your-naver-client-id        # Optional: Naver news search
+NAVER_CLIENT_SECRET=your-naver-client-secret  # Optional: Naver news search
 
-# LangSmith (Optional)
-LANGCHAIN_API_KEY=your-langsmith-api-key
-LANGCHAIN_TRACING_V2=1
-LANGCHAIN_PROJECT=your-langsmith-project
-ENABLE_COST_TRACKING=false
-DEBUG_COST_TRACKING=false
+# ── LANGSMITH / OBSERVABILITY ──
+LANGCHAIN_API_KEY=your-langsmith-api-key    # Optional: LangSmith tracing
+LANGCHAIN_TRACING_V2=1                      # Optional: enable LangSmith tracing
+LANGCHAIN_PROJECT=your-langsmith-project    # Optional: tracing project name
+ENABLE_COST_TRACKING=false                  # Optional: provider cost callback
+DEBUG_COST_TRACKING=false                   # Optional: cost tracking debug log
 
-# Persistence / Queue (Optional)
-DATABASE_URL=sqlite:///./newsletter.db
+# ── PERSISTENCE & QUEUE ──
+DATABASE_URL=sqlite:///./newsletter.db  # Optional: app DB (default: SQLite)
+REDIS_URL=redis://localhost:6379/0      # Optional (Required for worker/scheduler)
+RQ_QUEUE=default                        # Optional: RQ queue name
 
-# Redis (Optional, for worker / scheduler)
-REDIS_URL=redis://localhost:6379/0
-RQ_QUEUE=default
+# ── ERROR TRACKING ──
+SENTRY_DSN=your-sentry-dsn             # Optional: Sentry error monitoring
+SENTRY_TRACES_SAMPLE_RATE=0.1          # Optional: Sentry tracing sample rate
+SENTRY_PROFILES_SAMPLE_RATE=0.1        # Optional: Sentry profiling sample rate
 
-# Sentry (Optional, for error tracking)
-SENTRY_DSN=your-sentry-dsn
-SENTRY_TRACES_SAMPLE_RATE=0.1
-SENTRY_PROFILES_SAMPLE_RATE=0.1
+# ── RSS FEEDS ──
+ADDITIONAL_RSS_FEEDS=https://example.com/feed1,https://example.com/feed2  # Optional: extra RSS sources
 
-# RSS Feeds (Optional)
-ADDITIONAL_RSS_FEEDS=https://example.com/feed1,https://example.com/feed2
-
-# Test Configuration
-TESTING=false
-MOCK_MODE=false
+# ── TEST / DEV ──
+TESTING=false    # Optional: force test mode
+MOCK_MODE=false  # Optional: use mock data

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -13,7 +13,7 @@
 
 ## Canonical Runtime Contract
 
-### Core Runtime / Web Ops
+### App Environment, Server & Web / Ops
 
 | 변수 | 필수 여부 | 용도 |
 |---|---|---|
@@ -25,7 +25,7 @@
 | `PORT` | 배포 시 선택 | canonical source runtime 웹 포트 (`.env.example` 기준 `8000`, Windows EXE packaging entrypoint는 현재 compatibility default `5000`) |
 | `LOG_LEVEL` | 선택 | runtime/application log level |
 | `LOG_FORMAT` | 선택 | logging format (`standard`/`json`) |
-| `SECRET_KEY` | 프로덕션 권장(웹) | Flask 시크릿 키 |
+| `SECRET_KEY` | 프로덕션 필수(웹) | Flask 시크릿 키 |
 | `ADMIN_API_TOKEN` | 민감 운영 API 보호 시 필수 | 모든 스코프(data·schedule·email·ops)를 허용하는 root 토큰. 기존 단일 토큰 방식과 완전히 하위호환. |
 | `ADMIN_API_TOKEN_DATA` | 선택 | `data` 스코프 전용 토큰 — `/api/history`, `/api/analytics`, `/api/archive`, `/api/presets`, `/api/approvals`, `/api/source-policies` |
 | `ADMIN_API_TOKEN_SCHEDULE` | 선택 | `schedule` 스코프 전용 토큰 — `/api/schedule*`, `/api/schedules*` |
@@ -33,11 +33,11 @@
 | `ADMIN_API_TOKEN_OPS` | 선택 | `ops` 스코프 전용 토큰 — `/api/ops/*` |
 | `ALLOWED_ORIGINS` | 선택 | canonical Flask runtime CORS allow-list |
 
-### Search / LLM / Delivery
+### Search / LLM / Email / Delivery
 
 | 변수 | 필수 여부 | 용도 |
 |---|---|---|
-| `SERPER_API_KEY` | 생성 기능 필수 | 뉴스 검색 API |
+| `SERPER_API_KEY` | Serper 사용 시 필수 | Serper 뉴스 검색 API (F-14: Optional로 변경됨) |
 | `GEMINI_API_KEY` | LLM 중 하나 필수 | Gemini 제공자 |
 | `OPENAI_API_KEY` | LLM 중 하나 필수 | OpenAI 제공자 |
 | `ANTHROPIC_API_KEY` | LLM 중 하나 필수 | Anthropic 제공자 |
@@ -49,7 +49,7 @@
 | `NAVER_CLIENT_ID` | 네이버 API 사용 시 선택 | Naver client id |
 | `NAVER_CLIENT_SECRET` | 네이버 API 사용 시 선택 | Naver client secret |
 
-### Optional Integrations / Observability / Test
+### Observability, Persistence & Test
 
 | 변수 | 필수 여부 | 용도 |
 |---|---|---|

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -13,3 +13,7 @@
 ## Lessons 정비
 - [x] tasks/lessons.md 에 LESSON-002 (test/ prefix 불허) 추가
 - [x] tasks/lessons.md 에 LESSON-003 (__init__.py 필수) 추가
+
+## P1-A — .env.example 가독성 개선
+- [x] .env.example 기능별 블록 헤더 추가 및 Required/Optional 인라인 주석 추가
+- [x] docs/reference/environment-variables.md 섹션명 정렬 및 SERPER_API_KEY 필수 여부 수정


### PR DESCRIPTION
## Summary (what / why)

- `.env.example`을 12개 기능별 블록(`# ── BLOCK NAME ──`)으로 재구성
- 모든 변수에 `# Required` / `# Optional` 인라인 주석 추가
- 기존 `Persistence / Queue`와 `Redis` 두 블록을 `PERSISTENCE & QUEUE`로 통합
- `docs/reference/environment-variables.md` 섹션명 정렬 및 내용 정확도 개선:
  - `SERPER_API_KEY` 필수 여부: `"생성 기능 필수"` → `"Serper 사용 시 필수"` (F-14: Optional로 변경됨 반영)
  - `SECRET_KEY` 표현: `"프로덕션 권장"` → `"프로덕션 필수"` (더 정확한 표현)
- PRD G5 (docs truthfulness 유지) 목적

## Scope

- `.env.example` — 블록 헤더 + Required/Optional 인라인 주석
- `docs/reference/environment-variables.md` — 섹션명 + SERPER/SECRET_KEY 필수 여부 수정
- `tasks/todo.md` — 완료 항목 추가
- 소스 코드, 테스트, 설정 파일 변경 없음

## Delivery Unit

RR: #445
Delivery Unit ID: DU-20260415-env-example-readability
Merge Boundary: 단일 커밋, docs 전용 변경
Rollback Boundary: `git revert 4ca5503` 으로 즉시 복원 가능

## Test & Evidence

- `python3 scripts/repo_audit.py --policy scripts/repo_hygiene_policy.json` → warnings=0
- Step 5 adversarial review: SERPER_API_KEY F-14 Optional 확인 (`centralized_settings.py` L247 `validate_optional_serper_key`)
- 변수명·값 변경 없음 — 40개 변수 전부 동일 키/값 유지
- Step 4 체크리스트 7/7 PASS

## Risk & Rollback

- Risk: None — docs/.env.example 전용, 소스/테스트 변경 없음
- Rollback: `git revert 4ca5503`

## Ops-Safety Addendum (if touching protected paths)

해당 없음 — 보호 경로 미접촉

## Not Run (with reason)

- 전체 test suite 미실행 — docs/.env.example 전용 변경으로 소스 영향 없음
- CI 자동 게이트에서 확인 예정