### PR TITLE
chore: add explicit skip markers to pre-existing failing tests

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,17 @@
 # Tasks
 
+## TASK-A — Pre-existing failing tests: add explicit skip markers
+- [x] tests/api_tests/test_article_filter_integration.py::test_cli_integration — skip (news_summarize removed)
+- [x] tests/unit_tests/test_llm.py::TestLLMSystem::test_api_keys_configuration — skip (requires GEMINI_API_KEY)
+- [x] tests/unit_tests/test_llm.py::TestLLMSystem::test_provider_availability — skip (requires API keys)
+- [x] tests/unit_tests/test_llm.py::TestLLMSystem::test_llm_instance_creation — skip (requires API keys)
+- [x] tests/unit_tests/test_llm.py::TestLLMSystem::test_fallback_mechanism — skip (requires API keys)
+- [x] tests/unit_tests/test_llm_providers.py::TestLLMProviders::test_all_task_llm_creation — skip (requires API keys)
+- [x] tests/unit_tests/test_llm_providers.py::TestLLMProviders::test_provider_distribution — skip (requires API keys)
+- [x] tests/unit_tests/test_llm_providers.py::TestLLMProviders::test_fallback_mechanism_detailed — skip (requires API keys)
+- [x] tests/contract/test_dev_entrypoint_consistency.py::test_active_docs_point_to_python_entrypoint_and_avoid_fixed_clone_paths — skip ("thin wrapper" missing from README)
+- 제약: 소스 코드 수정 없음, 테스트 파일만 수정
+
 ## Prompt C — generation contract 테스트
 - [x] tests/contract/test_generation_routes_contract.py 신규 작성
 - 대상 경로 4개:

--- a/tests/api_tests/test_article_filter_integration.py
+++ b/tests/api_tests/test_article_filter_integration.py
@@ -414,6 +414,9 @@ class TestArticleFilterIntegration(unittest.TestCase):
         else:
             os.environ.pop("SERPER_API_KEY", None)
 
+    @pytest.mark.skip(
+        reason="newsletter.cli.news_summarize was removed; patch target no longer exists"
+    )
     @patch("newsletter.cli.collect")
     def test_cli_integration(self, mock_collect):
         """Test CLI integration with filtering options."""

--- a/tests/contract/test_dev_entrypoint_consistency.py
+++ b/tests/contract/test_dev_entrypoint_consistency.py
@@ -1,6 +1,8 @@
 import re
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEV_ENTRYPOINT = "scripts.devtools.dev_entrypoint"
 
@@ -69,6 +71,9 @@ def test_shell_wrapper_and_help_text_use_dev_entrypoint_contract():
     assert f"python -m {DEV_ENTRYPOINT} check --full" in run_ci_checks
 
 
+@pytest.mark.skip(
+    reason="README.md does not contain 'thin wrapper' phrase; doc update required separately"
+)
 def test_active_docs_point_to_python_entrypoint_and_avoid_fixed_clone_paths():
     support_policy = _read_text("docs/reference/support-policy.md")
     readme = _read_text("README.md")

--- a/tests/unit_tests/test_llm.py
+++ b/tests/unit_tests/test_llm.py
@@ -19,6 +19,9 @@ from newsletter.llm_factory import (  # noqa: E402
 class TestLLMSystem:
     """LLM 시스템 기본 테스트 클래스"""
 
+    @pytest.mark.skip(
+        reason="Requires GEMINI_API_KEY env var; fails in CI without real API credentials"
+    )
     def test_api_keys_configuration(self):
         """API 키 설정 상태를 테스트합니다."""
         print("\n=== API 키 상태 테스트 ===")
@@ -36,6 +39,9 @@ class TestLLMSystem:
         print(f"🔧 OPENAI_API_KEY: {openai_status}")
         print(f"🔧 ANTHROPIC_API_KEY: {anthropic_status}")
 
+    @pytest.mark.skip(
+        reason="Requires at least one LLM API key; fails in CI without real API credentials"
+    )
     def test_provider_availability(self):
         """제공자 사용 가능 여부 테스트 - F-14 중앙화된 설정"""
         print("\n=== 제공자 사용 가능 여부 테스트 ===")
@@ -83,6 +89,9 @@ class TestLLMSystem:
             assert "model" in task_config, f"작업 '{task}'에 모델 설정이 없습니다"
             print(f"✅ {task}: {task_config['provider']} / {task_config['model']}")
 
+    @pytest.mark.skip(
+        reason="Calls get_llm_for_task() which raises ValueError without API keys"
+    )
     def test_llm_instance_creation(self):
         """LLM 인스턴스 생성을 테스트합니다."""
         print("\n=== LLM 인스턴스 생성 테스트 ===")
@@ -98,6 +107,9 @@ class TestLLMSystem:
             except Exception as e:
                 pytest.fail(f"작업 '{task}'에 대한 LLM 생성 중 오류: {e}")
 
+    @pytest.mark.skip(
+        reason="Calls get_llm_for_task() which raises ValueError without API keys"
+    )
     def test_fallback_mechanism(self):
         """Fallback 메커니즘을 테스트합니다."""
         print("\n=== Fallback 메커니즘 테스트 ===")

--- a/tests/unit_tests/test_llm_providers.py
+++ b/tests/unit_tests/test_llm_providers.py
@@ -97,6 +97,9 @@ class TestLLMProviders:
         """F-14: 테스트 메서드 설정"""
         self.llm_factory = llm_factory
 
+    @pytest.mark.skip(
+        reason="Requires all LLM API keys; raises ValueError without API credentials"
+    )
     def test_all_task_llm_creation(self):
         """F-14 중앙화된 설정을 사용한 전체 작업 LLM 생성 테스트"""
         print("\n=== F-14 전체 작업 LLM 생성 테스트 ===")
@@ -198,6 +201,9 @@ class TestLLMProviders:
         # 검증 완료, return 대신 assert 사용
         assert len(response_results) >= 0, "응답 결과를 확인했습니다"
 
+    @pytest.mark.skip(
+        reason="Requires LLM API keys; all providers fail with ValueError without credentials"
+    )
     def test_provider_distribution(self):
         """F-14 중앙화된 설정을 사용한 제공자 분산 테스트"""
         print("\n=== F-14 제공자 분산 테스트 ===")
@@ -240,6 +246,9 @@ class TestLLMProviders:
         else:
             assert len(fallback_tasks) > 0, "F-14: Fallback 메커니즘이 사용되지 않았습니다"
 
+    @pytest.mark.skip(
+        reason="Calls get_llm_for_task() which raises ValueError without API keys"
+    )
     def test_fallback_mechanism_detailed(self):
         """상세한 Fallback 메커니즘 테스트"""
         print("\n=== 상세한 Fallback 메커니즘 테스트 ===")


### PR DESCRIPTION
## Summary (what / why)
Add `pytest.mark.skip` with actionable reason strings to 9 pre-existing failing tests across 4 files. These tests were failing due to removed symbols or missing API credentials — not regressions from recent changes. Explicit skip markers silence CI noise while documenting what needs to be fixed later.

## Scope
- `tests/api_tests/test_article_filter_integration.py` — 1 test
- `tests/unit_tests/test_llm.py` — 4 tests
- `tests/unit_tests/test_llm_providers.py` — 3 tests
- `tests/contract/test_dev_entrypoint_consistency.py` — 1 test

No source code modified.

## Delivery Unit
- RR: #457
- Delivery Unit ID: DU-20260415-skip-preexisting-tests
- Merge Boundary: squash merge to main
- Rollback Boundary: revert this PR

## Test & Evidence
```
pytest tests/unit_tests/test_llm.py tests/unit_tests/test_llm_providers.py tests/contract/test_dev_entrypoint_consistency.py -v
→ 10 passed, 9 skipped, 0 failed
```
Syntax-checked `test_article_filter_integration.py` (feedparser not in local conda env).

## Risk & Rollback
**Risk**: None — test-only changes, no source code affected.
**Rollback**: `git revert 4c62168`

## Ops-Safety Addendum (if touching protected paths)
N/A — no protected paths touched.

## Not Run (with reason)
- `tests/api_tests/test_article_filter_integration.py` — full pytest run blocked by missing `feedparser` in local conda env (not in project venv). Verified syntax via `ast.parse` instead.