### PR TITLE
docs(readme): wrap Example Output code block in <details> tag

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -75,6 +75,8 @@ Updates that reduce repetitive maintainer coordination work.
 ## 예시 출력
 생성 결과 예시는 다음과 같습니다. 아래 예시는 영문 공개 데모 기준이지만, 실제 구조는 기본 `compact` 템플릿 흐름을 따릅니다.
 
+<details><summary>전체 예시 출력 보기</summary>
+
 ```md
 # Maintainer Communication Brief
 _Maintainer workflow automation · Issue 14 · 2026-03-19_
@@ -113,6 +115,8 @@ Improvements that make updates easier to consume across community and internal a
 
 _Generated as an English compact preview of the production newsletter template._
 ```
+
+</details>
 
 ## 왜 중요한가
 메인테이너는 이미 리뷰, 이슈 분류, 릴리스 준비에 많은 시간을 쓰고 있습니다. 커뮤니케이션은 꼭 필요하지만 또 하나의 수작업 백로그가 되어서는 안 됩니다. 이 프로젝트는 업데이트 정리, 릴리스 노트, 이해관계자 보고처럼 커뮤니케이션 비중이 큰 워크플로에서 maintainer workload를 직접 줄이는 데 초점을 맞춥니다.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The production app renders HTML newsletters in `compact`, `detailed`, and `email
 ## Example Output
 Example of a generated newsletter:
 
+<details><summary>Full example output</summary>
+
 ```md
 # Maintainer Communication Brief
 _Maintainer workflow automation · Issue 14 · 2026-03-19_
@@ -113,6 +115,8 @@ Improvements that make updates easier to consume across community and internal a
 
 _Generated as an English compact preview of the production newsletter template._
 ```
+
+</details>
 
 ## Why This Matters
 Maintainers already spend their time reviewing contributions, triaging issues, and keeping releases moving. Communication work is necessary, but it should not become another manual backlog. This project directly reduces maintainer workload in communication-heavy workflows such as updates, release notes, and stakeholder reporting.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,9 @@
 # Tasks
 
+## Example Output 섹션 <details> 접기 처리
+- [x] README.md: Example Output 코드 블록을 <details><summary>Full example output</summary> 로 감싸기
+- [x] README.ko.md: 동일 (<summary> 텍스트 "전체 예시 출력 보기")
+
 ## Security Scan 뱃지 ?branch=main 제거
 - [x] README.md L6: Security Scan 뱃지 URL에서 ?branch=main 제거
 - [x] README.ko.md L6: Security Scan 뱃지 URL에서 ?branch=main 제거


### PR DESCRIPTION
## Summary (what / why)
- `Quick Demo`와 `Example Output` 섹션이 거의 동일한 코드 블록을 중복 표시해 README 스크롤이 불필요하게 길어짐
- `Example Output` 섹션의 긴 코드 블록을 `<details>` 토글로 접어 기본 상태에서는 숨기고 필요 시 펼칠 수 있도록 변경

## Scope
- `README.md`: Example Output 섹션 코드 블록에 `<details><summary>Full example output</summary>` 감싸기
- `README.ko.md`: 동일 (`<summary>` 텍스트: "전체 예시 출력 보기")
- `tasks/todo.md`: 작업 항목 완료 처리
- Zero changes to: `Quick Demo` 섹션, 기타 모든 섹션

## Delivery Unit
- RR: #469
- Delivery Unit ID: DU-20260416-collapse-example-output
- Merge Boundary: README.md, README.ko.md Example Output 섹션 코드 블록만
- Rollback Boundary: `git revert HEAD` 1 commit

## Test & Evidence
```
grep -n "<details>" README.md README.ko.md     # → 각 파일 L78 확인
grep -n "</details>" README.md README.ko.md    # → 각 파일 L119 확인
grep -n "Full example output" README.md        # → L78 존재
grep -n "전체 예시 출력 보기" README.ko.md     # → L78 존재
grep -n "Quick Demo" README.md README.ko.md   # → 변경 없음 확인
```

## Risk & Rollback
- Risk: 없음 — HTML/Markdown 구조 변경만, 기능/동작 영향 없음
- Rollback: `git revert HEAD` 1 commit

## Ops-Safety Addendum (if touching protected paths)
해당 없음 — README 파일만 수정

## Not Run (with reason)
- 단위/통합 테스트 불필요 — markdown 파일 구조 변경만