### PR TITLE
fix(security-scan): pin safety<3 and restore badge branch filter

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -88,7 +88,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-          pip install safety
+          pip install "safety<3"
 
       - name: Run Bandit security scan (high severity / high confidence only)
         run: |

--- a/README.ko.md
+++ b/README.ko.md
@@ -3,7 +3,7 @@
 
 [![Main CI](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/main-ci.yml/badge.svg?branch=main)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/main-ci.yml)
 [![Docs Quality](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/docs-quality.yml/badge.svg?branch=main)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/docs-quality.yml)
-[![Security Scan](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml/badge.svg)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml)
+[![Security Scan](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml/badge.svg?branch=main)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml)
 [![Python 3.11 | 3.12](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Deploy Guide (Railway)](https://img.shields.io/badge/deploy-Railway-0B0D0E?logo=railway)](docs/setup/RAILWAY_DEPLOYMENT.md)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Main CI](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/main-ci.yml/badge.svg?branch=main)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/main-ci.yml)
 [![Docs Quality](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/docs-quality.yml/badge.svg?branch=main)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/docs-quality.yml)
-[![Security Scan](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml/badge.svg)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml)
+[![Security Scan](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml/badge.svg?branch=main)](https://github.com/hjjung-katech/newsletter-generator/actions/workflows/security-scan.yml)
 [![Python 3.11 | 3.12](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Deploy Guide (Railway)](https://img.shields.io/badge/deploy-Railway-0B0D0E?logo=railway)](docs/setup/RAILWAY_DEPLOYMENT.md)


### PR DESCRIPTION
## Summary (what / why)
- `safety` 3.x에서 `--output` 플래그가 파일명이 아닌 포맷 지정자(`json/text/...`)로 변경되어 `bandit-security` job이 crash 중
- Security Scan 뱃지의 `?branch=main`이 없어 schedule 실행 결과가 뱃지에 반영되지 않음

## Scope
### In Scope
- `.github/workflows/security-scan.yml`: `pip install "safety<3"` 버전 고정
- `README.md`, `README.ko.md`: Security Scan 뱃지에 `?branch=main` 복원

### Out of Scope
- `safety scan` (3.x) 마이그레이션
- 다른 workflow 변경

## Delivery Unit
RR: #475
Delivery Unit ID: DU-20260416-security-scan-safety-pin
Merge Boundary: 이 PR 단독 머지 가능 — workflow/badge 수정만 포함
Rollback Boundary: `pip install "safety<3"` → `pip install safety` 되돌리기

## Test & Evidence
- [x] `make check`
- [ ] `make check-full`
- [ ] GitHub required checks green before merge
- [ ] Additional tests (if needed): N/A — workflow/docs 변경만

### Commands and Results
```bash
# pre-commit hooks: all passed
trim trailing whitespace: Passed
fix end of files: Passed
check yaml: Passed

# diff stat
.github/workflows/security-scan.yml | 2 +-
README.ko.md                        | 2 +-
README.md                           | 2 +-
3 files changed, 3 insertions(+), 3 deletions(-)
```

## Risk & Rollback
- Risk: safety<3 고정으로 최신 safety 기능 미사용 — advisory scan 용도라 실 운영 영향 없음
- Rollback: `pip install "safety<3"` → `pip install safety` 1줄 되돌리기

## Ops-Safety Addendum (if touching protected paths)
해당 없음 — workflow 파일과 README만 수정

## Not Run (with reason)
- `make check-full`: CI에서 확인 예정