### PR TITLE
docs(readme): sync README.ko.md intro, roadmap, and quote with EN

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -8,7 +8,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Deploy Guide (Railway)](https://img.shields.io/badge/deploy-Railway-0B0D0E?logo=railway)](docs/setup/RAILWAY_DEPLOYMENT.md)
 
-원시 프로젝트 업데이트를 구조화된 뉴스레터로 자동 변환해 메인테이너의 커뮤니케이션 부담을 줄이는 도구입니다.
+운영자를 위한 한국어 뉴스 큐레이션 및 뉴스레터 배포 워크플로 시스템입니다.
 
 오픈소스 메인테이너, 소규모 팀, 사내 기술 커뮤니케이션 워크플로를 위해 설계되었습니다.
 
@@ -51,7 +51,7 @@ Updates that reduce repetitive maintainer coordination work.
 - **Idempotency key:** A stable request identifier used to prevent duplicate jobs or duplicate email sends.
 
 ## 💡 Things to Watch
-> If GitHub issue and pull request summaries are added next, maintainers can publish weekly updates with much less manual editing.
+> Operators managing recurring digests can reduce review time by refining keyword sets and source policies as coverage patterns stabilize.
 ```
 
 ## 개요
@@ -111,7 +111,7 @@ Improvements that make updates easier to consume across community and internal a
 - **Docs gate:** An automated check that verifies documentation links, required references, and policy consistency.
 
 ## 💡 Things to Watch
-> If GitHub issue and pull request summaries are added next, maintainers can publish weekly updates with much less manual editing.
+> Operators managing recurring digests can reduce review time by refining keyword sets and source policies as coverage patterns stabilize.
 
 _Generated as an English compact preview of the production newsletter template._
 ```

--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ newsletter run --keywords "open source, maintainer tooling"
 - Hold legacy runtime surface in maintenance mode — no structural reopening without explicit trigger (G4)
 - Keep operational contracts, support policy, and documentation aligned to the same production reality (G5)
 
+## Roadmap
+- Integrate GitHub to pull repository updates directly
+- Automate maintainer digests from PR and issue summaries
+- Auto-generate release notes and stakeholder updates
+
 ## Project Docs
 | Purpose | Reference |
 |---|---|

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,10 @@
 # Tasks
 
+## README.ko.md 소개문·로드맵·인용구 영문판 동기화
+- [x] README.ko.md L11: 소개문 "운영자를 위한..." 으로 수정 (4a)
+- [x] README.md: Roadmap 섹션 추가 (Current Priorities 아래) (4b)
+- [x] README.ko.md L54, L114: Things to Watch 인용구 영문판과 동일하게 수정 (4c)
+
 ## Start Here / Getting Started 섹션 통합
 - [x] README.md: "Start Here" → "Getting Started" 로 이름 변경, 빠른 시작 코드 블록 흡수, 구 "Getting Started" 섹션 삭제
 - [x] README.ko.md: "시작 가이드" 유지, "빠른 시작" 코드 블록 흡수, "빠른 시작" 섹션 삭제


### PR DESCRIPTION
## Summary (what / why)
Three content gaps between README.md and README.ko.md resolved:
- **(4a)** README.ko.md intro sentence aligned to operator-facing framing (matches EN `"Operator-facing workflow system..."` intent)
- **(4b)** `## Roadmap` section added to README.md — the section existed only in README.ko.md
- **(4c)** Both `Things to Watch` blockquotes in README.ko.md (Quick Demo + Example Output) unified with EN version

## Scope
- `README.md`: Roadmap section added (5 lines after Current Priorities G5)
- `README.ko.md`: intro L11 modified, 2× Things to Watch quote replaced
- `tasks/todo.md`: task checked
- Zero changes to: code, badges, CI, templates, any other sections

## Delivery Unit
- RR: #473
- Delivery Unit ID: DU-20260416-sync-readme-ko-content
- Merge Boundary: Single squash commit — revert to undo
- Rollback Boundary: Revert this commit; no downstream impact

## Test & Evidence
```
grep -n "운영자를 위한" README.ko.md         → L11: found ✓
grep -c "## Roadmap" README.md              → 1 ✓
grep -A3 "## Roadmap" README.md             → 3 bullets ✓
diff <(grep "Things to Watch" -A1 README.md) \
     <(grep "Things to Watch" -A1 README.ko.md)  → empty (match) ✓
grep -c "If GitHub issue" README.ko.md      → 0 ✓
```

## Risk & Rollback
Low — docs-only. Rollback: `git revert` this commit.

## Ops-Safety Addendum (if touching protected paths)
N/A — no protected paths touched.

## Not Run (with reason)
- Unit/integration tests: not applicable (docs-only change)