### PR TITLE
docs(readme): merge Start Here and Getting Started into one section

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -130,8 +130,7 @@ _Generated as an English compact preview of the production newsletter template._
 
 공식 지원 범위와 운영 기준은 지원 정책 문서를 따릅니다. 요약하면 Python 3.11, 3.12가 주요 대상이고 Linux는 canonical production server, Windows는 native desktop bundle 대상, macOS는 source-based development와 smoke 중심 지원입니다.
 
-## 빠른 시작
-위 Quick Demo는 정적 preview입니다. 실제 제품을 로컬에서 실행하려면 아래 canonical setup과 CLI entrypoint를 사용하면 됩니다.
+로컬 실행:
 
 ```bash
 git clone https://github.com/hjjung-katech/newsletter-generator.git

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ _Generated as an English compact preview of the production newsletter template._
 ## Why This Matters
 Maintainers already spend their time reviewing contributions, triaging issues, and keeping releases moving. Communication work is necessary, but it should not become another manual backlog. This project directly reduces maintainer workload in communication-heavy workflows such as updates, release notes, and stakeholder reporting.
 
-## Start Here
+## Getting Started
 1. Quick start: [`docs/setup/QUICK_START_GUIDE.md`](docs/setup/QUICK_START_GUIDE.md)
 2. Support policy: [`docs/reference/support-policy.md`](docs/reference/support-policy.md)
 3. Environment-variable contract: [`docs/reference/environment-variables.md`](docs/reference/environment-variables.md)
@@ -130,8 +130,7 @@ Maintainers already spend their time reviewing contributions, triaging issues, a
 
 Supported runtime guidance is defined in the support policy. In short, Python 3.11 and 3.12 are the active targets, Linux is the canonical production server, Windows is the native desktop bundle target, and macOS is supported mainly for source-based development and smoke checks.
 
-## Getting Started
-The quick demo above is a static preview. To run the actual product locally, use the canonical setup and CLI entrypoints below:
+To run locally:
 
 ```bash
 git clone https://github.com/hjjung-katech/newsletter-generator.git

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,9 @@
 # Tasks
 
+## Start Here / Getting Started 섹션 통합
+- [x] README.md: "Start Here" → "Getting Started" 로 이름 변경, 빠른 시작 코드 블록 흡수, 구 "Getting Started" 섹션 삭제
+- [x] README.ko.md: "시작 가이드" 유지, "빠른 시작" 코드 블록 흡수, "빠른 시작" 섹션 삭제
+
 ## Example Output 섹션 <details> 접기 처리
 - [x] README.md: Example Output 코드 블록을 <details><summary>Full example output</summary> 로 감싸기
 - [x] README.ko.md: 동일 (<summary> 텍스트 "전체 예시 출력 보기")


### PR DESCRIPTION
## Summary (what / why)
Collapsed the two-section redundancy in both README files:
- README.md: `## Start Here` renamed to `## Getting Started`; duplicate `## Getting Started` section (heading + description sentence) replaced by `To run locally:` label
- README.ko.md: `## 시작 가이드` kept; `## 빠른 시작` section (heading + description sentence) replaced by `로컬 실행:` label; code block absorbed in-place

Both sections appeared in immediate sequence, adding scroll length without new information.

## Scope
2 files: `README.md`, `README.ko.md`. No source code changes.

## Delivery Unit
- RR: #471
- Delivery Unit ID: DU-20260416-merge-start-getting-started
- Merge Boundary: Single squash commit — revert to undo
- Rollback Boundary: Revert this commit; no downstream impact

## Test & Evidence
- `grep` confirms no remaining `## Start Here` / `## 빠른 시작` headings in repo markdown
- No anchor links to either old heading found in any `.md` file
- Pre-commit hooks passed (trailing whitespace, EOF, large-files checks)

## Risk & Rollback
Low — docs-only change. Rollback: `git revert` this commit.

## Ops-Safety Addendum (if touching protected paths)
N/A — no protected paths touched.

## Not Run (with reason)
- Unit/integration tests: not applicable (docs-only change)