### PR TITLE
docs(readme): remove ?branch=main from Security Scan badge URL

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -3,7 +3,7 @@
 
 [![Main CI](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/main-ci.yml/badge.svg?branch=main)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/main-ci.yml)
 [![Docs Quality](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/docs-quality.yml/badge.svg?branch=main)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/docs-quality.yml)
-[![Security Scan](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml/badge.svg?branch=main)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml)
+[![Security Scan](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml/badge.svg)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml)
 [![Python 3.11 | 3.12](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Deploy Guide (Railway)](https://img.shields.io/badge/deploy-Railway-0B0D0E?logo=railway)](docs/setup/RAILWAY_DEPLOYMENT.md)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Main CI](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/main-ci.yml/badge.svg?branch=main)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/main-ci.yml)
 [![Docs Quality](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/docs-quality.yml/badge.svg?branch=main)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/docs-quality.yml)
-[![Security Scan](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml/badge.svg?branch=main)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml)
+[![Security Scan](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml/badge.svg)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml)
 [![Python 3.11 | 3.12](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Deploy Guide (Railway)](https://img.shields.io/badge/deploy-Railway-0B0D0E?logo=railway)](docs/setup/RAILWAY_DEPLOYMENT.md)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,10 @@
 # Tasks
 
+## Security Scan 뱃지 ?branch=main 제거
+- [x] README.md L6: Security Scan 뱃지 URL에서 ?branch=main 제거
+- [x] README.ko.md L6: Security Scan 뱃지 URL에서 ?branch=main 제거
+
+
 ## TASK-C — requirements-e2e.txt + hygiene allowlist + E2E setup docs
 - [x] requirements-e2e.txt 신규 작성 (playwright>=1.40.0 pinned)
 - [x] scripts/repo_hygiene_policy.json: requirements-e2e.txt allowlist 추가


### PR DESCRIPTION
## Summary (what / why)
- `security-scan.yml`은 `push: branches: [main]` 트리거가 없음 (`schedule`, `workflow_dispatch`, `pull_request`만 존재)
- `?branch=main` 필터가 있으면 GitHub badge API가 main 브랜치에서 실행된 run을 찾지 못해 stale/empty 상태 표시
- 파라미터 제거 시 가장 최근 workflow run을 브랜치 무관하게 표시

## Scope
- `README.md` L6: Security Scan 뱃지 URL에서 `?branch=main` 제거
- `README.ko.md` L6: Security Scan 뱃지 URL에서 `?branch=main` 제거
- `tasks/todo.md`: 작업 항목 완료 처리
- Zero changes to: `.github/workflows/`, Main CI 뱃지, Docs Quality 뱃지

## Delivery Unit
- RR: #467
- Delivery Unit ID: DU-20260416-security-badge-fix
- Merge Boundary: README.md, README.ko.md badge URL 1줄씩
- Rollback Boundary: 단순 URL 파라미터 변경 — revert 1 commit

## Test & Evidence
```
grep "security-scan.yml/badge" README.md README.ko.md
# → ?branch=main 없음 확인

grep "main-ci.yml/badge\|docs-quality.yml/badge" README.md README.ko.md
# → ?branch=main 그대로 존재 확인
```

## Risk & Rollback
- Risk: 없음 — URL 파라미터 제거만으로 기능/동작 변경 없음
- Rollback: `git revert HEAD` 1 commit

## Ops-Safety Addendum (if touching protected paths)
해당 없음 — README 파일만 수정

## Not Run (with reason)
- 단위/통합 테스트 불필요 — markdown 파일 1줄 변경