### PR TITLE
chore: add requirements-e2e.txt and local E2E setup documentation

### DIFF
--- a/docs/setup/LOCAL_SETUP.md
+++ b/docs/setup/LOCAL_SETUP.md
@@ -354,6 +354,29 @@ redis-server
 PORT=8001 python -m scripts.devtools.dev_entrypoint run web
 ```
 
+## 14. E2E 스모크 테스트 로컬 실행
+
+E2E 스모크 테스트는 Playwright를 사용하여 웹 서버의 핵심 흐름(GET /health, GET /)을 검증합니다.
+CI에서는 `e2e-smoke` job이 `main` branch protection required check로 등록되어 있습니다.
+
+### 의존성 설치
+
+```bash
+pip install -r requirements-e2e.txt
+python -m playwright install chromium --with-deps
+```
+
+### 실행
+
+```bash
+pytest tests/e2e/test_smoke.py -v
+```
+
+**참고**: `pytest-playwright`가 아닌 `playwright` 단독 패키지를 사용합니다.
+`tests/e2e/conftest.py`에 `browser`/`page` fixture가 직접 구현되어 있으며,
+`pytest-playwright`의 transitive 의존성인 `pytest-base-url`이 기존 `base_url` fixture와 충돌하기 때문입니다.
+자세한 내용은 `tasks/lessons.md` LESSON-006을 참조하세요.
+
 ## 추가 팁
 
 ### 개발 중 자동 재로드

--- a/requirements-e2e.txt
+++ b/requirements-e2e.txt
@@ -1,0 +1,5 @@
+# E2E test dependencies
+# Mirrors pyproject.toml [project.optional-dependencies] e2e group
+# Install: pip install -r requirements-e2e.txt
+# Then: python -m playwright install chromium --with-deps
+playwright>=1.40.0

--- a/scripts/repo_hygiene_policy.json
+++ b/scripts/repo_hygiene_policy.json
@@ -23,6 +23,7 @@
       "pyproject.toml",
       "railway.yml",
       "requirements-dev.txt",
+      "requirements-e2e.txt",
       "requirements-lock.txt",
       "requirements.txt",
       "run_ci_checks.py",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,10 @@
 # Tasks
 
+## TASK-C — requirements-e2e.txt + hygiene allowlist + E2E setup docs
+- [x] requirements-e2e.txt 신규 작성 (playwright>=1.40.0 pinned)
+- [x] scripts/repo_hygiene_policy.json: requirements-e2e.txt allowlist 추가
+- [x] docs/setup/LOCAL_SETUP.md: Section 14 "E2E 스모크 테스트 로컬 실행" 추가
+
 ## TASK-B — Register e2e-smoke as required status check + doc update
 - [x] GitHub branch protection: added `e2e-smoke` to main required checks (via gh API)
 - [x] .github/workflows/README.md: added `e2e-smoke` to required checks list


### PR DESCRIPTION
## Summary (what / why)
Add `requirements-e2e.txt` as a first-class install target for Playwright E2E tests, update the repo hygiene allowlist so the CI gate does not flag the new root file, and document the local E2E setup procedure in `docs/setup/LOCAL_SETUP.md`.

## Scope
- `requirements-e2e.txt` (new): `playwright>=1.40.0`, mirrors `pyproject.toml` `[e2e]` group
- `scripts/repo_hygiene_policy.json`: add `requirements-e2e.txt` to `allowed_file_names`
- `docs/setup/LOCAL_SETUP.md`: Section 14 "E2E 스모크 테스트 로컬 실행"

## Delivery Unit
- RR: #461
- Delivery Unit ID: DU-20260415-add-requirements-e2e-docs
- Merge Boundary: squash merge to main
- Rollback Boundary: delete requirements-e2e.txt; revert policy and docs changes

## Test & Evidence
```
python -c "import json; p=json.load(open('scripts/repo_hygiene_policy.json')); assert 'requirements-e2e.txt' in p['root_policy']['allowed_file_names']"
→ passes
```
Pre-commit hooks passed (black/isort/flake8 no Python files changed; json check passed).

## Risk & Rollback
**Risk**: None — new file + docs change. Repo hygiene CI hard gate would fail without the allowlist update; included in same commit.
**Rollback**: `git revert e044e62`

## Ops-Safety Addendum (if touching protected paths)
N/A — no protected paths touched.

## Not Run (with reason)
- Full `pytest tests/e2e/` not run locally (local conda env lacks feedparser for the full test suite); CI e2e-smoke will validate.