### PR TITLE
docs: register e2e-smoke as main branch required status check

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,6 +13,7 @@
   - `Unit Tests - ubuntu-latest-py3.11`, `Unit Tests - ubuntu-latest-py3.12`
   - `Source Smoke (ubuntu-latest)`, `Source Smoke (macos-latest)`, `Source Smoke (windows-latest)`
   - `Build Check (ubuntu-latest)`, `Build Check (windows-latest)`, `Container Smoke (ubuntu-latest)`
+  - `e2e-smoke`
 - 추가 PR validation: `Mock API Tests`
 
 2. `deployment.yml`

--- a/docs/dev/CI_CD_GUIDE.md
+++ b/docs/dev/CI_CD_GUIDE.md
@@ -112,7 +112,7 @@ make repo-audit-strict
 
 ### PR Gate
 
-아래 12개 check는 `main` branch protection required check 기준이다.
+아래 13개 check는 `main` branch protection required check 기준이다.
 
 - `policy-check`
 - `docs-quality`
@@ -126,6 +126,7 @@ make repo-audit-strict
 - `Build Check (ubuntu-latest)`
 - `Build Check (windows-latest)`
 - `Container Smoke (ubuntu-latest)`
+- `e2e-smoke`
 
 추가 PR validation:
 - `Mock API Tests`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,10 @@
 # Tasks
 
+## TASK-B — Register e2e-smoke as required status check + doc update
+- [x] GitHub branch protection: added `e2e-smoke` to main required checks (via gh API)
+- [x] .github/workflows/README.md: added `e2e-smoke` to required checks list
+- [x] docs/dev/CI_CD_GUIDE.md: updated count 12→13, added `e2e-smoke` to PR gate list
+
 ## TASK-A — Pre-existing failing tests: add explicit skip markers
 - [x] tests/api_tests/test_article_filter_integration.py::test_cli_integration — skip (news_summarize removed)
 - [x] tests/unit_tests/test_llm.py::TestLLMSystem::test_api_keys_configuration — skip (requires GEMINI_API_KEY)


### PR DESCRIPTION
## Summary (what / why)
Register `e2e-smoke` as a required status check on the `main` branch protection rule. The workflow was added in PR #454 as a blocking gate but was not yet wired into branch protection. This PR documents the policy change; the branch protection itself was already updated via GitHub API.

## Scope
- `.github/workflows/README.md`: added `e2e-smoke` to required checks list in workflow #1 (`main-ci.yml`) entry
- `docs/dev/CI_CD_GUIDE.md`: updated PR gate count 12→13, added `e2e-smoke` to required check list

No source or test code modified.

## Delivery Unit
- RR: #459
- Delivery Unit ID: DU-20260415-e2e-smoke-required-check
- Merge Boundary: squash merge to main
- Rollback Boundary: remove e2e-smoke from branch protection via `gh api`; revert this PR

## Test & Evidence
```
gh api repos/hjjung-katech/newsletter-generator/branches/main/protection \
  --jq '.required_status_checks.contexts'
→ [..., "e2e-smoke"]  # confirmed 13 items
```

## Risk & Rollback
**Risk**: None — docs-only; branch protection already updated before this PR.
**Rollback**: Remove `e2e-smoke` from required checks via `gh api PUT`.

## Ops-Safety Addendum (if touching protected paths)
N/A — no protected paths touched.

## Not Run (with reason)
N/A — pure doc update; no tests to run.